### PR TITLE
HWKALERTS-31 Create a Twilio SMS notification sender

### DIFF
--- a/hawkular-actions-api/src/main/java/org/hawkular/actions/api/log/MsgLogger.java
+++ b/hawkular-actions-api/src/main/java/org/hawkular/actions/api/log/MsgLogger.java
@@ -45,4 +45,8 @@ public interface MsgLogger extends BasicLogger {
     @Message(id = 240005, value = "Plugin [%s] cannot send a message to the bus. Error: [%s]")
     void errorCannotSendMessage(String actionPlugin, String msg);
 
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 240006, value = "Plugin [%s] cannot be started. Error: [%s]")
+    void errorCannotBeStarted(String actionPlugin, String msg);
+
 }

--- a/hawkular-actions-sms/pom.xml
+++ b/hawkular-actions-sms/pom.xml
@@ -33,8 +33,15 @@
   <packaging>war</packaging>
 
   <name>Hawkular Action Sms Plugin</name>
+  <description>An action plugin to send SMS with Twilio</description>
 
   <dependencies>
+
+    <dependency>
+      <groupId>com.twilio.sdk</groupId>
+      <artifactId>twilio-java-sdk</artifactId>
+      <version>3.8.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
@@ -104,9 +111,17 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Tests -->
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hawkular-actions-sms/src/main/java/org/hawkular/actions/sms/listener/SmsListener.java
+++ b/hawkular-actions-sms/src/main/java/org/hawkular/actions/sms/listener/SmsListener.java
@@ -16,14 +16,26 @@
  */
 package org.hawkular.actions.sms.listener;
 
-import org.hawkular.bus.common.consumer.BasicMessageListener;
-import org.hawkular.actions.api.log.MsgLogger;
-import org.hawkular.actions.api.model.ActionMessage;
-import org.jboss.logging.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.MessageDriven;
 import javax.jms.MessageListener;
+
+import com.twilio.sdk.TwilioRestClient;
+import com.twilio.sdk.TwilioRestException;
+import com.twilio.sdk.resource.factory.MessageFactory;
+import com.twilio.sdk.resource.instance.Account;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.hawkular.actions.api.log.MsgLogger;
+import org.hawkular.actions.api.model.ActionMessage;
+import org.hawkular.bus.common.consumer.BasicMessageListener;
 
 /**
  * An example of listener for sms processing.
@@ -34,12 +46,62 @@ import javax.jms.MessageListener;
 @MessageDriven(messageListenerInterface = MessageListener.class, activationConfig = {
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "HawkularAlertsActionsTopic"),
-        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "actionPlugin like 'sms'")})
+    @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "actionPlugin like 'sms'") })
 public class SmsListener extends BasicMessageListener<ActionMessage> {
+    static final String ACCOUNT_SID_PROPERTY = "org.hawkular.actions.sms.sid";
+    static final String ACCOUNT_SID = System.getProperty(ACCOUNT_SID_PROPERTY);
+    static final String AUTH_TOKEN_PROPERTY = "org.hawkular.actions.sms.token";
+    static final String AUTH_TOKEN = System.getProperty(AUTH_TOKEN_PROPERTY);
+    static final String FROM_PROPERTY = "org.hawkular.actions.sms.from";
+    static final String FROM = System.getProperty(FROM_PROPERTY);
+
     private final MsgLogger msgLog = MsgLogger.LOGGER;
-    private final Logger log = Logger.getLogger(SmsListener.class);
+
+    MessageFactory messageFactory;
+
+    @PostConstruct
+    void setup() {
+        if (StringUtils.isBlank(ACCOUNT_SID) || StringUtils.isBlank(AUTH_TOKEN)) {
+            String msg = "Configure " + ACCOUNT_SID_PROPERTY + " and " + AUTH_TOKEN_PROPERTY;
+            msgLog.errorCannotBeStarted("sms", msg);
+            return;
+        }
+        try {
+            TwilioRestClient client = new TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN);
+            Account account = client.getAccount();
+            messageFactory = account.getMessageFactory();
+        } catch (Exception e) {
+            msgLog.errorCannotBeStarted("sms", e.getLocalizedMessage());
+        }
+    }
 
     protected void onBasicMessage(ActionMessage msg) {
         msgLog.infoActionReceived("sms", msg.toString());
+
+        if (messageFactory == null) {
+            msgLog.errorCannotSendMessage("sms", "Plugin is not started");
+        }
+
+        Map<String, String> properties = msg.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            msgLog.errorCannotSendMessage("sms", "Missing message properties");
+            return;
+        }
+        String to = properties.get("phone");
+        if (StringUtils.isBlank(to)) {
+            msgLog.errorCannotSendMessage("sms", "Missing recipient");
+            return;
+        }
+
+        List<NameValuePair> params = new ArrayList<>(3);
+        params.add(new BasicNameValuePair("To", to));
+        params.add(new BasicNameValuePair("From", FROM));
+        params.add(new BasicNameValuePair("Body", msg.getMessage()));
+
+        try {
+            messageFactory.create(params);
+        } catch (TwilioRestException e) {
+            msgLog.errorCannotSendMessage("sms", e.getLocalizedMessage());
+        }
     }
 }

--- a/hawkular-actions-sms/src/test/java/org/hawkular/actions/sms/listener/SmsListenerTest.java
+++ b/hawkular-actions-sms/src/test/java/org/hawkular/actions/sms/listener/SmsListenerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.actions.sms.listener;
+
+import static org.hawkular.actions.sms.listener.SmsListener.ACCOUNT_SID_PROPERTY;
+import static org.hawkular.actions.sms.listener.SmsListener.AUTH_TOKEN_PROPERTY;
+import static org.hawkular.actions.sms.listener.SmsListener.FROM_PROPERTY;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.twilio.sdk.resource.factory.MessageFactory;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.hawkular.actions.api.model.ActionMessage;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SmsListenerTest {
+
+    @BeforeClass
+    public static void configureListener() {
+        System.setProperty(ACCOUNT_SID_PROPERTY, "account");
+        System.setProperty(AUTH_TOKEN_PROPERTY, "token");
+        System.setProperty(FROM_PROPERTY, "+14158141829");
+    }
+
+    private MessageFactory messageFactory;
+    private SmsListener smsListener;
+
+    @Before
+    public void setup() {
+        messageFactory = mock(MessageFactory.class);
+        smsListener = new SmsListener();
+        smsListener.messageFactory = messageFactory;
+    }
+
+    @Test
+    public void testSend() throws Exception {
+        String expectedRecipient = "+14158141828";
+        String expectedContent = "marseille";
+
+        ActionMessage actionMessage = new ActionMessage();
+        actionMessage.setProperties(ImmutableMap.of("phone", expectedRecipient));
+        actionMessage.setMessage(expectedContent);
+        smsListener.onBasicMessage(actionMessage);
+
+        List<NameValuePair> expectedParams = new ImmutableList.Builder<NameValuePair>()
+            .add(new BasicNameValuePair("To", expectedRecipient))
+            .add(new BasicNameValuePair("From", System.getProperty(FROM_PROPERTY)))
+            .add(new BasicNameValuePair("Body", expectedContent))
+            .build();
+        verify(messageFactory, times(1)).create(eq(expectedParams));
+    }
+}

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/actions.data
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/actions.data
@@ -2,4 +2,4 @@
 SNMP-Trap-1,snmp,host=snmp-host,port=1234,OID=1.2.3.4.5,description=This is an example of SNMP Action Plugin
 SNMP-Trap-2,snmp,host=snmp-host,port=1234,OID=1.2.3.5.5,description=This is an example of SNMP Action Plugin
 email-to-admin,email,to=admin@hawkular.org,cc=bigboss@hawkular.org,description=This is an example of Email Action Plugin
-sms-to-cio,sms,phone=555-12345,description=This is an example of SMS Action Plugin
+sms-to-cio,sms,phone=+15005550006,description=This is an example of SMS Action Plugin

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/actions.data
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/actions.data
@@ -1,9 +1,5 @@
-<<<<<<< HEAD
 #action id, action plugin,propertyName1=propertyValue1,propertyName2=propertyValue2,propertyNameN=propertyValueN
-=======
-#action id, action plugin,description
->>>>>>> HWKALERTS-24 Refactoring of notifications
 SNMP-Trap-1,snmp,host=snmp-host,port=1234,OID=1.2.3.4.5,description=This is an example of SNMP Action Plugin
 SNMP-Trap-2,snmp,host=snmp-host,port=1234,OID=1.2.3.5.5,description=This is an example of SNMP Action Plugin
 email-to-admin,email,to=admin@hawkular.org,cc=bigboss@hawkular.org,description=This is an example of Email Action Plugin
-sms-to-cio,sms,phone=555-12345,description=This is an example of SMS Action Plugin
+sms-to-cio,sms,phone=+15005550006,description=This is an example of SMS Action Plugin

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
         <scope>import</scope>
       </dependency>
 
+      <!-- Tests dependencies -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.19</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
The plugin expects to find a few system properties to configure the Twilio client:
service id, token, from number

If the client can't be initialized, an error message is logged and when messages arrive they're just dropped.

The PR has a unit test and the integration was tested with a free Twilio account