### PR TITLE
Add Json anotations into API model

### DIFF
--- a/hawkular-alerts-api/pom.xml
+++ b/hawkular-alerts-api/pom.xml
@@ -54,6 +54,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/action/Action.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/action/Action.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.alerts.api.model.action;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * A base class for action representation from the perspective of the alerts engine.
  * An action is the abstract concept of a consequence of an alert.
@@ -30,8 +33,18 @@ package org.hawkular.alerts.api.model.action;
  */
 public class Action {
 
+    @JsonInclude
     private String actionId;
+
+    @JsonInclude(Include.NON_NULL)
     private String message;
+
+    public Action() { }
+
+    public Action(String actionId, String message) {
+        this.actionId = actionId;
+        this.message = message;
+    }
 
     public String getMessage() {
         return message;
@@ -45,8 +58,8 @@ public class Action {
         return actionId;
     }
 
-    public void setActionId(String notifierId) {
-        this.actionId = notifierId;
+    public void setActionId(String actionId) {
+        this.actionId = actionId;
     }
 
     @Override
@@ -72,7 +85,7 @@ public class Action {
     @Override
     public String toString() {
         return "Action{" +
-                "message='" + message + '\'' +
+                "message=" + (message == null ? null : '\'' + message + '\'') +
                 ", actionId='" + actionId + '\'' +
                 '}';
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -19,6 +19,10 @@ package org.hawkular.alerts.api.model.condition;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
+
 /**
  * A status of an alert thrown by several matched conditions.
  *
@@ -27,8 +31,13 @@ import java.util.Set;
  */
 public class Alert {
 
+    @JsonInclude
     private String triggerId;
+
+    @JsonInclude(Include.NON_EMPTY)
     private List<Set<ConditionEval>> evalSets;
+
+    @JsonInclude
     private long time;
 
     public Alert(String triggerId, List<Set<ConditionEval>> evalSets) {
@@ -85,7 +94,9 @@ public class Alert {
 
     @Override
     public String toString() {
-        return "Alert [triggerId=" + triggerId + ", evals=" + evalSets + ", time=" + time + "]";
+        return "Alert [triggerId=" + triggerId + ", " +
+                "evals=" + evalSets + ", " +
+                "time=" + time + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
@@ -18,6 +18,8 @@ package org.hawkular.alerts.api.model.condition;
 
 import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRE;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.log.MsgLogger;
 import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
@@ -35,7 +37,10 @@ public class AvailabilityCondition extends Condition {
         DOWN, NOT_UP, UP
     }
 
+    @JsonInclude(Include.NON_NULL)
     private String dataId;
+
+    @JsonInclude(Include.NON_NULL)
     private Operator operator;
 
     public AvailabilityCondition() {
@@ -45,6 +50,16 @@ public class AvailabilityCondition extends Condition {
         this("DefaultId", 1, 1, null, null);
     }
 
+    public AvailabilityCondition(String triggerId,
+                                 String dataId, Operator operator) {
+        this(triggerId, FIRE, 1, 1, dataId, operator);
+    }
+
+    public AvailabilityCondition(String triggerId, Mode triggerMode,
+                                 String dataId, Operator operator) {
+        this(triggerId, triggerMode, 1, 1, dataId, operator);
+    }
+
     public AvailabilityCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
         this(triggerId, FIRE, conditionSetSize, conditionSetIndex, dataId, operator);
@@ -52,7 +67,7 @@ public class AvailabilityCondition extends Condition {
 
     public AvailabilityCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.AVAILABILITY);
         this.dataId = dataId;
         this.operator = operator;
     }
@@ -120,8 +135,10 @@ public class AvailabilityCondition extends Condition {
 
     @Override
     public String toString() {
-        return "AvailabilityCondition [dataId=" + dataId + ", operator=" + operator + ", toString()="
-                + super.toString() + "]";
+        return "AvailabilityCondition [triggerId='" + triggerId + "', " +
+                "triggerMode=" + triggerMode + ", " +
+                "dataId=" + (dataId == null ? null : '\'' + dataId + '\'') + ", " +
+                "operator=" + (operator == null ? null : '\'' + operator.toString() + '\'') + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.model.data.Availability;
 import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
 
@@ -27,7 +29,10 @@ import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
  */
 public class AvailabilityConditionEval extends ConditionEval {
 
+    @JsonInclude(Include.NON_NULL)
     private AvailabilityCondition condition;
+
+    @JsonInclude(Include.NON_NULL)
     private AvailabilityType value;
 
     public AvailabilityConditionEval() {
@@ -107,8 +112,10 @@ public class AvailabilityConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "AvailabilityConditionEval [condition=" + condition + ", value=" + value + ", toString()="
-                + super.toString() + "]";
+        return "AvailabilityConditionEval [evalTimestamp=" + evalTimestamp + ", " +
+                "dataTimestamp=" + dataTimestamp + ", " +
+                "condition=" + condition + ", " +
+                "value=" + value + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
@@ -18,6 +18,8 @@ package org.hawkular.alerts.api.model.condition;
 
 import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRE;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.log.MsgLogger;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
@@ -35,9 +37,16 @@ public class CompareCondition extends Condition {
         LT, GT, LTE, GTE
     }
 
+    @JsonInclude(Include.NON_NULL)
     private String data1Id;
+
+    @JsonInclude(Include.NON_NULL)
     private Operator operator;
+
+    @JsonInclude(Include.NON_NULL)
     private String data2Id;
+
+    @JsonInclude(Include.NON_NULL)
     private Double data2Multiplier;
 
     public CompareCondition() {
@@ -47,6 +56,16 @@ public class CompareCondition extends Condition {
         this("DefaultId", 1, 1, null, null, null, null);
     }
 
+    public CompareCondition(String triggerId,
+                            String data1Id, Operator operator, Double data2Multiplier, String data2Id) {
+        this(triggerId, FIRE, 1, 1, data1Id, operator, data2Multiplier, data2Id);
+    }
+
+    public CompareCondition(String triggerId, Mode triggerMode,
+                            String data1Id, Operator operator, Double data2Multiplier, String data2Id) {
+        this(triggerId, triggerMode, 1, 1, data1Id, operator, data2Multiplier, data2Id);
+    }
+
     public CompareCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String data1Id, Operator operator, Double data2Multiplier, String data2Id) {
         this(triggerId, FIRE, conditionSetSize, conditionSetIndex, data1Id, operator, data2Multiplier, data2Id);
@@ -54,7 +73,7 @@ public class CompareCondition extends Condition {
 
     public CompareCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String data1Id, Operator operator, Double data2Multiplier, String data2Id) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.COMPARE);
         this.data1Id = data1Id;
         this.operator = operator;
         this.data2Id = data2Id;
@@ -151,8 +170,12 @@ public class CompareCondition extends Condition {
 
     @Override
     public String toString() {
-        return "CompareCondition [data1Id=" + data1Id + ", operator=" + operator + ", data2Id=" + data2Id
-                + ", data2Multiplier=" + data2Multiplier + ", toString()=" + super.toString() + "]";
+        return "CompareCondition [triggerId='" + triggerId + "', " +
+                "triggerMode=" + triggerMode + ", " +
+                "data1Id=" + (data1Id == null ? null : '\'' + data1Id + '\'') + ", " +
+                "operator=" + (operator == null ? null : '\'' + operator.toString() + '\'') + ", " +
+                "data2Id=" + (data2Id == null ? null : '\'' + data2Id + '\'') + ", " +
+                "data2Multiplier=" + data2Multiplier + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
@@ -16,7 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.NumericData;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
 /**
  * An evaluation state for compare condition.
@@ -26,8 +29,13 @@ import org.hawkular.alerts.api.model.data.NumericData;
  */
 public class CompareConditionEval extends ConditionEval {
 
+    @JsonInclude(Include.NON_NULL)
     private CompareCondition condition;
+
+    @JsonInclude(Include.NON_NULL)
     private Double value1;
+
+    @JsonInclude(Include.NON_NULL)
     private Double value2;
 
     public CompareConditionEval() {
@@ -122,8 +130,11 @@ public class CompareConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "CompareConditionEval [condition=" + condition + ", value1=" + value1 + ", value2=" + value2
-                + ", toString()=" + super.toString() + "]";
+        return "CompareConditionEval [evalTimestamp=" + evalTimestamp + ", " +
+                "dataTimestamp=" + dataTimestamp + ", " +
+                "condition=" + condition + ", " +
+                "value1=" + value1 + ", " +
+                "value2=" + value2 + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
 /**
@@ -26,38 +28,51 @@ import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
  */
 public abstract class Condition {
 
+    public enum Type {
+        AVAILABILITY, COMPARE, STRING, THRESHOLD, RANGE
+    }
+
     /**
      * The owning trigger
      */
+    @JsonInclude
     protected String triggerId;
 
     /**
      * The owning trigger's mode when this condition is active
      */
+    @JsonInclude
     protected Mode triggerMode;
+
+    @JsonInclude
+    protected Type type;
 
     /**
      * Number of conditions associated with a particular trigger.
      * i.e. 2 [ conditions ]
      */
+    @JsonIgnore
     protected int conditionSetSize;
 
     /**
      * Index of the current condition
      * i.e. 1 [ of 2 conditions ]
      */
+    @JsonIgnore
     protected int conditionSetIndex;
 
     /**
      * A composed key for the condition
      */
+    @JsonIgnore
     protected String conditionId;
 
-    public Condition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex) {
+    public Condition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex, Type type) {
         this.triggerId = triggerId;
         this.triggerMode = triggerMode;
         this.conditionSetSize = conditionSetSize;
         this.conditionSetIndex = conditionSetIndex;
+        this.type = type;
         updateId();
     }
 
@@ -109,6 +124,10 @@ public abstract class Condition {
         this.conditionId = sb.toString();
     }
 
+    public Type getType() {
+        return type;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -132,12 +151,6 @@ public abstract class Condition {
         } else if (!conditionId.equals(other.conditionId))
             return false;
         return true;
-    }
-
-    @Override
-    public String toString() {
-        return "Condition [triggerId=" + triggerId + ", triggerMode=" + triggerMode + ", conditionSetSize="
-                + conditionSetSize + ", conditionSetIndex=" + conditionSetIndex + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * An evaluation state of a specific condition.
  *
@@ -25,12 +28,19 @@ package org.hawkular.alerts.api.model.condition;
 public abstract class ConditionEval {
 
     // result of the condition evaluation
+    @JsonIgnore
     protected boolean match;
+
     // time of condition evaluation (i.e. creation time)
+    @JsonInclude
     protected long evalTimestamp;
+
     // time stamped on the data used in the eval
+    @JsonInclude
     protected long dataTimestamp;
+
     // flag noting whether this condition eval was used in a tested Tuple and already applied to dampening
+    @JsonIgnore
     protected boolean used;
 
     public ConditionEval(boolean match, long dataTimestamp) {
@@ -72,12 +82,16 @@ public abstract class ConditionEval {
         this.used = used;
     }
 
+    @JsonIgnore
     public abstract String getTriggerId();
 
+    @JsonIgnore
     public abstract int getConditionSetSize();
 
+    @JsonIgnore
     public abstract int getConditionSetIndex();
 
+    @JsonIgnore
     public abstract String getLog();
 
     @Override
@@ -110,11 +124,4 @@ public abstract class ConditionEval {
             return false;
         return true;
     }
-
-    @Override
-    public String toString() {
-        return "ConditionEval [match=" + match + ", evalTimestamp=" + evalTimestamp + ", dataTimestamp="
-                + dataTimestamp + ", used=" + used + "]";
-    }
-
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.log.MsgLogger;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
@@ -32,9 +34,16 @@ public class StringCondition extends Condition {
         EQUAL, NOT_EQUAL, STARTS_WITH, ENDS_WITH, CONTAINS, MATCH
     }
 
+    @JsonInclude(Include.NON_NULL)
     private String dataId;
+
+    @JsonInclude(Include.NON_NULL)
     private Operator operator;
+
+    @JsonInclude(Include.NON_NULL)
     private String pattern;
+
+    @JsonInclude
     private boolean ignoreCase;
 
     public StringCondition() {
@@ -44,6 +53,16 @@ public class StringCondition extends Condition {
         this("DefaultId", 1, 1, null, null, null, false);
     }
 
+    public StringCondition(String triggerId,
+                           String dataId, Operator operator, String pattern, boolean ignoreCase) {
+        this(triggerId, Mode.FIRE, 1, 1, dataId, operator, pattern, ignoreCase);
+    }
+
+    public StringCondition(String triggerId, Mode triggerMode,
+                           String dataId, Operator operator, String pattern, boolean ignoreCase) {
+        this(triggerId, triggerMode, 1, 1, dataId, operator, pattern, ignoreCase);
+    }
+
     public StringCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, String pattern, boolean ignoreCase) {
         this(triggerId, Mode.FIRE, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
@@ -51,7 +70,7 @@ public class StringCondition extends Condition {
 
     public StringCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, String pattern, boolean ignoreCase) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.STRING);
         this.dataId = dataId;
         this.operator = operator;
         this.pattern = pattern;
@@ -155,8 +174,12 @@ public class StringCondition extends Condition {
 
     @Override
     public String toString() {
-        return "StringCondition [dataId=" + dataId + ", operator=" + operator + ", pattern=" + pattern
-                + ", ignoreCase=" + ignoreCase + ", toString()=" + super.toString() + "]";
+        return  "StringCondition [triggerId='" + triggerId + "', " +
+                "triggerMode=" + triggerMode + ", " +
+                "dataId=" + (dataId == null ? null : '\'' + dataId + '\'') + ", " +
+                "operator=" + (operator == null ? null : '\'' + operator.toString() + '\'') + ", " +
+                "pattern=" + (pattern == null ? null : '\'' + pattern + '\'') + ", " +
+                "ignoreCase=" + ignoreCase + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
@@ -16,7 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.StringData;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
 /**
  * An evaluation state for string condition.
@@ -26,7 +29,10 @@ import org.hawkular.alerts.api.model.data.StringData;
  */
 public class StringConditionEval extends ConditionEval {
 
+    @JsonInclude(Include.NON_NULL)
     private StringCondition condition;
+
+    @JsonInclude(Include.NON_NULL)
     private String value;
 
     public StringConditionEval() {
@@ -101,8 +107,10 @@ public class StringConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "StringConditionEval [condition=" + condition + ", value=" + value + ", toString()=" + super.toString()
-                + "]";
+        return "StringConditionEval [evalTimestamp=" + evalTimestamp + ", " +
+                "dataTimestamp=" + dataTimestamp + ", " +
+                "condition=" + condition + ", " +
+                "value=" + value + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.log.MsgLogger;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
@@ -32,8 +34,13 @@ public class ThresholdCondition extends Condition {
         LT, GT, LTE, GTE
     }
 
+    @JsonInclude(Include.NON_NULL)
     private String dataId;
+
+    @JsonInclude(Include.NON_NULL)
     private Operator operator;
+
+    @JsonInclude(Include.NON_NULL)
     private Double threshold;
 
     public ThresholdCondition() {
@@ -41,6 +48,18 @@ public class ThresholdCondition extends Condition {
             Default constructor is needed for JSON libraries in JAX-RS context.
          */
         this("DefaultId", 1, 1, null, null, null);
+    }
+
+    public ThresholdCondition(String triggerId,
+                              String dataId, Operator operator, Double threshold) {
+
+        this(triggerId, Mode.FIRE, 1, 1, dataId, operator, threshold);
+    }
+
+    public ThresholdCondition(String triggerId, Mode triggerMode,
+                              String dataId, Operator operator, Double threshold) {
+
+        this(triggerId, triggerMode, 1, 1, dataId, operator, threshold);
     }
 
     public ThresholdCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
@@ -51,7 +70,7 @@ public class ThresholdCondition extends Condition {
 
     public ThresholdCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double threshold) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.THRESHOLD);
         this.dataId = dataId;
         this.operator = operator;
         this.threshold = threshold;
@@ -133,8 +152,11 @@ public class ThresholdCondition extends Condition {
 
     @Override
     public String toString() {
-        return "ThresholdCondition [dataId=" + dataId + ", operator=" + operator + ", threshold=" + threshold
-                + ", toString()=" + super.toString() + "]";
+        return "ThresholdCondition [triggerId='" + triggerId + "', " +
+                "triggerMode=" + triggerMode + ", " +
+                "dataId=" + (dataId == null ? null : '\'' + dataId + '\'') + ", " +
+                "operator=" + (operator == null ? null : '\'' + operator.toString() + '\'') + ", " +
+                "threshold=" + threshold + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
@@ -16,7 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.NumericData;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
 /**
  * An evaluation state for threshold condition.
@@ -26,7 +29,10 @@ import org.hawkular.alerts.api.model.data.NumericData;
  */
 public class ThresholdConditionEval extends ConditionEval {
 
+    @JsonInclude(Include.NON_NULL)
     private ThresholdCondition condition;
+
+    @JsonInclude(Include.NON_NULL)
     private Double value;
 
     public ThresholdConditionEval() {
@@ -101,8 +107,10 @@ public class ThresholdConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "ThresholdConditionEval [condition=" + condition + ", value=" + value + ", toString()="
-                + super.toString() + "]";
+        return "ThresholdConditionEval [evalTimestamp=" + evalTimestamp + ", " +
+                "dataTimestamp=" + dataTimestamp + ", " +
+                "condition=" + condition + ", " +
+                "value=" + value + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.log.MsgLogger;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
@@ -47,11 +48,22 @@ public class ThresholdRangeCondition extends Condition {
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String dataId;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Operator operatorLow;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Operator operatorHigh;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double thresholdLow;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double thresholdHigh;
+
+    @JsonInclude
     private boolean inRange;
 
     public ThresholdRangeCondition() {
@@ -59,6 +71,22 @@ public class ThresholdRangeCondition extends Condition {
             Default constructor is needed for JSON libraries in JAX-RS context.
          */
         this("DefaultId", 1, 1, null, null, null, null, null, false);
+    }
+
+    public ThresholdRangeCondition(String triggerId,
+                                   String dataId, Operator operatorLow, Operator operatorHigh,
+                                   Double thresholdLow, Double thresholdHigh, boolean inRange) {
+
+        this(triggerId, Mode.FIRE, 1, 1, dataId, operatorLow, operatorHigh,
+             thresholdLow, thresholdHigh, inRange);
+    }
+
+    public ThresholdRangeCondition(String triggerId, Mode triggerMode,
+                                   String dataId, Operator operatorLow, Operator operatorHigh,
+                                   Double thresholdLow, Double thresholdHigh, boolean inRange) {
+
+        this(triggerId, triggerMode, 1, 1, dataId, operatorLow, operatorHigh,
+             thresholdLow, thresholdHigh, inRange);
     }
 
     public ThresholdRangeCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
@@ -72,7 +100,7 @@ public class ThresholdRangeCondition extends Condition {
     public ThresholdRangeCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operatorLow, Operator operatorHigh,
             Double thresholdLow, Double thresholdHigh, boolean inRange) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.RANGE);
         this.dataId = dataId;
         this.operatorLow = operatorLow;
         this.operatorHigh = operatorHigh;
@@ -210,9 +238,14 @@ public class ThresholdRangeCondition extends Condition {
 
     @Override
     public String toString() {
-        return "ThresholdRangeCondition [dataId=" + dataId + ", operatorLow=" + operatorLow + ", operatorHigh="
-                + operatorHigh + ", thresholdLow=" + thresholdLow + ", thresholdHigh=" + thresholdHigh + ", inRange="
-                + inRange + ", toString()=" + super.toString() + "]";
+        return "ThresholdRangeCondition [triggerId='" + triggerId + "', " +
+                "triggerMode=" + triggerMode + ", " +
+                "dataId=" + (dataId == null ? null : '\'' + dataId + '\'') + ", " +
+                "operatorLow=" + (operatorLow == null ? null : '\'' + operatorLow.toString() + '\'') + ", " +
+                "operatorHigh=" + (operatorHigh == null ? null : '\'' + operatorHigh.toString() + '\'') + ", " +
+                "thresholdLow=" + thresholdLow + ", " +
+                "thresholdHigh=" + thresholdHigh + ", " +
+                "inRange=" + inRange + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
@@ -16,7 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.NumericData;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
 /**
  * An evaluation state for threshold range condition.
@@ -26,7 +29,10 @@ import org.hawkular.alerts.api.model.data.NumericData;
  */
 public class ThresholdRangeConditionEval extends ConditionEval {
 
+    @JsonInclude(Include.NON_NULL)
     private ThresholdRangeCondition condition;
+
+    @JsonInclude(Include.NON_NULL)
     private Double value;
 
     public ThresholdRangeConditionEval() {
@@ -101,8 +107,10 @@ public class ThresholdRangeConditionEval extends ConditionEval {
 
     @Override
     public String toString() {
-        return "ThresholdRangeConditionEval [condition=" + condition + ", value=" + value + ", toString()="
-                + super.toString() + "]";
+        return "ThresholdRangeConditionEval [evalTimestamp=" + evalTimestamp + ", " +
+                "dataTimestamp=" + dataTimestamp + ", " +
+                "condition=" + condition + ", " +
+                "value=" + value + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.trigger.Trigger.Mode;
 
@@ -36,22 +38,44 @@ public class Dampening {
         STRICT, RELAXED_COUNT, RELAXED_TIME, STRICT_TIME
     };
 
+    @JsonInclude
     private String triggerId;
+
+    @JsonInclude
     private Mode triggerMode;
+
+    @JsonInclude
     private Type type;
+
+    @JsonInclude
     private int evalTrueSetting;
+
+    @JsonInclude
     private int evalTotalSetting;
+
+    @JsonInclude
     private long evalTimeSetting;
+
     /**
      * A composed key for the dampening
      */
+    @JsonInclude
     protected String dampeningId;
 
     // The following fields are only relevant while the engine is executing.
+    @JsonIgnore
     private transient int numTrueEvals;
+
+    @JsonIgnore
     private transient int numEvals;
+
+    @JsonIgnore
     private transient long trueEvalsStartTime;
+
+    @JsonIgnore
     private transient boolean satisfied;
+
+    @JsonIgnore
     private transient List<Set<ConditionEval>> satisfyingEvals = new ArrayList<Set<ConditionEval>>();
 
     public Dampening() {
@@ -168,6 +192,7 @@ public class Dampening {
         this.type = type;
     }
 
+    @JsonIgnore
     public int getNumTrueEvals() {
         return numTrueEvals;
     }
@@ -176,6 +201,7 @@ public class Dampening {
         this.numTrueEvals = numTrueEvals;
     }
 
+    @JsonIgnore
     public long getTrueEvalsStartTime() {
         return trueEvalsStartTime;
     }
@@ -184,6 +210,7 @@ public class Dampening {
         this.trueEvalsStartTime = trueEvalsStartTime;
     }
 
+    @JsonIgnore
     public int getNumEvals() {
         return numEvals;
     }
@@ -208,6 +235,7 @@ public class Dampening {
         return evalTimeSetting;
     }
 
+    @JsonIgnore
     public boolean isSatisfied() {
         return satisfied;
     }
@@ -215,6 +243,7 @@ public class Dampening {
     /**
      * @return a safe, but not deep, copy of the satisfying evals List
      */
+    @JsonIgnore
     public List<Set<ConditionEval>> getSatisfyingEvals() {
         return new ArrayList<Set<ConditionEval>>(satisfyingEvals);
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
@@ -33,7 +33,7 @@ public class Availability extends Data {
     }
 
     public Availability(String id, long timestamp, AvailabilityType value) {
-        super(id, timestamp, (null == value) ? AvailabilityType.UP : value);
+        super(id, timestamp, (null == value) ? AvailabilityType.UP : value, Type.AVAILABILITY);
     }
 
     public AvailabilityType getValue() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * A base class for incoming data into alerts subsystem.  All {@link Data} has an Id and a timestamp. The
  * timestamp is used to ensure that data is time-ordered when being sent into the alerting engine.  If
@@ -29,9 +32,22 @@ package org.hawkular.alerts.api.model.data;
  * @author Lucas Ponce
  */
 public abstract class Data implements Comparable<Data> {
+
+    public enum Type {
+        AVAILABILITY, NUMERIC, STRING
+    };
+
+    @JsonInclude
     protected String id;
+
+    @JsonInclude
     protected long timestamp;
+
+    @JsonInclude(Include.NON_NULL)
     protected Object value;
+
+    @JsonInclude
+    protected Type type;
 
     public Data() {
         /*
@@ -44,10 +60,11 @@ public abstract class Data implements Comparable<Data> {
      * @param id not null.
      * @param timestamp if <=0 assigned currentTime.
      */
-    public Data(String id, long timestamp, Object value) {
+    public Data(String id, long timestamp, Object value, Type type) {
         this.id = id;
         this.timestamp = (timestamp <= 0) ? System.currentTimeMillis() : timestamp;
         this.value = value;
+        this.type = type;
     }
 
     public String getId() {
@@ -75,6 +92,14 @@ public abstract class Data implements Comparable<Data> {
 
     public void setValue(Object value) {
         this.value = value;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
     }
 
     @Override

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
@@ -32,7 +32,7 @@ public class NumericData extends Data {
     }
 
     public NumericData(String id, long timestamp, Double value) {
-        super(id, timestamp, (null == value) ? Double.NaN : value);
+        super(id, timestamp, (null == value) ? Double.NaN : value, Type.NUMERIC);
     }
 
     public Double getValue() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
@@ -32,7 +32,7 @@ public class StringData extends Data {
     }
 
     public StringData(String id, long timestamp, String value) {
-        super(id, timestamp, (null == value) ? "" : value);
+        super(id, timestamp, (null == value) ? "" : value, Type.STRING);
     }
 
     public String getValue() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.alerts.api.model.trigger;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A trigger definition.
  *
@@ -28,11 +31,19 @@ public class Trigger extends TriggerTemplate {
         FIRE, SAFETY
     };
 
+    @JsonInclude
     private String id;
+
+    @JsonInclude
     private boolean enabled;
+
+    @JsonInclude
     private boolean safetyEnabled;
+
+    @JsonInclude
     private Mode mode;
 
+    @JsonIgnore
     private transient Match match;
 
     public Trigger() {
@@ -100,6 +111,7 @@ public class Trigger extends TriggerTemplate {
         this.safetyEnabled = safetyEnabled;
     }
 
+    @JsonIgnore
     public Match getMatch() {
         return match;
     }
@@ -107,7 +119,6 @@ public class Trigger extends TriggerTemplate {
     public void setMatch(Match match) {
         this.match = match;
     }
-
 
     @Override
     public int hashCode() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerTemplate.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerTemplate.java
@@ -19,6 +19,10 @@ package org.hawkular.alerts.api.model.trigger;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * A base template for trigger definition.
  *
@@ -31,14 +35,21 @@ public abstract class TriggerTemplate {
         ALL, ANY
     };
 
+    @JsonInclude
     private String name;
+
+    @JsonInclude
     private String description;
 
     /** A group of actions's ids. */
+    @JsonInclude(Include.NON_EMPTY)
     private Set<String> actions;
 
-    private transient Match firingMatch;
-    private transient Match safetyMatch;
+    @JsonInclude
+    private Match firingMatch;
+
+    @JsonInclude
+    private Match safetyMatch;
 
     public TriggerTemplate(String name) {
         this.name = name;
@@ -67,6 +78,7 @@ public abstract class TriggerTemplate {
         this.description = description;
     }
 
+    @JsonIgnore
     public Match getFiringMatch() {
         return firingMatch;
     }
@@ -75,6 +87,7 @@ public abstract class TriggerTemplate {
         this.firingMatch = firingMatch;
     }
 
+    @JsonIgnore
     public Match getSafetyMatch() {
         return safetyMatch;
     }

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -1,0 +1,734 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hawkular.alerts.api.model.action.Action;
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition;
+import org.hawkular.alerts.api.model.condition.AvailabilityConditionEval;
+import org.hawkular.alerts.api.model.condition.CompareCondition;
+import org.hawkular.alerts.api.model.condition.CompareConditionEval;
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.StringCondition;
+import org.hawkular.alerts.api.model.condition.StringConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.Availability;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.data.StringData;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hawkular.alerts.api.model.data.Availability.*;
+import static org.hawkular.alerts.api.model.trigger.Trigger.*;
+
+/**
+ * Validation of JSON serialization/deserialization
+ *
+ * @author Lucas Ponce
+ */
+public class JsonTest {
+
+    ObjectMapper objectMapper;
+
+    @Before
+    public void before() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void jsonActionTest() throws Exception {
+        String str = "{\"actionId\":\"test\",\"message\":\"test-msg\"}";
+        Action action = objectMapper.readValue(str, Action.class);
+
+        assert action.getActionId().equals("test");
+        assert action.getMessage().equals("test-msg");
+
+        String output = objectMapper.writeValueAsString(action);
+
+        assert str.equals(output);
+
+        str = "{\"actionId\":\"test\"}";
+        action = objectMapper.readValue(str, Action.class);
+        output = objectMapper.writeValueAsString(action);
+
+        assert !output.contains("message");
+    }
+
+    @Test
+    public void jsonAlertTest() throws Exception {
+        Alert alert = new Alert("trigger-test", null);
+
+        String output = objectMapper.writeValueAsString(alert);
+
+        assert !output.contains("evalSets");
+
+        AvailabilityCondition aCond = new AvailabilityCondition("trigger-test",
+                                                                "Default",
+                                                                AvailabilityCondition.Operator.UP);
+        Availability aData = new Availability("Metric-test", 1, AvailabilityType.UP);
+        AvailabilityConditionEval aEval = new AvailabilityConditionEval(aCond, aData);
+
+        ThresholdCondition tCond = new ThresholdCondition("trigger-test",
+                                                          "Default",
+                                                          ThresholdCondition.Operator.LTE,
+                                                          50.0);
+        NumericData tData = new NumericData("Metric-test2", 2, 25.5);
+        ThresholdConditionEval tEval = new ThresholdConditionEval(tCond, tData);
+
+        Set<ConditionEval> evals = new HashSet<>();
+        evals.add(aEval);
+        evals.add(tEval);
+
+        List<Set<ConditionEval>> list = new ArrayList<>();
+        list.add(evals);
+
+        alert.setEvalSets(list);
+
+        output = objectMapper.writeValueAsString(alert);
+
+        assert output.contains("evalSets");
+    }
+
+    @Test
+    public void jsonAvailabilityConditionTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"AVAILABILITY\"," +
+                "\"dataId\":\"Default\",\"operator\":\"UP\"}";
+        AvailabilityCondition condition = objectMapper.readValue(str, AvailabilityCondition.class);
+
+        assert condition.getTriggerId().equals("test");
+        assert condition.getTriggerMode().equals(Mode.FIRE);
+        assert condition.getDataId().equals("Default");
+        assert condition.getOperator().equals(AvailabilityCondition.Operator.UP);
+
+        String output = objectMapper.writeValueAsString(condition);
+
+        assert str.equals(output);
+
+        // Check bad mode and operator
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\",\"dataId\":\"Default\",\"operator\":\"UP\"}";
+        try {
+            condition = objectMapper.readValue(str, AvailabilityCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\",\"operator\":\"UPX\"}";
+        try {
+            condition = objectMapper.readValue(str, AvailabilityCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Check uncompleted json
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\"}";
+        condition = objectMapper.readValue(str, AvailabilityCondition.class);
+
+        assert condition.getOperator() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operator");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"operator\":\"UP\"}";
+        condition = objectMapper.readValue(str, AvailabilityCondition.class);
+
+        assert condition.getDataId() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("dataId");
+    }
+
+    @Test
+    public void jsonAvailabilityConditionEvalTest() throws Exception {
+        String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
+                "\"condition\":" +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\",\"operator\":\"UP\"}," +
+                "\"value\":\"UP\"}";
+        AvailabilityConditionEval eval = objectMapper.readValue(str, AvailabilityConditionEval.class);
+
+        assert eval.getEvalTimestamp() == 1;
+        assert eval.getDataTimestamp() == 1;
+        assert eval.getCondition().getType().equals(Condition.Type.AVAILABILITY);
+        assert eval.getCondition().getTriggerId().equals("test");
+        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
+        assert eval.getCondition().getDataId().equals("Default");
+        assert eval.getCondition().getOperator().equals(AvailabilityCondition.Operator.UP);
+        assert eval.getValue().equals(AvailabilityType.UP);
+    }
+
+    @Test
+    public void jsonCompareConditionTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"COMPARE\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
+        CompareCondition condition = objectMapper.readValue(str, CompareCondition.class);
+
+        assert condition.getTriggerId().equals("test");
+        assert condition.getTriggerMode().equals(Mode.FIRE);
+        assert condition.getData1Id().equals("Default1");
+        assert condition.getOperator().equals(CompareCondition.Operator.LT);
+        assert condition.getData2Id().equals("Default2");
+        assert condition.getData2Multiplier() == 1.2d;
+
+        String output = objectMapper.writeValueAsString(condition);
+
+        assert str.equals(output);
+
+        // Check bad mode and operator
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
+        try {
+            condition = objectMapper.readValue(str, CompareCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LTX\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
+        try {
+            condition = objectMapper.readValue(str, CompareCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Check uncompleted json
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
+        condition = objectMapper.readValue(str, CompareCondition.class);
+
+        assert condition.getData1Id() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("data1Id");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"data1Id\":\"Default1\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
+        condition = objectMapper.readValue(str, CompareCondition.class);
+
+        assert condition.getOperator() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operator");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LT\",\"data2Multiplier\":1.2}";
+
+        condition = objectMapper.readValue(str, CompareCondition.class);
+
+        assert condition.getData2Id() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("data2Id");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\"}";
+
+        condition = objectMapper.readValue(str, CompareCondition.class);
+
+        assert condition.getData2Multiplier() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("data2Multiplier");
+    }
+
+    @Test
+    public void jsonCompareConditionEvalTest() throws Exception {
+        String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
+                "\"condition\":" +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"data1Id\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}," +
+                "\"value1\":10.0," +
+                "\"value2\":15.0}";
+        CompareConditionEval eval = objectMapper.readValue(str, CompareConditionEval.class);
+
+        assert eval.getEvalTimestamp() == 1;
+        assert eval.getDataTimestamp() == 1;
+        assert eval.getCondition().getType().equals(Condition.Type.COMPARE);
+        assert eval.getCondition().getTriggerId().equals("test");
+        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
+        assert eval.getCondition().getData1Id().equals("Default1");
+        assert eval.getCondition().getOperator().equals(CompareCondition.Operator.LT);
+        assert eval.getValue1().equals(10.0);
+        assert eval.getValue2().equals(15.0);
+    }
+
+    @Test
+    public void jsonStringConditionTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRING\"," +
+                "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
+        StringCondition condition = objectMapper.readValue(str, StringCondition.class);
+
+        assert condition.getTriggerId().equals("test");
+        assert condition.getTriggerMode().equals(Mode.FIRE);
+        assert condition.getDataId().equals("Default");
+        assert condition.getOperator().equals(StringCondition.Operator.MATCH);
+        assert condition.getPattern().equals("test-pattern");
+        assert condition.isIgnoreCase() == false;
+
+        String output = objectMapper.writeValueAsString(condition);
+
+        assert str.equals(output);
+
+        // Check bad mode and operator
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+                "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
+        try {
+            condition = objectMapper.readValue(str, StringCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operator\":\"MATCHX\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
+        try {
+            condition = objectMapper.readValue(str, StringCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Check uncompleted json
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
+        condition = objectMapper.readValue(str, StringCondition.class);
+
+        assert condition.getDataId() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("dataId");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
+        condition = objectMapper.readValue(str, StringCondition.class);
+
+        assert condition.getOperator() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operator");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"ignoreCase\":false}";
+        condition = objectMapper.readValue(str, StringCondition.class);
+
+        assert condition.getPattern() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("pattern");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        condition = objectMapper.readValue(str, StringCondition.class);
+
+        assert condition.isIgnoreCase() == false;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        // ignoreCase will be present as it is a boolean with default value
+        assert output.contains("ignoreCase");
+    }
+
+    @Test
+    public void jsonStringConditionEvalTest() throws Exception {
+        String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
+                "\"condition\":" +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}," +
+                "\"value\":\"test-value\"}";
+        StringConditionEval eval = objectMapper.readValue(str, StringConditionEval.class);
+
+        assert eval.getEvalTimestamp() == 1;
+        assert eval.getDataTimestamp() == 1;
+        assert eval.getCondition().getType().equals(Condition.Type.STRING);
+        assert eval.getCondition().getTriggerId().equals("test");
+        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
+        assert eval.getCondition().getDataId().equals("Default");
+        assert eval.getCondition().getOperator().equals(StringCondition.Operator.MATCH);
+        assert eval.getCondition().getPattern().equals("test-pattern");
+        assert eval.getCondition().isIgnoreCase() == false;
+        assert eval.getValue().equals("test-value");
+    }
+
+    @Test
+    public void jsonThresholdConditionTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"THRESHOLD\"," +
+                "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}";
+        ThresholdCondition condition = objectMapper.readValue(str, ThresholdCondition.class);
+
+        assert condition.getTriggerId().equals("test");
+        assert condition.getTriggerMode().equals(Mode.FIRE);
+        assert condition.getDataId().equals("Default");
+        assert condition.getOperator().equals(ThresholdCondition.Operator.LT);
+        assert condition.getThreshold() == 10.5d;
+
+        String output = objectMapper.writeValueAsString(condition);
+
+        assert str.equals(output);
+
+        // Check bad mode and operator
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+                "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}";
+        try {
+            condition = objectMapper.readValue(str, ThresholdCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operator\":\"LTX\",\"threshold\":10.5}";
+        try {
+            condition = objectMapper.readValue(str, ThresholdCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Check uncompleted json
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"operator\":\"LT\",\"threshold\":10.5}";
+        condition = objectMapper.readValue(str, ThresholdCondition.class);
+
+        assert condition.getDataId() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("dataId");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"threshold\":10.5}";
+        condition = objectMapper.readValue(str, ThresholdCondition.class);
+
+        assert condition.getOperator() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operator");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        condition = objectMapper.readValue(str, ThresholdCondition.class);
+
+        assert condition.getThreshold() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("threshold");
+    }
+
+    @Test
+    public void jsonThresholdConditionEvalTest() throws Exception {
+        String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
+                "\"condition\":" +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}," +
+                "\"value\":1.0}";
+        ThresholdConditionEval eval = objectMapper.readValue(str, ThresholdConditionEval.class);
+
+        assert eval.getEvalTimestamp() == 1;
+        assert eval.getDataTimestamp() == 1;
+        assert eval.getCondition().getType().equals(Condition.Type.THRESHOLD);
+        assert eval.getCondition().getTriggerId().equals("test");
+        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
+        assert eval.getCondition().getDataId().equals("Default");
+        assert eval.getCondition().getOperator().equals(ThresholdCondition.Operator.LT);
+        assert eval.getCondition().getThreshold() == 10.5;
+        assert eval.getValue() == 1.0;
+    }
+
+    @Test
+    public void jsonThresholdRangeConditionTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"RANGE\"," +
+                "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        ThresholdRangeCondition condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getTriggerId().equals("test");
+        assert condition.getTriggerMode().equals(Mode.FIRE);
+        assert condition.getDataId().equals("Default");
+        assert condition.getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
+        assert condition.getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
+        assert condition.getThresholdLow() == 10.5d;
+        assert condition.getThresholdHigh() == 20.5d;
+
+        String output = objectMapper.writeValueAsString(condition);
+
+        assert str.equals(output);
+
+        // Check bad mode and operator
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+                "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        try {
+            condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVEX\",\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        try {
+            condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVEX\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        try {
+            condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Check uncompleted json
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getDataId() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("dataId");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getOperatorLow() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operatorLow");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getOperatorHigh() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("operatorHigh");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"thresholdHigh\":20.5,\"inRange\":true}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getThresholdLow() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("thresholdLow");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"inRange\":true}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.getThresholdHigh() == null;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert !output.contains("thresholdHigh");
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
+
+        assert condition.isInRange() == false;
+
+        output = objectMapper.writeValueAsString(condition);
+
+        assert output.contains("inRange");
+    }
+
+    @Test
+    public void jsonThresholdRangeConditionEvalTest() throws Exception {
+        String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
+                "\"condition\":" +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
+                "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}," +
+                "\"value\":1.0}";
+        ThresholdRangeConditionEval eval = objectMapper.readValue(str, ThresholdRangeConditionEval.class);
+
+        assert eval.getEvalTimestamp() == 1;
+        assert eval.getDataTimestamp() == 1;
+        assert eval.getCondition().getType().equals(Condition.Type.RANGE);
+        assert eval.getCondition().getTriggerId().equals("test");
+        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
+        assert eval.getCondition().getDataId().equals("Default");
+        assert eval.getCondition().getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
+        assert eval.getCondition().getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
+        assert eval.getCondition().getThresholdLow() == 10.5;
+        assert eval.getCondition().getThresholdHigh() == 20.5;
+        assert eval.getValue() == 1.0;
+    }
+
+    @Test
+    public void jsonDampeningTest() throws Exception {
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRICT\"," +
+                "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
+        Dampening damp = objectMapper.readValue(str, Dampening.class);
+
+        assert damp.getDampeningId().equals("test-FIRE");
+        assert damp.getTriggerId().equals("test");
+        assert damp.getTriggerMode().equals(Mode.FIRE);
+        assert damp.getType().equals(Dampening.Type.STRICT);
+        assert damp.getEvalTrueSetting() == 1;
+        assert damp.getEvalTotalSetting() == 1;
+        assert damp.getEvalTimeSetting() == 1;
+
+        String output = objectMapper.writeValueAsString(damp);
+
+        // Checking ignored fields are not there
+
+        assert output.contains("dampeningId");
+        assert !output.contains("numTrueEvals");
+        assert !output.contains("numEvals");
+        assert !output.contains("trueEvalsStartTime");
+        assert !output.contains("satisfied");
+        assert !output.contains("satisfyingEvals");
+
+        // Checking bad fields
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\",\"type\":\"STRICT\"," +
+                "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
+        try {
+            damp = objectMapper.readValue(str, Dampening.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRICTX\"," +
+                "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
+        try {
+            damp = objectMapper.readValue(str, Dampening.class);
+            throw new Exception("It should throw an InvalidFormatException");
+        } catch (Exception e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void jsonDataTest() throws Exception {
+        String str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"UNAVAILABLE\"}";
+        Availability aData = objectMapper.readValue(str, Availability.class);
+
+        assert aData.getId().equals("test");
+        assert aData.getTimestamp() == 1;
+        assert aData.getValue().equals(AvailabilityType.UNAVAILABLE);
+
+        String output = objectMapper.writeValueAsString(aData);
+
+        assert output.contains("type");
+        assert output.contains("AVAILABILITY");
+
+        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":10.45}";
+        NumericData nData = objectMapper.readValue(str, NumericData.class);
+
+        assert nData.getId().equals("test");
+        assert nData.getTimestamp() == 1;
+        assert nData.getValue() == 10.45;
+
+        output = objectMapper.writeValueAsString(nData);
+
+        assert output.contains("type");
+        assert output.contains("NUMERIC");
+
+        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"test-value\"}";
+        StringData sData = objectMapper.readValue(str, StringData.class);
+
+        assert sData.getId().equals("test");
+        assert sData.getTimestamp() == 1;
+        assert sData.getValue().equals("test-value");
+
+        output = objectMapper.writeValueAsString(sData);
+
+        assert output.contains("type");
+        assert output.contains("STRING");
+    }
+
+    @Test
+    public void jsonTriggerTest() throws Exception {
+        String str = "{\"name\":\"test-name\",\"description\":\"test-description\"," +
+                "\"actions\":[\"uno\",\"dos\",\"tres\"]," +
+                "\"firingMatch\":\"ALL\"," +
+                "\"safetyMatch\":\"ALL\"," +
+                "\"id\":\"test\"," +
+                "\"enabled\":true," +
+                "\"safetyEnabled\":true," +
+                "\"mode\":\"FIRE\"}";
+        Trigger trigger = objectMapper.readValue(str, Trigger.class);
+
+        assert trigger.getName().equals("test-name");
+        assert trigger.getDescription().equals("test-description");
+        assert trigger.getActions() != null && trigger.getActions().size() == 3;
+        assert trigger.getFiringMatch().equals(Match.ALL);
+        assert trigger.getSafetyMatch().equals(Match.ALL);
+        assert trigger.getId().equals("test");
+        assert trigger.isEnabled() == true;
+        assert trigger.isSafetyEnabled() == true;
+        assert trigger.getMode().equals(Mode.FIRE);
+
+        String output = objectMapper.writeValueAsString(trigger);
+
+        assert !output.contains("firingMatch");
+        assert !output.contains("safetyMatch");
+        assert !output.contains("match");
+    }
+
+}

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -373,9 +373,7 @@ rule AlertOnSatisfiedDampening
         alerts.add(newAlert);
         if (actions != null) {
             for (String actionId : $t.getActions()) {
-                Action action = new Action();
-                action.setActionId(actionId);
-                action.setMessage(newAlert.toString());
+                Action action = new Action(actionId, newAlert.toString());
                 actions.send(action);
             }
         }

--- a/hawkular-alerts-rest/src/test/groovy/org/hawkular/alerts/rest/AvailabilityConditionsTest.groovy
+++ b/hawkular-alerts-rest/src/test/groovy/org/hawkular/alerts/rest/AvailabilityConditionsTest.groovy
@@ -54,7 +54,7 @@ class AvailabilityConditionsTest extends AbstractTestBase {
         def resp = client.post(path: "triggers", body: testTrigger)
         assertEquals(200, resp.status)
 
-        AvailabilityCondition testCond = new AvailabilityCondition("test-trigger-1", 1, 1,
+        AvailabilityCondition testCond = new AvailabilityCondition("test-trigger-1",
                                                                    "No-Metric", Operator.NOT_UP);
 
         resp = client.post(path: "conditions/availability", body: testCond)

--- a/hawkular-alerts-rest/src/test/groovy/org/hawkular/alerts/rest/CompareConditionsTest.groovy
+++ b/hawkular-alerts-rest/src/test/groovy/org/hawkular/alerts/rest/CompareConditionsTest.groovy
@@ -53,7 +53,7 @@ class CompareConditionsTest extends AbstractTestBase {
         def resp = client.post(path: "triggers", body: testTrigger)
         assertEquals(200, resp.status)
 
-        CompareCondition testCond = new CompareCondition("test-trigger-2", 1, 1,
+        CompareCondition testCond = new CompareCondition("test-trigger-2",
                                                          "No-Metric-1", Operator.LT, 1.0, "No-Metric-2");
 
         resp = client.post(path: "conditions/compare", body: testCond)


### PR DESCRIPTION
As a previous step to review REST end points, I have added Json annotations into the API model.
This can also help in the documentation between interaction from Java vs JSON model.
So, with this approach we can avoid to maintain a parallel model inside the engine.
REST endpoints are not yet reviewed, those will come in future commits.