### PR TITLE
Add Data timestamps to allow time-ordered insertions.

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -85,10 +85,7 @@ public class Alert {
 
     @Override
     public String toString() {
-        return "Alert{" +
-                "evals=" + evals +
-                ", triggerId='" + triggerId + '\'' +
-                ", time=" + time +
-                '}';
+        return "Alert [triggerId=" + triggerId + ", evals=" + evals + ", time=" + time + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
@@ -108,9 +108,8 @@ public class AvailabilityCondition extends Condition {
 
     @Override
     public String toString() {
-        return "AvailabilityCondition{conditionId='" + conditionId + '\'' +
-                ", dataId='" + dataId + '\'' +
-                ", operator=" + operator +
-                '}';
+        return "AvailabilityCondition [dataId=" + dataId + ", operator=" + operator + ", toString()="
+                + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.Availability;
 import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
 
 /**
@@ -30,15 +31,15 @@ public class AvailabilityConditionEval extends ConditionEval {
     private AvailabilityType value;
 
     public AvailabilityConditionEval() {
-        super(false);
+        super(false, 0);
         this.condition = null;
         this.value = null;
     }
 
-    public AvailabilityConditionEval(AvailabilityCondition condition, AvailabilityType value) {
-        super(condition.match(value));
+    public AvailabilityConditionEval(AvailabilityCondition condition, Availability avail) {
+        super(condition.match(avail.getValue()), avail.getTimestamp());
         this.condition = condition;
-        this.value = value;
+        this.value = avail.getValue();
     }
 
     public AvailabilityCondition getCondition() {
@@ -101,9 +102,8 @@ public class AvailabilityConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "AvailabilityConditionEval{" +
-                "condition=" + condition +
-                ", value=" + value +
-                '}';
+        return "AvailabilityConditionEval [condition=" + condition + ", value=" + value + ", toString()="
+                + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
@@ -138,11 +138,8 @@ public class CompareCondition extends Condition {
 
     @Override
     public String toString() {
-        return "CompareCondition{conditionId='" + conditionId + '\'' +
-                "data1Id='" + data1Id + '\'' +
-                ", operator=" + operator +
-                ", data2Id='" + data2Id + '\'' +
-                ", data2Multiplier=" + data2Multiplier +
-                '}';
+        return "CompareCondition [data1Id=" + data1Id + ", operator=" + operator + ", data2Id=" + data2Id
+                + ", data2Multiplier=" + data2Multiplier + ", toString()=" + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.NumericData;
+
 /**
  * An evaluation state for compare condition.
  *
@@ -29,17 +31,18 @@ public class CompareConditionEval extends ConditionEval {
     private Double value2;
 
     public CompareConditionEval() {
-        super(false);
+        super(false, 0);
         this.condition = null;
         this.value1 = null;
         this.value2 = null;
     }
 
-    public CompareConditionEval(CompareCondition condition, Double value1, Double value2) {
-        super(condition.match(value1, value2));
+    public CompareConditionEval(CompareCondition condition, NumericData data1, NumericData data2) {
+        super(condition.match(data1.getValue(), data2.getValue()),
+                ((data1.getTimestamp() > data1.getTimestamp()) ? data1.getTimestamp() : data2.getTimestamp()));
         this.condition = condition;
-        this.value1 = value1;
-        this.value2 = value2;
+        this.value1 = data1.getValue();
+        this.value2 = data2.getValue();
     }
 
     public CompareCondition getCondition() {
@@ -88,15 +91,21 @@ public class CompareConditionEval extends ConditionEval {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
 
         CompareConditionEval that = (CompareConditionEval) o;
 
-        if (condition != null ? !condition.equals(that.condition) : that.condition != null) return false;
-        if (value1 != null ? !value1.equals(that.value1) : that.value1 != null) return false;
-        if (value2 != null ? !value2.equals(that.value2) : that.value2 != null) return false;
+        if (condition != null ? !condition.equals(that.condition) : that.condition != null)
+            return false;
+        if (value1 != null ? !value1.equals(that.value1) : that.value1 != null)
+            return false;
+        if (value2 != null ? !value2.equals(that.value2) : that.value2 != null)
+            return false;
 
         return true;
     }
@@ -112,10 +121,8 @@ public class CompareConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "CompareConditionEval{" +
-                "condition=" + condition +
-                ", value1=" + value1 +
-                ", value2=" + value2 +
-                '}';
+        return "CompareConditionEval [condition=" + condition + ", value1=" + value1 + ", value2=" + value2
+                + ", toString()=" + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -110,10 +110,8 @@ public abstract class Condition {
 
     @Override
     public String toString() {
-        return "Condition{" +
-                "conditionSetIndex=" + conditionSetIndex +
-                ", triggerId='" + triggerId + '\'' +
-                ", conditionSetSize=" + conditionSetSize +
-                ", conditionId=" + conditionId + '}';
+        return "Condition [triggerId=" + triggerId + ", conditionSetSize=" + conditionSetSize + ", conditionSetIndex="
+                + conditionSetIndex + ", conditionId=" + conditionId + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
@@ -27,13 +27,16 @@ public abstract class ConditionEval {
     // result of the condition evaluation
     protected boolean match;
     // time of condition evaluation (i.e. creation time)
-    protected long time;
+    protected long evalTimestamp;
+    // time stamped on the data used in the eval
+    protected long dataTimestamp;
     // flag noting whether this condition eval was used in a tested Tuple and already applied to dampening
     protected boolean used;
 
-    public ConditionEval(boolean match) {
+    public ConditionEval(boolean match, long dataTimestamp) {
         this.match = match;
-        this.time = System.currentTimeMillis();
+        this.dataTimestamp = dataTimestamp;
+        this.evalTimestamp = System.currentTimeMillis();
         this.used = false;
     }
 
@@ -45,12 +48,20 @@ public abstract class ConditionEval {
         this.match = match;
     }
 
-    public long getTime() {
-        return time;
+    public long getEvalTimestamp() {
+        return evalTimestamp;
     }
 
-    public void setTime(long time) {
-        this.time = time;
+    public void setEvalTimestamp(long evalTimestamp) {
+        this.evalTimestamp = evalTimestamp;
+    }
+
+    public long getDataTimestamp() {
+        return dataTimestamp;
+    }
+
+    public void setDataTimestamp(long dataTimestamp) {
+        this.dataTimestamp = dataTimestamp;
     }
 
     public boolean isUsed() {
@@ -70,32 +81,40 @@ public abstract class ConditionEval {
     public abstract String getLog();
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        ConditionEval that = (ConditionEval) o;
-
-        if (match != that.match)
-            return false;
-        if (time != that.time)
-            return false;
-
-        return true;
-    }
-
-    @Override
     public int hashCode() {
-        int result = (match ? 1 : 0);
-        result = 31 * result + (int) (time ^ (time >>> 32));
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (dataTimestamp ^ (dataTimestamp >>> 32));
+        result = prime * result + (int) (evalTimestamp ^ (evalTimestamp >>> 32));
+        result = prime * result + (match ? 1231 : 1237);
+        result = prime * result + (used ? 1231 : 1237);
         return result;
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ConditionEval other = (ConditionEval) obj;
+        if (dataTimestamp != other.dataTimestamp)
+            return false;
+        if (evalTimestamp != other.evalTimestamp)
+            return false;
+        if (match != other.match)
+            return false;
+        if (used != other.used)
+            return false;
+        return true;
+    }
+
+    @Override
     public String toString() {
-        return "ConditionEval [match=" + match + ", time=" + time + ", used=" + used + "]";
+        return "ConditionEval [match=" + match + ", evalTimestamp=" + evalTimestamp + ", dataTimestamp="
+                + dataTimestamp + ", used=" + used + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
@@ -143,11 +143,8 @@ public class StringCondition extends Condition {
 
     @Override
     public String toString() {
-        return "StringCondition{conditionId='" + conditionId + '\'' +
-                "dataId='" + dataId + '\'' +
-                ", operator=" + operator +
-                ", pattern='" + pattern + '\'' +
-                ", ignoreCase=" + ignoreCase +
-                '}';
+        return "StringCondition [dataId=" + dataId + ", operator=" + operator + ", pattern=" + pattern
+                + ", ignoreCase=" + ignoreCase + ", toString()=" + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.StringData;
+
 /**
  * An evaluation state for string condition.
  *
@@ -28,15 +30,15 @@ public class StringConditionEval extends ConditionEval {
     private String value;
 
     public StringConditionEval() {
-        super(false);
+        super(false, 0);
         this.condition = null;
         this.value = null;
     }
 
-    public StringConditionEval(StringCondition condition, String value) {
-        super(condition.match(value));
+    public StringConditionEval(StringCondition condition, StringData data) {
+        super(condition.match(data.getValue()), data.getTimestamp());
         this.condition = condition;
-        this.value = value;
+        this.value = data.getValue();
     }
 
     public StringCondition getCondition() {
@@ -99,9 +101,8 @@ public class StringConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "StringConditionEval{" +
-                "condition=" + condition +
-                ", value='" + value + '\'' +
-                '}';
+        return "StringConditionEval [condition=" + condition + ", value=" + value + ", toString()=" + super.toString()
+                + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
@@ -121,10 +121,8 @@ public class ThresholdCondition extends Condition {
 
     @Override
     public String toString() {
-        return "ThresholdCondition{conditionId='" + conditionId + '\'' +
-                ", dataId='" + dataId + '\'' +
-                ", operator=" + operator +
-                ", threshold=" + threshold +
-                '}';
+        return "ThresholdCondition [dataId=" + dataId + ", operator=" + operator + ", threshold=" + threshold
+                + ", toString()=" + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.NumericData;
+
 /**
  * An evaluation state for threshold condition.
  *
@@ -28,15 +30,15 @@ public class ThresholdConditionEval extends ConditionEval {
     private Double value;
 
     public ThresholdConditionEval() {
-        super(false);
+        super(false, 0);
         this.condition = null;
         this.value = null;
     }
 
-    public ThresholdConditionEval(ThresholdCondition condition, Double value) {
-        super(condition.match(value));
+    public ThresholdConditionEval(ThresholdCondition condition, NumericData data) {
+        super(condition.match(data.getValue()), data.getTimestamp());
         this.condition = condition;
-        this.value = value;
+        this.value = data.getValue();
     }
 
     public ThresholdCondition getCondition() {
@@ -99,9 +101,8 @@ public class ThresholdConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "ThresholdConditionEval{" +
-                "condition=" + condition +
-                ", value=" + value +
-                '}';
+        return "ThresholdConditionEval [condition=" + condition + ", value=" + value + ", toString()="
+                + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
@@ -194,13 +194,9 @@ public class ThresholdRangeCondition extends Condition {
 
     @Override
     public String toString() {
-        return "ThresholdRangeCondition{conditionId='" + conditionId + '\'' +
-                ", dataId='" + dataId + '\'' +
-                ", operatorLow=" + operatorLow +
-                ", operatorHigh=" + operatorHigh +
-                ", thresholdLow=" + thresholdLow +
-                ", thresholdHigh=" + thresholdHigh +
-                ", inRange=" + inRange +
-                '}';
+        return "ThresholdRangeCondition [dataId=" + dataId + ", operatorLow=" + operatorLow + ", operatorHigh="
+                + operatorHigh + ", thresholdLow=" + thresholdLow + ", thresholdHigh=" + thresholdHigh + ", inRange="
+                + inRange + ", toString()=" + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.NumericData;
+
 /**
  * An evaluation state for threshold range condition.
  *
@@ -28,15 +30,15 @@ public class ThresholdRangeConditionEval extends ConditionEval {
     private Double value;
 
     public ThresholdRangeConditionEval() {
-        super(false);
+        super(false, 0);
         this.condition = null;
         this.value = null;
     }
 
-    public ThresholdRangeConditionEval(ThresholdRangeCondition condition, Double value) {
-        super(condition.match(value));
+    public ThresholdRangeConditionEval(ThresholdRangeCondition condition, NumericData data) {
+        super(condition.match(data.getValue()), data.getTimestamp());
         this.condition = condition;
-        this.value = value;
+        this.value = data.getValue();
     }
 
     public ThresholdRangeCondition getCondition() {
@@ -99,9 +101,8 @@ public class ThresholdRangeConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "ThresholdRangeConditionEval{" +
-                "condition=" + condition +
-                ", value=" + value +
-                '}';
+        return "ThresholdRangeConditionEval [condition=" + condition + ", value=" + value + ", toString()="
+                + super.toString() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
@@ -31,11 +31,11 @@ public class Availability extends Data {
     private AvailabilityType value;
 
     public Availability() {
-        this(null, null);
+        this(null, 0, null);
     }
 
-    public Availability(String id, AvailabilityType value) {
-        this.id = id;
+    public Availability(String id, long timestamp, AvailabilityType value) {
+        super(id, timestamp);
         this.value = value;
     }
 
@@ -49,13 +49,17 @@ public class Availability extends Data {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
 
         Availability that = (Availability) o;
 
-        if (value != that.value) return false;
+        if (value != that.value)
+            return false;
 
         return true;
     }
@@ -69,8 +73,7 @@ public class Availability extends Data {
 
     @Override
     public String toString() {
-        return "Availability{id='" + id + '\'' +
-                "value=" + value +
-                '}';
+        return "Availability [value=" + value + ", getId()=" + getId() + ", getTimestamp()=" + getTimestamp() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -17,14 +17,17 @@
 package org.hawkular.alerts.api.model.data;
 
 /**
- * A base class for incoming data into alerts subsystem.
+ * A base class for incoming data into alerts subsystem.  All {@link Data} has an Id and a timestamp. The
+ * timestamp is used to ensure that data is time-ordered when being sent into the alerting engine.  If
+ * not assigned the timestamp will be assigned to current time.
  *
  * @author Jay Shaughnessy
  * @author Lucas Ponce
  */
 public class Data {
 
-    protected String id;
+    private String id;
+    private long timestamp;
 
     public Data() {
         /*
@@ -33,8 +36,13 @@ public class Data {
         this.id = null;
     }
 
-    public Data(String id) {
+    /**
+     * @param id not null.
+     * @param timestamp if <=0 assigned currentTime.
+     */
+    public Data(String id, long timestamp) {
         this.id = id;
+        this.timestamp = (timestamp <= 0) ? System.currentTimeMillis() : timestamp;
     }
 
     public String getId() {
@@ -45,27 +53,48 @@ public class Data {
         this.id = id;
     }
 
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * @param timestamp if <=0 assigned currentTime.
+     */
+    public void setTimestamp(long timestamp) {
+        this.timestamp = (timestamp <= 0) ? System.currentTimeMillis() : timestamp;
+    }
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Data data = (Data) o;
-
-        if (id != null ? !id.equals(data.id) : data.id != null) return false;
-
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Data other = (Data) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (timestamp != other.timestamp)
+            return false;
         return true;
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
     }
 
     @Override
     public String toString() {
-        return "Data{" +
-                "id='" + id + '\'' +
-                '}';
+        return "Data [id=" + id + ", timestamp=" + timestamp + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
@@ -30,11 +30,11 @@ public class NumericData extends Data {
         /*
             Default constructor is needed for JSON libraries in JAX-RS context.
          */
-        this(null, null);
+        this(null, 0, null);
     }
 
-    public NumericData(String id, Double value) {
-        this.id = id;
+    public NumericData(String id, long timestamp, Double value) {
+        super(id, timestamp);
         this.value = value;
     }
 
@@ -48,13 +48,17 @@ public class NumericData extends Data {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
 
         NumericData that = (NumericData) o;
 
-        if (value != null ? !value.equals(that.value) : that.value != null) return false;
+        if (value != null ? !value.equals(that.value) : that.value != null)
+            return false;
 
         return true;
     }
@@ -68,8 +72,7 @@ public class NumericData extends Data {
 
     @Override
     public String toString() {
-        return "NumericData{id='" + id + '\'' +
-                ", value=" + value +
-                '}';
+        return "NumericData [value=" + value + ", getId()=" + getId() + ", getTimestamp()=" + getTimestamp() + "]";
     }
+
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
@@ -30,11 +30,11 @@ public class StringData extends Data {
         /*
             Default constructor is needed for JSON libraries in JAX-RS context.
          */
-        this(null, null);
+        this(null, 0, null);
     }
 
-    public StringData(String id, String value) {
-        this.id = id;
+    public StringData(String id, long timestamp, String value) {
+        super(id, timestamp);
         this.value = value;
     }
 
@@ -48,13 +48,17 @@ public class StringData extends Data {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
 
         StringData that = (StringData) o;
 
-        if (value != null ? !value.equals(that.value) : that.value != null) return false;
+        if (value != null ? !value.equals(that.value) : that.value != null)
+            return false;
 
         return true;
     }
@@ -68,8 +72,7 @@ public class StringData extends Data {
 
     @Override
     public String toString() {
-        return "StringData{id='" + id + '\'' +
-                ", value='" + value + '\'' +
-                '}';
+        return "StringData [value=" + value + ", getId()=" + getId() + ", getTimestamp()=" + getTimestamp() + "]";
     }
+
 }

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/messages/AlertData.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/messages/AlertData.java
@@ -17,6 +17,7 @@
 package org.hawkular.alerts.bus.messages;
 
 import com.google.gson.annotations.Expose;
+
 import org.hawkular.alerts.api.model.data.Availability;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.data.NumericData;
@@ -35,33 +36,41 @@ public class AlertData {
     private final String id;
 
     @Expose
+    private final long timestamp;
+
+    @Expose
     private final String value;
 
     @Expose
     private final String type;
 
     public AlertData() {
-        this(null, null, null);
+        this(null, 0, null, null);
     }
 
-    public AlertData(String id, String value, String type) {
+    public AlertData(String id, long timestamp, String value, String type) {
         this.id = id;
+        this.timestamp = timestamp;
         this.value = value;
         this.type = type;
     }
 
     public Data convert() {
         if (type != null && !type.isEmpty() && type.equalsIgnoreCase("numeric")) {
-            return new NumericData(id, Double.valueOf(value));
+            return new NumericData(id, timestamp, Double.valueOf(value));
         } else if (type != null && !type.isEmpty() && type.equalsIgnoreCase("availability")) {
-            return new Availability(id, Availability.AvailabilityType.valueOf(value));
+            return new Availability(id, timestamp, Availability.AvailabilityType.valueOf(value));
         } else {
-            return new StringData(id, value);
+            return new StringData(id, timestamp, value);
         }
     }
 
     public String getId() {
         return id;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public String getType() {
@@ -73,33 +82,48 @@ public class AlertData {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AlertData alertData = (AlertData) o;
-
-        if (id != null ? !id.equals(alertData.id) : alertData.id != null) return false;
-        if (type != null ? !type.equals(alertData.type) : alertData.type != null) return false;
-        if (value != null ? !value.equals(alertData.value) : alertData.value != null) return false;
-
-        return true;
-    }
-
-    @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
     }
 
     @Override
-    public String toString() {
-        return "AlertData{" +
-                "id='" + id + '\'' +
-                ", value='" + value + '\'' +
-                ", type='" + type + '\'' +
-                '}';
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AlertData other = (AlertData) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (timestamp != other.timestamp)
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
     }
+
+    @Override
+    public String toString() {
+        return "AlertData [id=" + id + ", timestamp=" + timestamp + ", value=" + value + ", type=" + type + "]";
+    }
+
 }

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -65,9 +65,9 @@ rule Threshold
     when 
         $t : Trigger( active == true, $tid : id )
         $c : ThresholdCondition ( triggerId == $tid, $did : dataId )
-        NumericData( $did == id, $value : value)
+        $d : NumericData( $did == id )
     then
-        ThresholdConditionEval ce = new ThresholdConditionEval($c, (Double)$value);
+        ThresholdConditionEval ce = new ThresholdConditionEval($c, $d);
         if (log != null && log.isDebugEnabled()) {
             log.debug("Threshold Eval: " + (ce.isMatch() ? "  Match! " : "no match ")  + ce.getLog());
         }
@@ -78,9 +78,9 @@ rule ThresholdRange
     when 
         $t : Trigger( active == true, $tid : id )
         $c : ThresholdRangeCondition ( triggerId == $tid, $did : dataId )
-        NumericData( $did == id, $value : value)
+        $d : NumericData( $did == id )
     then
-        ThresholdRangeConditionEval ce = new ThresholdRangeConditionEval($c, (Double)$value);
+        ThresholdRangeConditionEval ce = new ThresholdRangeConditionEval($c, $d);
         if (log != null && log.isDebugEnabled()) {
             log.debug("ThresholdRange Eval: " + (ce.isMatch() ? "  Match! " : "no match ")  + ce.getLog());
         }
@@ -97,12 +97,12 @@ end
 // data when it arrives at different times.
 rule Compare
     when 
-        $t : Trigger( active == true, $tid : id )
-        $c : CompareCondition ( triggerId == $tid, $d1id : data1Id, $d2id : data2Id )
-        NumericData( $d1id == id, $value1 : value)
-        NumericData( $d2id == id, $value2 : value)
+        $t  : Trigger( active == true, $tid : id )
+        $c  : CompareCondition ( triggerId == $tid, $d1id : data1Id, $d2id : data2Id )
+        $d1 : NumericData( $d1id == id )
+        $d2 : NumericData( $d2id == id )
     then
-        CompareConditionEval ce = new CompareConditionEval($c, (Double)$value1, (Double)$value2);
+        CompareConditionEval ce = new CompareConditionEval($c, $d1, $d2);
         if (log != null && log.isDebugEnabled()) {
             log.debug("Compare Eval: " + (ce.isMatch() ? "  Match! " : "no match ")  + ce.getLog());
         }
@@ -113,9 +113,9 @@ rule Availability
     when 
         $t : Trigger( active == true, $tid : id )
         $c : AvailabilityCondition ( triggerId == $tid, $did : dataId )
-        Availability( $did == id, $value : value)
+        $d : Availability( $did == id )
     then
-        AvailabilityConditionEval ce = new AvailabilityConditionEval($c, (AvailabilityType)$value);
+        AvailabilityConditionEval ce = new AvailabilityConditionEval($c, $d);
         if (log != null && log.isDebugEnabled()) {
             log.debug("Availability Eval: " + (ce.isMatch() ? "  Match! " : "no match ")  + ce.getLog());
         }
@@ -126,9 +126,9 @@ rule String
     when 
         $t : Trigger( active == true, $tid : id )
         $c : StringCondition ( triggerId == $tid, $did : dataId  )
-        StringData( $did == id, $value : value)
+        $d : StringData( $did == id )
     then
-        StringConditionEval ce = new StringConditionEval($c, (String)$value);
+        StringConditionEval ce = new StringConditionEval($c, $d);
         if (log != null && log.isDebugEnabled()) {
             log.debug("String Eval: " + (ce.isMatch() ? "  Match! " : "no match ")  + ce.getLog());
         }
@@ -220,8 +220,8 @@ end
 rule RetractObsoleteConditionEval
     salience 10
     when
-        $ce1 : ConditionEval( $tid : triggerId, ( conditionSetSize > 1 ), $csi : conditionSetIndex, $t1 : time )
-        $ce2 : ConditionEval( $tid == triggerId, $csi == conditionSetIndex, $t1 > time )
+        $ce1 : ConditionEval( $tid : triggerId, ( conditionSetSize > 1 ), $csi : conditionSetIndex, $t1 : evalTimestamp )
+        $ce2 : ConditionEval( $tid == triggerId, $csi == conditionSetIndex, $t1 > evalTimestamp )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debug( "Retracting obsolete multi-condition eval " + $ce2 + " (due to " + $ce1 + ")");

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
@@ -16,6 +16,12 @@
  */
 package org.hawkular.alerts.engine;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
 import org.hawkular.alerts.api.model.condition.AvailabilityCondition;
 import org.hawkular.alerts.api.model.condition.CompareCondition;
 import org.hawkular.alerts.api.model.condition.StringCondition;
@@ -23,6 +29,7 @@ import org.hawkular.alerts.api.model.condition.ThresholdCondition;
 import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Availability;
+import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.data.NumericData;
 import org.hawkular.alerts.api.model.data.StringData;
@@ -33,14 +40,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-
-import static org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
 
 /**
  * Basic test of RulesEngine implementation.
@@ -58,25 +57,25 @@ public class RulesEngineTest {
         datums = new HashSet<Data>();
         Random r = new Random();
         for (int i = 0; i < 10; ++i) {
-            NumericData m = new NumericData("NumericData-01", r.nextDouble() * 20);
+            NumericData m = new NumericData("NumericData-01", i, r.nextDouble() * 20);
             datums.add(m);
         }
         for (int i = 0; i < 10; ++i) {
-            NumericData m = new NumericData("NumericData-02", r.nextDouble() * 20);
+            NumericData m = new NumericData("NumericData-02", i, r.nextDouble() * 20);
             datums.add(m);
         }
         for (int i = 0; i < 10; ++i) {
-            NumericData m = new NumericData("NumericData-03", r.nextDouble() * 20);
+            NumericData m = new NumericData("NumericData-03", i, r.nextDouble() * 20);
             datums.add(m);
         }
 
-        datums.add(new StringData("StringData-01", "Barney"));
-        datums.add(new StringData("StringData-01", "Fred and Barney"));
-        datums.add(new StringData("StringData-02", "Fred Flintstone"));
+        datums.add(new StringData("StringData-01", 1, "Barney"));
+        datums.add(new StringData("StringData-01", 2, "Fred and Barney"));
+        datums.add(new StringData("StringData-02", 3, "Fred Flintstone"));
 
-        datums.add(new Availability("Availability-01", AvailabilityType.UP));
-        datums.add(new Availability("Availability-01", AvailabilityType.UP));
-        datums.add(new Availability("Availability-01", AvailabilityType.UNAVAILABLE));
+        datums.add(new Availability("Availability-01", 1, AvailabilityType.UP));
+        datums.add(new Availability("Availability-01", 2, AvailabilityType.UP));
+        datums.add(new Availability("Availability-01", 3, AvailabilityType.UNAVAILABLE));
     }
 
     @Test


### PR DESCRIPTION
May also help with potential temporal reasoning, correlation, and more robust notification. The
timestamps are supplied by the app sending the Data and will default to
system time.
Also:
- Change XxxConditionEval constructors to pass in the relevant Data objects.
  A little cleaner in the rules, and a bit more flexible.
- update and standardize the model's toString() impls given the new fields
  and variations in the previous impls. Used Eclipse's generator.
- update equals/hashcode impls due to field additions. Used Eclipse generators.