### PR TITLE
HWKALERTS-35

### DIFF
--- a/hawkular-actions-plugins/hawkular-actions-email/src/test/java/org/hawkular/actions/email/listener/EmailListenerTest.java
+++ b/hawkular-actions-plugins/hawkular-actions-email/src/test/java/org/hawkular/actions/email/listener/EmailListenerTest.java
@@ -25,10 +25,10 @@ import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.Message.RecipientType;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.hawkular.actions.api.model.ActionMessage;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Thomas Segismont
@@ -49,7 +49,7 @@ public class EmailListenerTest {
 
         Message mimeMessage = emailListener.createMimeMessage(actionMessage);
 
-        assertAddressIs("sender", "noreply@hawkular", mimeMessage.getFrom());
+        assertAddressIs("sender", "noreply@hawkular.org", mimeMessage.getFrom());
         assertAddressIs("recipient", expectedRecipient, mimeMessage.getRecipients(RecipientType.TO));
         assertAddressIs("carbon copy", expectedCarbonCopy, mimeMessage.getRecipients(RecipientType.CC));
 

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -30,14 +30,46 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  */
 public class Alert {
 
+    public enum Status {
+        OPEN, ACKNOWLEDGED, RESOLVED
+    };
+
+    // This is a generated composite of form: triggerId|ctime
+    @JsonInclude
+    private String alertId;
+
     @JsonInclude
     private String triggerId;
+
+    @JsonInclude
+    private long ctime;
 
     @JsonInclude(Include.NON_EMPTY)
     private List<Set<ConditionEval>> evalSets;
 
     @JsonInclude
-    private long ctime;
+    private Status status;
+
+    @JsonInclude
+    private long ackTime;
+
+    @JsonInclude
+    private String ackBy;
+
+    @JsonInclude
+    private String ackNotes;
+
+    @JsonInclude
+    private long resolvedTime;
+
+    @JsonInclude
+    private String resolvedBy;
+
+    @JsonInclude
+    private String resolvedNotes;
+
+    @JsonInclude(Include.NON_EMPTY)
+    private List<Set<ConditionEval>> resolvedEvalSets;
 
     public Alert() {
         // for json assembly
@@ -47,6 +79,17 @@ public class Alert {
         this.triggerId = triggerId;
         this.evalSets = evalSets;
         this.ctime = System.currentTimeMillis();
+        this.status = Status.OPEN;
+
+        this.alertId = triggerId + "|" + ctime;
+    }
+
+    public String getAlertId() {
+        return alertId;
+    }
+
+    public void setAlertId(String alertId) {
+        this.alertId = alertId;
     }
 
     public List<Set<ConditionEval>> getEvalSets() {
@@ -57,11 +100,11 @@ public class Alert {
         this.evalSets = evalSets;
     }
 
-    public long getCTime() {
+    public long getCtime() {
         return ctime;
     }
 
-    public void setCTime(long ctime) {
+    public void setCtime(long ctime) {
         this.ctime = ctime;
     }
 
@@ -73,34 +116,99 @@ public class Alert {
         this.triggerId = triggerId;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public Status getStatus() {
+        return status;
+    }
 
-        Alert alert = (Alert) o;
+    public void setStatus(Status status) {
+        this.status = status;
+    }
 
-        if (ctime != alert.ctime)
-            return false;
-        if (evalSets != null ? !evalSets.equals(alert.evalSets) : alert.evalSets != null) return false;
-        if (triggerId != null ? !triggerId.equals(alert.triggerId) : alert.triggerId != null) return false;
+    public long getAckTime() {
+        return ackTime;
+    }
 
-        return true;
+    public void setAckTime(long ackTime) {
+        this.ackTime = ackTime;
+    }
+
+    public String getAckBy() {
+        return ackBy;
+    }
+
+    public void setAckBy(String ackBy) {
+        this.ackBy = ackBy;
+    }
+
+    public String getAckNotes() {
+        return ackNotes;
+    }
+
+    public void setAckNotes(String ackNotes) {
+        this.ackNotes = ackNotes;
+    }
+
+    public long getResolvedTime() {
+        return resolvedTime;
+    }
+
+    public void setResolvedTime(long resolvedTime) {
+        this.resolvedTime = resolvedTime;
+    }
+
+    public String getResolvedBy() {
+        return resolvedBy;
+    }
+
+    public void setResolvedBy(String resolvedBy) {
+        this.resolvedBy = resolvedBy;
+    }
+
+    public String getResolvedNotes() {
+        return resolvedNotes;
+    }
+
+    public void setResolvedNotes(String resolvedNotes) {
+        this.resolvedNotes = resolvedNotes;
+    }
+
+    public List<Set<ConditionEval>> getResolvedEvalSets() {
+        return resolvedEvalSets;
+    }
+
+    public void setResolvedEvalSets(List<Set<ConditionEval>> resolvedEvalSets) {
+        this.resolvedEvalSets = resolvedEvalSets;
     }
 
     @Override
     public int hashCode() {
-        int result = triggerId != null ? triggerId.hashCode() : 0;
-        result = 31 * result + (evalSets != null ? evalSets.hashCode() : 0);
-        result = 31 * result + (int) (ctime ^ (ctime >>> 32));
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((alertId == null) ? 0 : alertId.hashCode());
         return result;
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Alert other = (Alert) obj;
+        if (alertId == null) {
+            if (other.alertId != null)
+                return false;
+        } else if (!alertId.equals(other.alertId))
+            return false;
+        return true;
+    }
+
+    @Override
     public String toString() {
-        return "Alert [triggerId=" + triggerId + ", " +
-                "evals=" + evalSets + ", " +
-                "ctime=" + ctime + "]";
+        return "Alert [alertId=" + alertId + ", status=" + status + ", ackTime=" + ackTime
+                + ", ackBy=" + ackBy + ", resolvedTime=" + resolvedTime + ", resolvedBy=" + resolvedBy + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRE;
+import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRING;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -52,7 +52,7 @@ public class AvailabilityCondition extends Condition {
 
     public AvailabilityCondition(String triggerId,
                                  String dataId, Operator operator) {
-        this(triggerId, FIRE, 1, 1, dataId, operator);
+        this(triggerId, FIRING, 1, 1, dataId, operator);
     }
 
     public AvailabilityCondition(String triggerId, Mode triggerMode,
@@ -62,7 +62,7 @@ public class AvailabilityCondition extends Condition {
 
     public AvailabilityCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
-        this(triggerId, FIRE, conditionSetSize, conditionSetIndex, dataId, operator);
+        this(triggerId, FIRING, conditionSetSize, conditionSetIndex, dataId, operator);
     }
 
     public AvailabilityCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRE;
+import static org.hawkular.alerts.api.model.trigger.Trigger.Mode.FIRING;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -59,7 +59,7 @@ public class CompareCondition extends Condition {
 
     public CompareCondition(String triggerId,
                             String dataId, Operator operator, Double data2Multiplier, String data2Id) {
-        this(triggerId, FIRE, 1, 1, dataId, operator, data2Multiplier, data2Id);
+        this(triggerId, FIRING, 1, 1, dataId, operator, data2Multiplier, data2Id);
     }
 
     public CompareCondition(String triggerId, Mode triggerMode,
@@ -69,7 +69,7 @@ public class CompareCondition extends Condition {
 
     public CompareCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double data2Multiplier, String data2Id) {
-        this(triggerId, FIRE, conditionSetSize, conditionSetIndex, dataId, operator, data2Multiplier, data2Id);
+        this(triggerId, FIRING, conditionSetSize, conditionSetIndex, dataId, operator, data2Multiplier, data2Id);
     }
 
     public CompareCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
@@ -55,7 +55,7 @@ public class StringCondition extends Condition {
 
     public StringCondition(String triggerId,
                            String dataId, Operator operator, String pattern, boolean ignoreCase) {
-        this(triggerId, Mode.FIRE, 1, 1, dataId, operator, pattern, ignoreCase);
+        this(triggerId, Mode.FIRING, 1, 1, dataId, operator, pattern, ignoreCase);
     }
 
     public StringCondition(String triggerId, Mode triggerMode,
@@ -65,7 +65,7 @@ public class StringCondition extends Condition {
 
     public StringCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, String pattern, boolean ignoreCase) {
-        this(triggerId, Mode.FIRE, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
+        this(triggerId, Mode.FIRING, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
     }
 
     public StringCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
@@ -53,7 +53,7 @@ public class ThresholdCondition extends Condition {
     public ThresholdCondition(String triggerId,
                               String dataId, Operator operator, Double threshold) {
 
-        this(triggerId, Mode.FIRE, 1, 1, dataId, operator, threshold);
+        this(triggerId, Mode.FIRING, 1, 1, dataId, operator, threshold);
     }
 
     public ThresholdCondition(String triggerId, Mode triggerMode,
@@ -65,7 +65,7 @@ public class ThresholdCondition extends Condition {
     public ThresholdCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double threshold) {
 
-        this(triggerId, Mode.FIRE, conditionSetSize, conditionSetIndex, dataId, operator, threshold);
+        this(triggerId, Mode.FIRING, conditionSetSize, conditionSetIndex, dataId, operator, threshold);
     }
 
     public ThresholdCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
@@ -77,7 +77,7 @@ public class ThresholdRangeCondition extends Condition {
                                    String dataId, Operator operatorLow, Operator operatorHigh,
                                    Double thresholdLow, Double thresholdHigh, boolean inRange) {
 
-        this(triggerId, Mode.FIRE, 1, 1, dataId, operatorLow, operatorHigh,
+        this(triggerId, Mode.FIRING, 1, 1, dataId, operatorLow, operatorHigh,
              thresholdLow, thresholdHigh, inRange);
     }
 
@@ -93,7 +93,7 @@ public class ThresholdRangeCondition extends Condition {
             String dataId, Operator operatorLow, Operator operatorHigh,
             Double thresholdLow, Double thresholdHigh, boolean inRange) {
 
-        this(triggerId, Mode.FIRE, conditionSetSize, conditionSetIndex, dataId, operatorLow, operatorHigh,
+        this(triggerId, Mode.FIRING, conditionSetSize, conditionSetIndex, dataId, operatorLow, operatorHigh,
                 thresholdLow, thresholdHigh, inRange);
     }
 

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -80,7 +80,7 @@ public class Dampening {
     private transient List<Set<ConditionEval>> satisfyingEvals = new ArrayList<Set<ConditionEval>>();
 
     public Dampening() {
-        this("Default", Mode.FIRE, Type.STRICT, 1, 1, 0);
+        this("Default", Mode.FIRING, Type.STRICT, 1, 1, 0);
     }
 
     /**

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -39,9 +39,6 @@ public class Trigger extends TriggerTemplate {
     @JsonInclude
     private boolean enabled;
 
-    //@JsonInclude
-    //private boolean safetyEnabled;
-
     @JsonIgnore
     private Mode mode;
 
@@ -101,25 +98,6 @@ public class Trigger extends TriggerTemplate {
         this.mode = mode;
         setMatch(this.mode == Mode.FIRING ? getFiringMatch() : getAutoResolveMatch());
     }
-
-    //    /**
-    //     * This tells you whether the Trigger defines safety conditions and whether safety mode is enabled.
-    //     * This does NOT return the current <code>mode</code> of the Trigger.
-    //     * @return true if this Trigger supports safety mode and is it enabled.
-    //     * @see {@link #getMode()} to see the current <code>mode</code>.
-    //     */
-    //    public boolean isSafetyEnabled() {
-    //        return safetyEnabled;
-    //    }
-    //
-    //    /**
-    //     * Set true if safety conditions and dampening are fully defined and should be activated on a Trigger firing.
-    //     * Set false otherwise.
-    //     * @param safetyEnabled
-    //     */
-    //    public void setSafetyEnabled(boolean safetyEnabled) {
-    //        this.safetyEnabled = safetyEnabled;
-    //    }
 
     @JsonIgnore
     public Match getMatch() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class Trigger extends TriggerTemplate {
 
     public enum Mode {
-        FIRE, SAFETY
+        FIRING, AUTORESOLVE
     };
 
     @JsonInclude
@@ -39,8 +39,8 @@ public class Trigger extends TriggerTemplate {
     @JsonInclude
     private boolean enabled;
 
-    @JsonInclude
-    private boolean safetyEnabled;
+    //@JsonInclude
+    //private boolean safetyEnabled;
 
     @JsonIgnore
     private Mode mode;
@@ -72,8 +72,7 @@ public class Trigger extends TriggerTemplate {
         this.id = id;
 
         this.enabled = false;
-        this.safetyEnabled = false;
-        this.mode = Mode.FIRE;
+        this.mode = Mode.FIRING;
         this.match = getFiringMatch();
     }
 
@@ -100,27 +99,27 @@ public class Trigger extends TriggerTemplate {
 
     public void setMode(Mode mode) {
         this.mode = mode;
-        setMatch(this.mode == Mode.FIRE ? getFiringMatch() : getSafetyMatch());
+        setMatch(this.mode == Mode.FIRING ? getFiringMatch() : getAutoResolveMatch());
     }
 
-    /**
-     * This tells you whether the Trigger defines safety conditions and whether safety mode is enabled.
-     * This does NOT return the current <code>mode</code> of the Trigger.
-     * @return true if this Trigger supports safety mode and is it enabled.
-     * @see {@link #getMode()} to see the current <code>mode</code>.
-     */
-    public boolean isSafetyEnabled() {
-        return safetyEnabled;
-    }
-
-    /**
-     * Set true if safety conditions and dampening are fully defined and should be activated on a Trigger firing. Set
-     * false otherwise.
-     * @param safetyEnabled
-     */
-    public void setSafetyEnabled(boolean safetyEnabled) {
-        this.safetyEnabled = safetyEnabled;
-    }
+    //    /**
+    //     * This tells you whether the Trigger defines safety conditions and whether safety mode is enabled.
+    //     * This does NOT return the current <code>mode</code> of the Trigger.
+    //     * @return true if this Trigger supports safety mode and is it enabled.
+    //     * @see {@link #getMode()} to see the current <code>mode</code>.
+    //     */
+    //    public boolean isSafetyEnabled() {
+    //        return safetyEnabled;
+    //    }
+    //
+    //    /**
+    //     * Set true if safety conditions and dampening are fully defined and should be activated on a Trigger firing.
+    //     * Set false otherwise.
+    //     * @param safetyEnabled
+    //     */
+    //    public void setSafetyEnabled(boolean safetyEnabled) {
+    //        this.safetyEnabled = safetyEnabled;
+    //    }
 
     @JsonIgnore
     public Match getMatch() {
@@ -158,14 +157,8 @@ public class Trigger extends TriggerTemplate {
 
     @Override
     public String toString() {
-        return "Trigger [id=" + id + ", " +
-                "name=" + getName() + ", " +
-                "description=" + getDescription() + ", " +
-                "firingMatch=" + getFiringMatch() + ", " +
-                "safetyMatch=" + getSafetyMatch() + ", " +
-                "enabled=" + enabled + ", " +
-                "mode=" + mode + ", " +
-                "match=" + getMatch() + "]";
+        return "Trigger [id=" + id + ", enabled=" + enabled + ", mode=" + mode + ", getName()=" + getName()
+                + ", isAutoDisable()=" + isAutoDisable() + ", isAutoResolve()=" + isAutoResolve() + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerTemplate.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerTemplate.java
@@ -40,6 +40,15 @@ public abstract class TriggerTemplate {
     @JsonInclude
     private String description;
 
+    @JsonInclude
+    private boolean autoDisable;
+
+    @JsonInclude
+    private boolean autoResolve;
+
+    @JsonInclude
+    private boolean autoResolveAlerts;
+
     /** A group of actions's ids. */
     @JsonInclude(Include.NON_EMPTY)
     private Set<String> actions;
@@ -48,13 +57,16 @@ public abstract class TriggerTemplate {
     private Match firingMatch;
 
     @JsonInclude
-    private Match safetyMatch;
+    private Match autoResolveMatch;
 
     public TriggerTemplate(String name) {
         this.name = name;
 
+        this.autoDisable = false;
+        this.autoResolve = false;
+        this.autoResolveAlerts = true;
         this.firingMatch = Match.ALL;
-        this.safetyMatch = Match.ALL;
+        this.autoResolveMatch = Match.ALL;
         this.actions = new HashSet();
     }
 
@@ -77,6 +89,30 @@ public abstract class TriggerTemplate {
         this.description = description;
     }
 
+    public boolean isAutoDisable() {
+        return autoDisable;
+    }
+
+    public void setAutoDisable(boolean autoDisable) {
+        this.autoDisable = autoDisable;
+    }
+
+    public boolean isAutoResolve() {
+        return autoResolve;
+    }
+
+    public void setAutoResolve(boolean autoResolve) {
+        this.autoResolve = autoResolve;
+    }
+
+    public boolean isAutoResolveAlerts() {
+        return autoResolveAlerts;
+    }
+
+    public void setAutoResolveAlerts(boolean autoResolveAlerts) {
+        this.autoResolveAlerts = autoResolveAlerts;
+    }
+
     public Match getFiringMatch() {
         return firingMatch;
     }
@@ -85,12 +121,12 @@ public abstract class TriggerTemplate {
         this.firingMatch = firingMatch;
     }
 
-    public Match getSafetyMatch() {
-        return safetyMatch;
+    public Match getAutoResolveMatch() {
+        return autoResolveMatch;
     }
 
-    public void setSafetyMatch(Match safetyMatch) {
-        this.safetyMatch = safetyMatch;
+    public void setAutoResolveMatch(Match autoResolveMatch) {
+        this.autoResolveMatch = autoResolveMatch;
     }
 
     public Set<String> getActions() {
@@ -127,7 +163,7 @@ public abstract class TriggerTemplate {
         return "TriggerTemplate [name=" + name + ", " +
                 "description=" + description + ", " +
                 "firingMatch=" + firingMatch + ", " +
-                "safetyMatch=" + safetyMatch + "]";
+                "safetyMatch=" + autoResolveMatch + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -18,6 +18,7 @@ package org.hawkular.alerts.api.services;
 
 import java.util.Collection;
 
+import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.trigger.Tag;
 
 /**
@@ -29,6 +30,10 @@ import org.hawkular.alerts.api.model.trigger.Tag;
 public class AlertsCriteria {
     Long startTime = null;
     Long endTime = null;
+    String alertId = null;
+    Collection<String> alertIds = null;
+    Alert.Status status = null;
+    Collection<Alert.Status> statusSet = null;
     String triggerId = null;
     Collection<String> triggerIds = null;
     Tag tag = null;
@@ -58,6 +63,38 @@ public class AlertsCriteria {
      */
     public void setEndTime(Long endTime) {
         this.endTime = endTime;
+    }
+
+    public String getAlertId() {
+        return alertId;
+    }
+
+    public void setAlertId(String alertId) {
+        this.alertId = alertId;
+    }
+
+    public Collection<String> getAlertIds() {
+        return alertIds;
+    }
+
+    public void setAlertIds(Collection<String> alertIds) {
+        this.alertIds = alertIds;
+    }
+
+    public Alert.Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Alert.Status status) {
+        this.status = status;
+    }
+
+    public Collection<Alert.Status> getStatusSet() {
+        return statusSet;
+    }
+
+    public void setStatusSet(Collection<Alert.Status> statusSet) {
+        this.statusSet = statusSet;
     }
 
     public String getTriggerId() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
@@ -18,8 +18,10 @@ package org.hawkular.alerts.api.services;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
 
 /**
@@ -63,4 +65,39 @@ public interface AlertsService {
      * @return
      */
     void addAlerts(Collection<Alert> alerts) throws Exception;
+
+    /**
+     * The alerts must already have been added. Set the alerts to ACKNOWLEDGED status. The ackTime will be set to the
+     * system time.
+     * @param alerts Alerts to be acknowledged.
+     * @param ackBy Optional. Typically the user acknowledging the alerts.
+     * @param ackNotes Optional notes about the acknowledgement.
+     * @return
+     */
+    void ackAlerts(Collection<String> alertIds, String ackBy, String ackNotes) throws Exception;
+
+    /**
+     * The alerts must already have been added. Set the alerts to RESOLVED status. The resolvedTime will be set to the
+     * system time.
+     * @param alerts Alerts to be acknowledged.
+     * @param resolvedBy Optional. Typically the user resolving the alerts.
+     * @param resolvedNotes Optional notes about the resolution.
+     * @param resolvedEvalSets Optional. Typically the evalSets leading to an auto-resolved alert.
+     * @return
+     */
+    void resolveAlerts(Collection<String> alertIds, String resolvedBy, String resolvedNotes,
+            List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
+
+    /**
+     * Set unresolved alerts for the provided trigger to RESOLVED status. The resolvedTime will be set to the
+     * system time.
+     * @param triggerId
+     * @param resolvedBy Optional. Typically the user resolving the alerts.
+     * @param resolvedNotes Optional notes about the resolution.
+     * @param resolvedEvalSets Optional. Typically the evalSets leading to an auto-resolved alert.
+     * @return
+     */
+    void resolveAlertsForTrigger(String triggerId, String resolvedBy, String resolvedNotes,
+            List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
+
 }

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -16,12 +16,12 @@
  */
 package org.hawkular.alerts.api;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.hawkular.alerts.api.model.action.Action;
 import org.hawkular.alerts.api.model.condition.Alert;
@@ -48,6 +48,8 @@ import org.hawkular.alerts.api.model.trigger.TriggerTemplate.Match;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Validation of JSON serialization/deserialization
  *
@@ -67,18 +69,18 @@ public class JsonTest {
         String str = "{\"actionId\":\"test\",\"message\":\"test-msg\"}";
         Action action = objectMapper.readValue(str, Action.class);
 
-        assert action.getActionId().equals("test");
-        assert action.getMessage().equals("test-msg");
+        assertTrue(action.getActionId().equals("test"));
+        assertTrue(action.getMessage().equals("test-msg"));
 
         String output = objectMapper.writeValueAsString(action);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         str = "{\"actionId\":\"test\"}";
         action = objectMapper.readValue(str, Action.class);
         output = objectMapper.writeValueAsString(action);
 
-        assert !output.contains("message");
+        assertTrue(!output.contains("message"));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class JsonTest {
 
         String output = objectMapper.writeValueAsString(alert);
 
-        assert !output.contains("evalSets");
+        assertTrue(!output.contains("evalSets"));
 
         AvailabilityCondition aCond = new AvailabilityCondition("trigger-test",
                                                                 "Default",
@@ -113,27 +115,27 @@ public class JsonTest {
 
         output = objectMapper.writeValueAsString(alert);
 
-        assert output.contains("evalSets");
+        assertTrue(output.contains("evalSets"));
     }
 
     @Test
     public void jsonAvailabilityConditionTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"AVAILABILITY\"," +
-                "\"conditionId\":\"test-FIRE-1-1\",\"dataId\":\"Default\",\"operator\":\"UP\"}";
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"AVAILABILITY\"," +
+                "\"conditionId\":\"test-FIRING-1-1\",\"dataId\":\"Default\",\"operator\":\"UP\"}";
         AvailabilityCondition condition = objectMapper.readValue(str, AvailabilityCondition.class);
 
-        assert condition.getTriggerId().equals("test");
-        assert condition.getTriggerMode().equals(Mode.FIRE);
-        assert condition.getDataId().equals("Default");
-        assert condition.getOperator().equals(AvailabilityCondition.Operator.UP);
+        assertTrue(condition.getTriggerId().equals("test"));
+        assertTrue(condition.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(condition.getDataId().equals("Default"));
+        assertTrue(condition.getOperator().equals(AvailabilityCondition.Operator.UP));
 
         String output = objectMapper.writeValueAsString(condition);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         // Check bad mode and operator
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\",\"dataId\":\"Default\",\"operator\":\"UP\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"dataId\":\"Default\",\"operator\":\"UP\"}";
         try {
             condition = objectMapper.readValue(str, AvailabilityCondition.class);
             throw new Exception("It should throw an InvalidFormatException");
@@ -141,7 +143,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\",\"operator\":\"UPX\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"dataId\":\"Default\",\"operator\":\"UPX\"}";
         try {
             condition = objectMapper.readValue(str, AvailabilityCondition.class);
             throw new Exception("It should throw an InvalidFormatException");
@@ -151,64 +153,64 @@ public class JsonTest {
 
         // Check uncompleted json
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"dataId\":\"Default\"}";
         condition = objectMapper.readValue(str, AvailabilityCondition.class);
 
-        assert condition.getOperator() == null;
+        assertTrue(condition.getOperator() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operator");
+        assertTrue(!output.contains("operator"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"operator\":\"UP\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"operator\":\"UP\"}";
         condition = objectMapper.readValue(str, AvailabilityCondition.class);
 
-        assert condition.getDataId() == null;
+        assertTrue(condition.getDataId() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("dataId");
+        assertTrue(!output.contains("dataId"));
     }
 
     @Test
     public void jsonAvailabilityConditionEvalTest() throws Exception {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
-                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"dataId\":\"Default\",\"operator\":\"UP\"}," +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"dataId\":\"Default\",\"operator\":\"UP\"}," +
                 "\"value\":\"UP\"}";
         AvailabilityConditionEval eval = objectMapper.readValue(str, AvailabilityConditionEval.class);
 
-        assert eval.getEvalTimestamp() == 1;
-        assert eval.getDataTimestamp() == 1;
-        assert eval.getCondition().getType().equals(Condition.Type.AVAILABILITY);
-        assert eval.getCondition().getTriggerId().equals("test");
-        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
-        assert eval.getCondition().getDataId().equals("Default");
-        assert eval.getCondition().getOperator().equals(AvailabilityCondition.Operator.UP);
-        assert eval.getValue().equals(AvailabilityType.UP);
+        assertTrue(eval.getEvalTimestamp() == 1);
+        assertTrue(eval.getDataTimestamp() == 1);
+        assertTrue(eval.getCondition().getType().equals(Condition.Type.AVAILABILITY));
+        assertTrue(eval.getCondition().getTriggerId().equals("test"));
+        assertTrue(eval.getCondition().getTriggerMode().equals(Mode.FIRING));
+        assertTrue(eval.getCondition().getDataId().equals("Default"));
+        assertTrue(eval.getCondition().getOperator().equals(AvailabilityCondition.Operator.UP));
+        assertTrue(eval.getValue().equals(AvailabilityType.UP));
     }
 
     @Test
     public void jsonCompareConditionTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"COMPARE\"," +
-                "\"conditionId\":\"test-FIRE-1-1\"," +
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"COMPARE\"," +
+                "\"conditionId\":\"test-FIRING-1-1\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
         CompareCondition condition = objectMapper.readValue(str, CompareCondition.class);
 
-        assert condition.getTriggerId().equals("test");
-        assert condition.getTriggerMode().equals(Mode.FIRE);
-        assert condition.getDataId().equals("Default1");
-        assert condition.getOperator().equals(CompareCondition.Operator.LT);
-        assert condition.getData2Id().equals("Default2");
-        assert condition.getData2Multiplier() == 1.2d;
+        assertTrue(condition.getTriggerId().equals("test"));
+        assertTrue(condition.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(condition.getDataId().equals("Default1"));
+        assertTrue(condition.getOperator().equals(CompareCondition.Operator.LT));
+        assertTrue(condition.getData2Id().equals("Default2"));
+        assertTrue(condition.getData2Multiplier() == 1.2d);
 
         String output = objectMapper.writeValueAsString(condition);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         // Check bad mode and operator
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRINGX\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
         try {
             condition = objectMapper.readValue(str, CompareCondition.class);
@@ -217,7 +219,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LTX\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
         try {
             condition = objectMapper.readValue(str, CompareCondition.class);
@@ -228,91 +230,91 @@ public class JsonTest {
 
         // Check uncompleted json
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
         condition = objectMapper.readValue(str, CompareCondition.class);
 
-        assert condition.getDataId() == null;
+        assertTrue(condition.getDataId() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("dataId");
+        assertTrue(!output.contains("dataId"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}";
         condition = objectMapper.readValue(str, CompareCondition.class);
 
-        assert condition.getOperator() == null;
+        assertTrue(condition.getOperator() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operator");
+        assertTrue(!output.contains("operator"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Multiplier\":1.2}";
 
         condition = objectMapper.readValue(str, CompareCondition.class);
 
-        assert condition.getData2Id() == null;
+        assertTrue(condition.getData2Id() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("data2Id");
+        assertTrue(!output.contains("data2Id"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\"}";
 
         condition = objectMapper.readValue(str, CompareCondition.class);
 
-        assert condition.getData2Multiplier() == null;
+        assertTrue(condition.getData2Multiplier() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("data2Multiplier");
+        assertTrue(!output.contains("data2Multiplier"));
     }
 
     @Test
     public void jsonCompareConditionEvalTest() throws Exception {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
-                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}," +
                 "\"value1\":10.0," +
                 "\"value2\":15.0}";
         CompareConditionEval eval = objectMapper.readValue(str, CompareConditionEval.class);
 
-        assert eval.getEvalTimestamp() == 1;
-        assert eval.getDataTimestamp() == 1;
-        assert eval.getCondition().getType().equals(Condition.Type.COMPARE);
-        assert eval.getCondition().getTriggerId().equals("test");
-        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
-        assert eval.getCondition().getDataId().equals("Default1");
-        assert eval.getCondition().getOperator().equals(CompareCondition.Operator.LT);
-        assert eval.getValue1().equals(10.0);
-        assert eval.getValue2().equals(15.0);
+        assertTrue(eval.getEvalTimestamp() == 1);
+        assertTrue(eval.getDataTimestamp() == 1);
+        assertTrue(eval.getCondition().getType().equals(Condition.Type.COMPARE));
+        assertTrue(eval.getCondition().getTriggerId().equals("test"));
+        assertTrue(eval.getCondition().getTriggerMode().equals(Mode.FIRING));
+        assertTrue(eval.getCondition().getDataId().equals("Default1"));
+        assertTrue(eval.getCondition().getOperator().equals(CompareCondition.Operator.LT));
+        assertTrue(eval.getValue1().equals(10.0));
+        assertTrue(eval.getValue2().equals(15.0));
     }
 
     @Test
     public void jsonStringConditionTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRING\"," +
-                "\"conditionId\":\"test-FIRE-1-1\"," +
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"STRING\"," +
+                "\"conditionId\":\"test-FIRING-1-1\"," +
                 "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
         StringCondition condition = objectMapper.readValue(str, StringCondition.class);
 
-        assert condition.getTriggerId().equals("test");
-        assert condition.getTriggerMode().equals(Mode.FIRE);
-        assert condition.getDataId().equals("Default");
-        assert condition.getOperator().equals(StringCondition.Operator.MATCH);
-        assert condition.getPattern().equals("test-pattern");
-        assert condition.isIgnoreCase() == false;
+        assertTrue(condition.getTriggerId().equals("test"));
+        assertTrue(condition.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(condition.getDataId().equals("Default"));
+        assertTrue(condition.getOperator().equals(StringCondition.Operator.MATCH));
+        assertTrue(condition.getPattern().equals("test-pattern"));
+        assertTrue(condition.isIgnoreCase() == false);
 
         String output = objectMapper.writeValueAsString(condition);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         // Check bad mode and operator
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRINGX\"," +
                 "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
         try {
             condition = objectMapper.readValue(str, StringCondition.class);
@@ -321,7 +323,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"MATCHX\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
         try {
             condition = objectMapper.readValue(str, StringCondition.class);
@@ -332,88 +334,88 @@ public class JsonTest {
 
         // Check uncompleted json
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
         condition = objectMapper.readValue(str, StringCondition.class);
 
-        assert condition.getDataId() == null;
+        assertTrue(condition.getDataId() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("dataId");
+        assertTrue(!output.contains("dataId"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"pattern\":\"test-pattern\",\"ignoreCase\":false}";
         condition = objectMapper.readValue(str, StringCondition.class);
 
-        assert condition.getOperator() == null;
+        assertTrue(condition.getOperator() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operator");
+        assertTrue(!output.contains("operator"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"ignoreCase\":false}";
         condition = objectMapper.readValue(str, StringCondition.class);
 
-        assert condition.getPattern() == null;
+        assertTrue(condition.getPattern() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("pattern");
+        assertTrue(!output.contains("pattern"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"}";
         condition = objectMapper.readValue(str, StringCondition.class);
 
-        assert condition.isIgnoreCase() == false;
+        assertTrue(condition.isIgnoreCase() == false);
 
         output = objectMapper.writeValueAsString(condition);
 
         // ignoreCase will be present as it is a boolean with default value
-        assert output.contains("ignoreCase");
+        assertTrue(output.contains("ignoreCase"));
     }
 
     @Test
     public void jsonStringConditionEvalTest() throws Exception {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
-                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}," +
                 "\"value\":\"test-value\"}";
         StringConditionEval eval = objectMapper.readValue(str, StringConditionEval.class);
 
-        assert eval.getEvalTimestamp() == 1;
-        assert eval.getDataTimestamp() == 1;
-        assert eval.getCondition().getType().equals(Condition.Type.STRING);
-        assert eval.getCondition().getTriggerId().equals("test");
-        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
-        assert eval.getCondition().getDataId().equals("Default");
-        assert eval.getCondition().getOperator().equals(StringCondition.Operator.MATCH);
-        assert eval.getCondition().getPattern().equals("test-pattern");
-        assert eval.getCondition().isIgnoreCase() == false;
-        assert eval.getValue().equals("test-value");
+        assertTrue(eval.getEvalTimestamp() == 1);
+        assertTrue(eval.getDataTimestamp() == 1);
+        assertTrue(eval.getCondition().getType().equals(Condition.Type.STRING));
+        assertTrue(eval.getCondition().getTriggerId().equals("test"));
+        assertTrue(eval.getCondition().getTriggerMode().equals(Mode.FIRING));
+        assertTrue(eval.getCondition().getDataId().equals("Default"));
+        assertTrue(eval.getCondition().getOperator().equals(StringCondition.Operator.MATCH));
+        assertTrue(eval.getCondition().getPattern().equals("test-pattern"));
+        assertTrue(eval.getCondition().isIgnoreCase() == false);
+        assertTrue(eval.getValue().equals("test-value"));
     }
 
     @Test
     public void jsonThresholdConditionTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"THRESHOLD\"," +
-                "\"conditionId\":\"test-FIRE-1-1\"," +
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"THRESHOLD\"," +
+                "\"conditionId\":\"test-FIRING-1-1\"," +
                 "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}";
         ThresholdCondition condition = objectMapper.readValue(str, ThresholdCondition.class);
 
-        assert condition.getTriggerId().equals("test");
-        assert condition.getTriggerMode().equals(Mode.FIRE);
-        assert condition.getDataId().equals("Default");
-        assert condition.getOperator().equals(ThresholdCondition.Operator.LT);
-        assert condition.getThreshold() == 10.5d;
+        assertTrue(condition.getTriggerId().equals("test"));
+        assertTrue(condition.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(condition.getDataId().equals("Default"));
+        assertTrue(condition.getOperator().equals(ThresholdCondition.Operator.LT));
+        assertTrue(condition.getThreshold() == 10.5d);
 
         String output = objectMapper.writeValueAsString(condition);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         // Check bad mode and operator
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRINGX\"," +
                 "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}";
         try {
             condition = objectMapper.readValue(str, ThresholdCondition.class);
@@ -422,7 +424,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"LTX\",\"threshold\":10.5}";
         try {
             condition = objectMapper.readValue(str, ThresholdCondition.class);
@@ -433,79 +435,79 @@ public class JsonTest {
 
         // Check uncompleted json
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"operator\":\"LT\",\"threshold\":10.5}";
         condition = objectMapper.readValue(str, ThresholdCondition.class);
 
-        assert condition.getDataId() == null;
+        assertTrue(condition.getDataId() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("dataId");
+        assertTrue(!output.contains("dataId"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"threshold\":10.5}";
         condition = objectMapper.readValue(str, ThresholdCondition.class);
 
-        assert condition.getOperator() == null;
+        assertTrue(condition.getOperator() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operator");
+        assertTrue(!output.contains("operator"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"}";
         condition = objectMapper.readValue(str, ThresholdCondition.class);
 
-        assert condition.getThreshold() == null;
+        assertTrue(condition.getThreshold() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("threshold");
+        assertTrue(!output.contains("threshold"));
     }
 
     @Test
     public void jsonThresholdConditionEvalTest() throws Exception {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
-                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}," +
                 "\"value\":1.0}";
         ThresholdConditionEval eval = objectMapper.readValue(str, ThresholdConditionEval.class);
 
-        assert eval.getEvalTimestamp() == 1;
-        assert eval.getDataTimestamp() == 1;
-        assert eval.getCondition().getType().equals(Condition.Type.THRESHOLD);
-        assert eval.getCondition().getTriggerId().equals("test");
-        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
-        assert eval.getCondition().getDataId().equals("Default");
-        assert eval.getCondition().getOperator().equals(ThresholdCondition.Operator.LT);
-        assert eval.getCondition().getThreshold() == 10.5;
-        assert eval.getValue() == 1.0;
+        assertTrue(eval.getEvalTimestamp() == 1);
+        assertTrue(eval.getDataTimestamp() == 1);
+        assertTrue(eval.getCondition().getType().equals(Condition.Type.THRESHOLD));
+        assertTrue(eval.getCondition().getTriggerId().equals("test"));
+        assertTrue(eval.getCondition().getTriggerMode().equals(Mode.FIRING));
+        assertTrue(eval.getCondition().getDataId().equals("Default"));
+        assertTrue(eval.getCondition().getOperator().equals(ThresholdCondition.Operator.LT));
+        assertTrue(eval.getCondition().getThreshold() == 10.5);
+        assertTrue(eval.getValue() == 1.0);
     }
 
     @Test
     public void jsonThresholdRangeConditionTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"RANGE\"," +
-                "\"conditionId\":\"test-FIRE-1-1\",\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\"," +
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"RANGE\"," +
+                "\"conditionId\":\"test-FIRING-1-1\",\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\"," +
                 "\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         ThresholdRangeCondition condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getTriggerId().equals("test");
-        assert condition.getTriggerMode().equals(Mode.FIRE);
-        assert condition.getDataId().equals("Default");
-        assert condition.getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
-        assert condition.getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
-        assert condition.getThresholdLow() == 10.5d;
-        assert condition.getThresholdHigh() == 20.5d;
+        assertTrue(condition.getTriggerId().equals("test"));
+        assertTrue(condition.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(condition.getDataId().equals("Default"));
+        assertTrue(condition.getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE));
+        assertTrue(condition.getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE));
+        assertTrue(condition.getThresholdLow() == 10.5d);
+        assertTrue(condition.getThresholdHigh() == 20.5d);
 
         String output = objectMapper.writeValueAsString(condition);
 
-        assert str.equals(output);
+        assertTrue(str.equals(output));
 
         // Check bad mode and operator
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRINGX\"," +
                 "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         try {
@@ -515,7 +517,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVEX\",\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         try {
@@ -525,7 +527,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVEX\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         try {
@@ -537,119 +539,119 @@ public class JsonTest {
 
         // Check uncompleted json
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getDataId() == null;
+        assertTrue(condition.getDataId() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("dataId");
+        assertTrue(!output.contains("dataId"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getOperatorLow() == null;
+        assertTrue(condition.getOperatorLow() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operatorLow");
+        assertTrue(!output.contains("operatorLow"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getOperatorHigh() == null;
+        assertTrue(condition.getOperatorHigh() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("operatorHigh");
+        assertTrue(!output.contains("operatorHigh"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"thresholdHigh\":20.5,\"inRange\":true}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getThresholdLow() == null;
+        assertTrue(condition.getThresholdLow() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("thresholdLow");
+        assertTrue(!output.contains("thresholdLow"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"inRange\":true}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.getThresholdHigh() == null;
+        assertTrue(condition.getThresholdHigh() == null);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert !output.contains("thresholdHigh");
+        assertTrue(!output.contains("thresholdHigh"));
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"}";
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"}";
         condition = objectMapper.readValue(str, ThresholdRangeCondition.class);
 
-        assert condition.isInRange() == false;
+        assertTrue(condition.isInRange() == false);
 
         output = objectMapper.writeValueAsString(condition);
 
-        assert output.contains("inRange");
+        assertTrue(output.contains("inRange"));
     }
 
     @Test
     public void jsonThresholdRangeConditionEvalTest() throws Exception {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
-                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\"," +
+                "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}," +
                 "\"value\":1.0}";
         ThresholdRangeConditionEval eval = objectMapper.readValue(str, ThresholdRangeConditionEval.class);
 
-        assert eval.getEvalTimestamp() == 1;
-        assert eval.getDataTimestamp() == 1;
-        assert eval.getCondition().getType().equals(Condition.Type.RANGE);
-        assert eval.getCondition().getTriggerId().equals("test");
-        assert eval.getCondition().getTriggerMode().equals(Mode.FIRE);
-        assert eval.getCondition().getDataId().equals("Default");
-        assert eval.getCondition().getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
-        assert eval.getCondition().getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE);
-        assert eval.getCondition().getThresholdLow() == 10.5;
-        assert eval.getCondition().getThresholdHigh() == 20.5;
-        assert eval.getValue() == 1.0;
+        assertTrue(eval.getEvalTimestamp() == 1);
+        assertTrue(eval.getDataTimestamp() == 1);
+        assertTrue(eval.getCondition().getType().equals(Condition.Type.RANGE));
+        assertTrue(eval.getCondition().getTriggerId().equals("test"));
+        assertTrue(eval.getCondition().getTriggerMode().equals(Mode.FIRING));
+        assertTrue(eval.getCondition().getDataId().equals("Default"));
+        assertTrue(eval.getCondition().getOperatorLow().equals(ThresholdRangeCondition.Operator.INCLUSIVE));
+        assertTrue(eval.getCondition().getOperatorHigh().equals(ThresholdRangeCondition.Operator.INCLUSIVE));
+        assertTrue(eval.getCondition().getThresholdLow() == 10.5);
+        assertTrue(eval.getCondition().getThresholdHigh() == 20.5);
+        assertTrue(eval.getValue() == 1.0);
     }
 
     @Test
     public void jsonDampeningTest() throws Exception {
-        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRICT\"," +
+        String str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"STRICT\"," +
                 "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
         Dampening damp = objectMapper.readValue(str, Dampening.class);
 
-        assert damp.getDampeningId().equals("test-FIRE");
-        assert damp.getTriggerId().equals("test");
-        assert damp.getTriggerMode().equals(Mode.FIRE);
-        assert damp.getType().equals(Dampening.Type.STRICT);
-        assert damp.getEvalTrueSetting() == 1;
-        assert damp.getEvalTotalSetting() == 1;
-        assert damp.getEvalTimeSetting() == 1;
+        assertTrue(damp.getDampeningId().equals("test-FIRING"));
+        assertTrue(damp.getTriggerId().equals("test"));
+        assertTrue(damp.getTriggerMode().equals(Mode.FIRING));
+        assertTrue(damp.getType().equals(Dampening.Type.STRICT));
+        assertTrue(damp.getEvalTrueSetting() == 1);
+        assertTrue(damp.getEvalTotalSetting() == 1);
+        assertTrue(damp.getEvalTimeSetting() == 1);
 
         String output = objectMapper.writeValueAsString(damp);
 
         // Checking ignored fields are not there
 
-        assert output.contains("dampeningId");
-        assert !output.contains("numTrueEvals");
-        assert !output.contains("numEvals");
-        assert !output.contains("trueEvalsStartTime");
-        assert !output.contains("satisfied");
-        assert !output.contains("satisfyingEvals");
+        assertTrue(output.contains("dampeningId"));
+        assertTrue(!output.contains("numTrueEvals"));
+        assertTrue(!output.contains("numEvals"));
+        assertTrue(!output.contains("trueEvalsStartTime"));
+        assertTrue(!output.contains("satisfied"));
+        assertTrue(!output.contains("satisfyingEvals"));
 
         // Checking bad fields
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIREX\",\"type\":\"STRICT\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRINGX\",\"type\":\"STRICT\"," +
                 "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
         try {
             damp = objectMapper.readValue(str, Dampening.class);
@@ -658,7 +660,7 @@ public class JsonTest {
             // Expected
         }
 
-        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRE\",\"type\":\"STRICTX\"," +
+        str = "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"type\":\"STRICTX\"," +
                 "\"evalTrueSetting\":1,\"evalTotalSetting\":1,\"evalTimeSetting\":1}";
         try {
             damp = objectMapper.readValue(str, Dampening.class);
@@ -673,38 +675,38 @@ public class JsonTest {
         String str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"UNAVAILABLE\"}";
         Availability aData = objectMapper.readValue(str, Availability.class);
 
-        assert aData.getId().equals("test");
-        assert aData.getTimestamp() == 1;
-        assert aData.getValue().equals(AvailabilityType.UNAVAILABLE);
+        assertTrue(aData.getId().equals("test"));
+        assertTrue(aData.getTimestamp() == 1);
+        assertTrue(aData.getValue().equals(AvailabilityType.UNAVAILABLE));
 
         String output = objectMapper.writeValueAsString(aData);
 
-        assert output.contains("type");
-        assert output.contains("AVAILABILITY");
+        assertTrue(output.contains("type"));
+        assertTrue(output.contains("AVAILABILITY"));
 
         str = "{\"id\":\"test\",\"timestamp\":1,\"value\":10.45}";
         NumericData nData = objectMapper.readValue(str, NumericData.class);
 
-        assert nData.getId().equals("test");
-        assert nData.getTimestamp() == 1;
-        assert nData.getValue() == 10.45;
+        assertTrue(nData.getId().equals("test"));
+        assertTrue(nData.getTimestamp() == 1);
+        assertTrue(nData.getValue() == 10.45);
 
         output = objectMapper.writeValueAsString(nData);
 
-        assert output.contains("type");
-        assert output.contains("NUMERIC");
+        assertTrue(output.contains("type"));
+        assertTrue(output.contains("NUMERIC"));
 
         str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"test-value\"}";
         StringData sData = objectMapper.readValue(str, StringData.class);
 
-        assert sData.getId().equals("test");
-        assert sData.getTimestamp() == 1;
-        assert sData.getValue().equals("test-value");
+        assertTrue(sData.getId().equals("test"));
+        assertTrue(sData.getTimestamp() == 1);
+        assertTrue(sData.getValue().equals("test-value"));
 
         output = objectMapper.writeValueAsString(sData);
 
-        assert output.contains("type");
-        assert output.contains("STRING");
+        assertTrue(output.contains("type"));
+        assertTrue(output.contains("STRING"));
     }
 
     @Test
@@ -712,25 +714,29 @@ public class JsonTest {
         String str = "{\"name\":\"test-name\",\"description\":\"test-description\"," +
                 "\"actions\":[\"uno\",\"dos\",\"tres\"]," +
                 "\"firingMatch\":\"ALL\"," +
-                "\"safetyMatch\":\"ALL\"," +
+                "\"autoResolveMatch\":\"ALL\"," +
                 "\"id\":\"test\"," +
                 "\"enabled\":true," +
-                "\"safetyEnabled\":true}";
+                "\"autoDisable\":true," +
+                "\"autoResolve\":true," +
+                "\"autoResolveAlerts\":true}";
         Trigger trigger = objectMapper.readValue(str, Trigger.class);
 
-        assert trigger.getName().equals("test-name");
-        assert trigger.getDescription().equals("test-description");
-        assert trigger.getActions() != null && trigger.getActions().size() == 3;
-        assert trigger.getFiringMatch().equals(Match.ALL);
-        assert trigger.getSafetyMatch().equals(Match.ALL);
-        assert trigger.getId().equals("test");
-        assert trigger.isEnabled() == true;
-        assert trigger.isSafetyEnabled() == true;
+        assertTrue(trigger.getName().equals("test-name"));
+        assertTrue(trigger.getDescription().equals("test-description"));
+        assertTrue(trigger.getActions() != null && trigger.getActions().size() == 3);
+        assertTrue(trigger.getFiringMatch().equals(Match.ALL));
+        assertTrue(trigger.getAutoResolveMatch().equals(Match.ALL));
+        assertTrue(trigger.getId().equals("test"));
+        assertTrue(trigger.isEnabled() == true);
+        assertTrue(trigger.isAutoDisable() == true);
+        assertTrue(trigger.isAutoResolve() == true);
+        assertTrue(trigger.isAutoResolveAlerts() == true);
 
         String output = objectMapper.writeValueAsString(trigger);
 
-        assert !output.contains("mode");
-        assert !output.contains("match");
+        assertTrue(!output.contains("mode"));
+        assertTrue(!output.contains("match"));
     }
 
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DbDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DbDefinitionsServiceImpl.java
@@ -179,10 +179,11 @@ public class DbDefinitionsServiceImpl implements DefinitionsService {
                     "  PRIMARY KEY(triggerId, category, name) )");
 
             s.execute("CREATE TABLE IF NOT EXISTS HWK_ALERTS_ALERTS " +
-                    "( triggerId VARCHAR2(250) NOT NULL, " +
+                    "( alertId VARCHAR2(300) PRIMARY KEY, " +
+                    "  triggerId VARCHAR2(250) NOT NULL, " +
                     "  ctime long NOT NULL," +
-                    "  payload CLOB," +
-                    "  PRIMARY KEY(triggerId, ctime) )");
+                    "  status VARCHAR2(20) NOT NULL," +
+                    "  payload CLOB )");
 
             s.close();
 
@@ -258,22 +259,26 @@ public class DbDefinitionsServiceImpl implements DefinitionsService {
                         continue;
                     }
                     String[] fields = line.split(",");
-                    if (fields.length == 8) {
+                    if (fields.length == 10) {
                         String triggerId = fields[0];
                         boolean enabled = new Boolean(fields[1]).booleanValue();
-                        boolean safetyEnabled = new Boolean(fields[2]).booleanValue();
-                        String name = fields[3];
-                        String description = fields[4];
-                        TriggerTemplate.Match firingMatch = TriggerTemplate.Match.valueOf(fields[5]);
-                        TriggerTemplate.Match safetyMatch = TriggerTemplate.Match.valueOf(fields[6]);
-                        String[] notifiers = fields[7].split("\\|");
+                        String name = fields[2];
+                        String description = fields[3];
+                        boolean autoDisable = new Boolean(fields[4]).booleanValue();
+                        boolean autoResolve = new Boolean(fields[5]).booleanValue();
+                        boolean autoResolveAlerts = new Boolean(fields[6]).booleanValue();
+                        TriggerTemplate.Match firingMatch = TriggerTemplate.Match.valueOf(fields[7]);
+                        TriggerTemplate.Match autoResolveMatch = TriggerTemplate.Match.valueOf(fields[8]);
+                        String[] notifiers = fields[9].split("\\|");
 
                         Trigger trigger = new Trigger(triggerId, name);
                         trigger.setEnabled(enabled);
-                        trigger.setSafetyEnabled(safetyEnabled);
+                        trigger.setAutoDisable(autoDisable);
+                        trigger.setAutoResolve(autoResolve);
+                        trigger.setAutoResolveAlerts(autoResolveAlerts);
                         trigger.setDescription(description);
                         trigger.setFiringMatch(firingMatch);
-                        trigger.setSafetyMatch(safetyMatch);
+                        trigger.setAutoResolveMatch(autoResolveMatch);
                         for (String notifier : notifiers) {
                             trigger.addAction(notifier);
                         }
@@ -1095,7 +1100,7 @@ public class DbDefinitionsServiceImpl implements DefinitionsService {
         newTrigger.setName(trigger.getName());
         newTrigger.setDescription(trigger.getDescription());
         newTrigger.setFiringMatch(trigger.getFiringMatch());
-        newTrigger.setSafetyMatch(trigger.getSafetyMatch());
+        newTrigger.setAutoResolveMatch(trigger.getAutoResolveMatch());
         newTrigger.setActions(trigger.getActions());
 
         addTrigger(newTrigger);

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/conditions.data
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/conditions.data
@@ -2,28 +2,28 @@
 # <type> == threshold
 # ..., dataId,operator,value
 #
-trigger-1,FIRE,1,1,threshold,NumericData-01,LT,10.0
-trigger-2,FIRE,2,1,threshold,NumericData-01,GTE,15.0
-trigger-2,FIRE,2,2,threshold,NumericData-02,GTE,15.0
+trigger-1,FIRING,1,1,threshold,NumericData-01,LT,10.0
+trigger-2,FIRING,2,1,threshold,NumericData-01,GTE,15.0
+trigger-2,FIRING,2,2,threshold,NumericData-02,GTE,15.0
 #
 # <type> == range
 # ...,dataId,operatorLow,operatorHigh,thresholdLow,thresholdHigh,inRange
 #
-trigger-3,FIRE,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
+trigger-3,FIRING,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
 #
 # <type> == compare
 # ...,dataId,operator,data2Multiplier,data2Id
 #
-trigger-4,FIRE,1,1,compare,NumericData-01,LT,0.5,NumericData-02
+trigger-4,FIRING,1,1,compare,NumericData-01,LT,0.5,NumericData-02
 #
 # <type> == string
 # ...,dataId,operator,pattern,ignoreCase
 #
-trigger-5,FIRE,1,1,string,StringData-01,STARTS_WITH,Fred,false
+trigger-5,FIRING,1,1,string,StringData-01,STARTS_WITH,Fred,false
 #
 # <type> == availability
 # ...,dataId,operator
 #
-trigger-6,FIRE,1,1,availability,Availability-01,NOT_UP
+trigger-6,FIRING,1,1,availability,Availability-01,NOT_UP
 
 

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/dampening.data
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/dampening.data
@@ -1,2 +1,2 @@
 # <triggerId>,<triggerMode>,<type>,<evalTrueSetting>,<evalTotalSetting>,<evalTimeSetting>
-trigger-1,FIRE,STRICT,2,2,0
+trigger-1,FIRING,STRICT,2,2,0

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<safetyEnabled>,<name>,<description>,<firingMatch>,<safetyMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
-trigger-1,true,false,NumericData-01-low,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-2,true,false,NumericData-01-02-high,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-3,true,false,NumericData-03-range,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-4,true,false,CompareData-01-d1-lthalf-d2,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-5,true,false,StringData-01-starts,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,false,Availability-01-NOT-UP,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+# <triggerId>,<enabled>,<name>,<description>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
 trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -44,11 +44,14 @@ import org.jboss.logging.Logger;
 
 import java.util.Set;
 import java.util.List;
+import java.util.Map;
 
 global Logger log;
 global ActionsService actions;
 global List alerts;
 global Set pendingTimeouts;
+global Map autoResolvedTriggers;
+global Set disabledTriggers;
 
 
 ////// CONDITION MATCHING
@@ -397,8 +400,8 @@ end
 // until the safety mode Dampening is satisfied and the Trigger returns to FIRE mode.
 rule AlertOnSatisfiedDampening
     when
-        $t  : Trigger( mode == Mode.FIRE, $tid : id )
-        $d  : Dampening( triggerMode == Mode.FIRE, triggerId == $tid, satisfied == true )
+        $t  : Trigger( mode == Mode.FIRING, $tid : id )
+        $d  : Dampening( triggerMode == Mode.FIRING, triggerId == $tid, satisfied == true )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debug("AlertOnSatisfiedDampening! " + $d.log());
@@ -418,33 +421,45 @@ rule AlertOnSatisfiedDampening
         $d.reset();
         insert( $d );
 
-        if ($t.isSafetyEnabled()) {
+        if ($t.isAutoResolve()) {
             if (log != null && log.isDebugEnabled()) {
-                log.debug("Setting Trigger to Safety Mode! " + $t);
+                log.debug("Setting Trigger to AutoResolve Mode! " + $t);
             }
             retract( $t );
-            $t.setMode(Mode.SAFETY);
+            $t.setMode(Mode.AUTORESOLVE);
             insert( $t );
 
+        } else if ($t.isAutoDisable()) {
+            if (log != null && log.isDebugEnabled()) {
+                log.debug("Setting Trigger Disabled! " + $t);
+            }
+            retract( $t );
+            $t.setEnabled( false );
+
+            disabledTriggers.add( $t );
+
         } else if (log != null && log.isDebugEnabled()) {
-            log.debug("Trigger remains in Fire mode, Safety Mode not enabled. " + $t);
+            log.debug("Trigger remains in Firing mode, AutoDisable and AutoResolve not set. " + $t);
         }
 end
 
 
 rule SetFiringModeOnSatisfiedDampening
     when
-        $t  : Trigger( mode == Mode.SAFETY, $tid : id )
-        $d  : Dampening( triggerMode == Mode.SAFETY, triggerId == $tid, satisfied == true )
+        $t  : Trigger( mode == Mode.AUTORESOLVE, $tid : id )
+        $d  : Dampening( triggerMode == Mode.AUTORESOLVE, triggerId == $tid, satisfied == true )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debug("SetFiringModeOnSatisfiedDampening! " + $d.log());
         }
+
+        autoResolvedTriggers.put( $t, $d.getSatisfyingEvals() );
+
         retract( $d );
         $d.reset();
         insert( $d );
 
         retract( $t );
-        $t.setMode(Mode.FIRE);
+        $t.setMode(Mode.FIRING);
         insert( $t );
 end

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DbDefinitionsServiceImplTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DbDefinitionsServiceImplTest.java
@@ -25,12 +25,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcDataSource;
 import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.Tag;
@@ -100,7 +102,7 @@ public class DbDefinitionsServiceImplTest {
         assertTrue(nt.toString(), nt.getName().equals(t.getName()));
         assertTrue(nt.toString(), nt.getDescription().equals(t.getDescription()));
         assertTrue(nt.toString(), nt.getFiringMatch().equals(t.getFiringMatch()));
-        assertTrue(nt.toString(), nt.getSafetyMatch().equals(t.getSafetyMatch()));
+        assertTrue(nt.toString(), nt.getAutoResolveMatch().equals(t.getAutoResolveMatch()));
 
         Collection<Condition> ncs = db.getTriggerConditions(nt.getId(), null);
         assertTrue(ncs.toString(), ncs.size() == 1);
@@ -205,6 +207,26 @@ public class DbDefinitionsServiceImplTest {
 
         @Override
         public void addAlerts(Collection<Alert> alerts) throws Exception {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void ackAlerts(Collection<String> alertIds, String ackBy, String ackNotes) throws Exception {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void resolveAlerts(Collection<String> alertIds, String resolvedBy, String resolvedNotes,
+                List<Set<ConditionEval>> resolvedEvalSets) throws Exception {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void resolveAlertsForTrigger(String triggerId, String resolvedBy, String resolvedNotes,
+                List<Set<ConditionEval>> resolvedEvalSets) throws Exception {
             // TODO Auto-generated method stub
 
         }

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/conditions.data
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/conditions.data
@@ -2,26 +2,26 @@
 # <type> == threshold
 # ..., dataId,operator,value
 #
-trigger-1,FIRE,1,1,threshold,NumericData-01,LT,10.0
-trigger-2,FIRE,2,1,threshold,NumericData-01,GTE,15.0
-trigger-2,FIRE,2,2,threshold,NumericData-02,GTE,15.0
+trigger-1,FIRING,1,1,threshold,NumericData-01,LT,10.0
+trigger-2,FIRING,2,1,threshold,NumericData-01,GTE,15.0
+trigger-2,FIRING,2,2,threshold,NumericData-02,GTE,15.0
 #
 # <type> == range
 # ...,dataId,operatorLow,operatorHigh,thresholdLow,thresholdHigh,inRange
 #
-trigger-3,FIRE,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
+trigger-3,FIRING,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
 #
 # <type> == compare
 # ...,dataId,operator,data2Multiplier,data2Id
 #
-trigger-4,FIRE,1,1,compare,NumericData-01,LT,0.5,NumericData-02
+trigger-4,FIRING,1,1,compare,NumericData-01,LT,0.5,NumericData-02
 #
 # <type> == string
 # ...,dataId,operator,pattern,ignoreCase
 #
-trigger-5,FIRE,1,1,string,StringData-01,STARTS_WITH,Fred,false
+trigger-5,FIRING,1,1,string,StringData-01,STARTS_WITH,Fred,false
 #
 # <type> == availability
 # ...,dataId,operator
 #
-trigger-6,FIRE,1,1,availability,Availability-01,NOT_UP
+trigger-6,FIRING,1,1,availability,Availability-01,NOT_UP

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/dampening.data
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/dampening.data
@@ -1,2 +1,2 @@
 # <triggerId>,<triggerMode>,<type>,<evalTrueSetting>,<evalTotalSetting>,<evalTimeSetting>
-trigger-1,FIRE,STRICT,2,2,0
+trigger-1,FIRING,STRICT,2,2,0

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<safetyEnabled>,<name>,<description>,<firingMatch>,<safetyMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
-trigger-1,true,false,NumericData-01-low,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-2,true,false,NumericData-01-02-high,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-3,true,false,NumericData-03-range,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-4,true,false,CompareData-01-d1-lthalf-d2,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-5,true,false,StringData-01-starts,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,false,Availability-01-NOT-UP,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+# <triggerId>,<enabled>,<name>,<description>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
 trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -106,7 +106,7 @@
 
   <profiles>
     <profile>
-      <id>rest</id>
+      <id>rest-only</id>
       <properties>
         <!-- IMPORTANT: The port must be the port offset + 8080. -->
         <hawkular.host>127.0.0.1</hawkular.host>
@@ -169,8 +169,12 @@
       </build>
     </profile>
     <profile>
-      <id>wildfly</id>
+      <id>rest</id>
       <properties>
+        <hawkular.host>127.0.0.1</hawkular.host>
+        <hawkular.port>9977</hawkular.port>
+        <hawkular.path>/hawkular/alerts/</hawkular.path>
+        <hawkular.base-uri>http://${hawkular.host}:${hawkular.port}${hawkular.path}</hawkular.base-uri>
         <!-- IMPORTANT: The port must be the port offset + 8080. -->
         <wildfly.port.offset>1897</wildfly.port.offset>
         <!-- IMPORTANT: The management port must be the port offset + 9990. -->
@@ -178,6 +182,53 @@
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-data-dir</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/wildfly-data</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/wildfly-data</directory>
+                      <includes>
+                        <include>**/*</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*ITest*</include>
+              </includes>
+              <systemPropertyVariables>
+                <hawkular.host>${hawkular.host}</hawkular.host>
+                <hawkular.port>${hawkular.port}</hawkular.port>
+                <hawkular.base-uri>${hawkular.base-uri}</hawkular.base-uri>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -113,7 +113,6 @@
         <hawkular.port>9977</hawkular.port>
         <hawkular.path>/hawkular/alerts/</hawkular.path>
         <hawkular.base-uri>http://${hawkular.host}:${hawkular.port}${hawkular.path}</hawkular.base-uri>
-        <wildfly.port.offset>1897</wildfly.port.offset>
         <!-- IMPORTANT: The management port must be the port offset + 9990. -->
         <wildfly.management.port>11887</wildfly.management.port>
       </properties>
@@ -166,7 +165,19 @@
               </execution>
             </executions>
           </plugin>
-          <!--
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>wildfly</id>
+      <properties>
+        <!-- IMPORTANT: The port must be the port offset + 8080. -->
+        <wildfly.port.offset>1897</wildfly.port.offset>
+        <!-- IMPORTANT: The management port must be the port offset + 9990. -->
+        <wildfly.management.port>11887</wildfly.management.port>
+      </properties>
+      <build>
+        <plugins>
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
@@ -220,7 +231,6 @@
               </execution>
             </executions>
           </plugin>
-           -->
         </plugins>
       </build>
     </profile>

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -42,6 +42,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-bus</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.bus</groupId>
+      <artifactId>hawkular-bus-rest-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hawkular-alerts-ear</artifactId>
       <version>${project.version}</version>
@@ -95,7 +109,10 @@
       <id>rest</id>
       <properties>
         <!-- IMPORTANT: The port must be the port offset + 8080. -->
-        <hawkular.base-uri>http://127.0.0.1:9977/hawkular/alerts/</hawkular.base-uri>
+        <hawkular.host>127.0.0.1</hawkular.host>
+        <hawkular.port>9977</hawkular.port>
+        <hawkular.path>/hawkular/alerts/</hawkular.path>
+        <hawkular.base-uri>http://${hawkular.host}:${hawkular.port}${hawkular.path}</hawkular.base-uri>
         <wildfly.port.offset>1897</wildfly.port.offset>
         <!-- IMPORTANT: The management port must be the port offset + 9990. -->
         <wildfly.management.port>11887</wildfly.management.port>
@@ -135,6 +152,8 @@
                 <include>**/*ITest*</include>
               </includes>
               <systemPropertyVariables>
+                <hawkular.host>${hawkular.host}</hawkular.host>
+                <hawkular.port>${hawkular.port}</hawkular.port>
                 <hawkular.base-uri>${hawkular.base-uri}</hawkular.base-uri>
               </systemPropertyVariables>
             </configuration>
@@ -147,6 +166,7 @@
               </execution>
             </executions>
           </plugin>
+          <!--
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
@@ -200,6 +220,7 @@
               </execution>
             </executions>
           </plugin>
+           -->
         </plugins>
       </build>
     </profile>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
@@ -39,6 +39,12 @@ class AlertsITest extends AbstractITestBase {
         def resp = client.get(path: "", query: [endTime:now, startTime:"0",triggerIds:"Trigger-01,Trigger-02"] )
         assert resp.status == 200 || resp.status == 204 : resp.status
 
+        resp = client.get(path: "", query: [endTime:now, startTime:"0",alertIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+        assert resp.status == 200 || resp.status == 204 : resp.status
+
+        resp = client.get(path: "", query: [endTime:now, startTime:"0",statuses:"OPEN,ACKNOWLEDGED,RESOLVED"] )
+        assert resp.status == 200 || resp.status == 204 : resp.status
+
         resp = client.get(path: "", query: [tags:"data-01,data-02"] )
         assert resp.status == 200 || resp.status == 204 : resp.status
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
@@ -42,7 +42,7 @@ class DampeningITest extends AbstractITestBase {
         def resp = client.post(path: "triggers", body: testTrigger)
         assertEquals(200, resp.status)
 
-        Dampening d = new Dampening("test-trigger-6", Mode.FIRE, Type.RELAXED_COUNT, 1, 1, 1);
+        Dampening d = new Dampening("test-trigger-6", Mode.FIRING, Type.RELAXED_COUNT, 1, 1, 1);
 
         resp = client.post(path: "triggers/test-trigger-6/dampenings", body: d)
         assertEquals(200, resp.status)
@@ -63,7 +63,7 @@ class DampeningITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
 
-        resp = client.get(path: "triggers/test-trigger-6/dampenings/mode/FIRE")
+        resp = client.get(path: "triggers/test-trigger-6/dampenings/mode/FIRING")
         assertEquals(200, resp.status)
         assertEquals("test-trigger-6", resp.data.triggerId)
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest
+
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.bus.messages.AlertData
+import org.hawkular.bus.restclient.RestClient
+
+import static org.hawkular.alerts.api.model.condition.AvailabilityCondition.Operator
+import static org.hawkular.alerts.api.model.trigger.Trigger.Mode
+import static org.junit.Assert.assertEquals
+
+import org.junit.Test
+
+/**
+ * Alerts REST tests.
+ *
+ * @author Jay Shaughnessy
+ */
+class LifecycleITest extends AbstractITestBase {
+
+    static host = System.getProperty('hawkular.host') ?: '127.0.0.1'
+    static port = Integer.valueOf(System.getProperty('hawkular.port') ?: "8080")
+
+    @Test
+    void disableTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assert resp.status == 200 || resp.status == 204 : resp.status
+
+        Trigger testTrigger = new Trigger("test-autodisable-trigger", "test-autodisable-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-autodisable-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(true);
+        testTrigger.setAutoResolve(false);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-autodisable-trigger",
+                Mode.FIRING, "test-lifecycle-avail", Operator.NOT_UP);
+
+        resp = client.post(path: "triggers/test-autodisable-trigger/conditions", body: firingCond)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-autodisable-trigger/", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-autodisable-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autodisable-trigger", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(true, resp.data.autoDisable);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+        assertEquals(204, resp.status)
+
+        // Send in avail data to fire the trigger
+        // Note, the groovyx rest c;lient seems incapable of allowing a JSON payload and a TEXT response (which is what
+        // we get back from the activemq rest client used by the bus), so use the bus' java rest client to do this.
+        RestClient busClient = new RestClient(host, port);
+        String json = "{\"data\":[{\"id\":\"test-lifecycle-avail\",\"timestamp\":" + System.currentTimeMillis() +
+                      ",\"value\"=\"DOWN\",\"type\"=\"availability\"}]}";
+        busClient.postTopicMessage("HawkularAlertData", json, null);
+        //assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            System.out.println( "SLEEP!" );
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+            if ( resp.status == 200 ) {
+                break;
+            }
+            assert resp.status == 204 : resp.status
+        }
+        assertEquals(200, resp.status)
+
+        String alertId = resp.data[0].alertId;
+
+        // FETCH trigger and make sure it's disabled
+        resp = client.get(path: "triggers/test-autodisable-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autodisable-trigger", resp.data.name)
+        assertEquals(false, resp.data.enabled)
+
+        // RESOLVE manually the alert
+        resp = client.put(path: "resolve", query: [alertIds:alertId,resolvedBy:"testUser",resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals("testUser", resp.data[0].resolvedBy)
+        assertEquals("testNotes", resp.data[0].resolvedNotes)
+        assert null == resp.data[0].resolvedEvalSets
+    }
+
+    @Test
+    void autoResolveTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assert resp.status == 200 || resp.status == 204 : resp.status
+
+        Trigger testTrigger = new Trigger("test-autoresolve-trigger", "test-autoresolve-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-autoresolve-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(true);
+        testTrigger.setAutoResolveAlerts(true);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-autoresolve-trigger",
+                Mode.FIRING, "test-lifecycle-avail", Operator.NOT_UP);
+
+        resp = client.post(path: "triggers/test-autoresolve-trigger/conditions", body: firingCond)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ADD AutoResolve condition
+        AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-autoresolve-trigger",
+                Mode.AUTORESOLVE, "test-lifecycle-avail", Operator.UP);
+
+        resp = client.post(path: "triggers/test-autoresolve-trigger/conditions", body: autoResolveCond)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-autoresolve-trigger/", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autoresolve-trigger", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(true, resp.data.autoResolve);
+        assertEquals(true, resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+        assertEquals(204, resp.status)
+
+        // Send in DOWN avail data to fire the trigger
+        // Note, the groovyx rest c;lient seems incapable of allowing a JSON payload and a TEXT response (which is what
+        // we get back from the activemq rest client used by the bus), so use the bus' java rest client to do this.
+        RestClient busClient = new RestClient(host, port);
+        String json = "{\"data\":[{\"id\":\"test-lifecycle-avail\",\"timestamp\":" + System.currentTimeMillis() +
+                      ",\"value\"=\"DOWN\",\"type\"=\"availability\"}]}";
+        busClient.postTopicMessage("HawkularAlertData", json, null);
+        //assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            System.out.println( "SLEEP!" );
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                break;
+            }
+            assert resp.status == 204 : resp.status
+        }
+        assertEquals(200, resp.status)
+        assertEquals("OPEN", resp.data[0].status)
+
+        // ACK the alert
+        resp = client.put(path: "ack", query: [alertIds:resp.data[0].alertId,ackBy:"testUser",ackNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals("ACKNOWLEDGED", resp.data[0].status)
+        assertEquals("testUser", resp.data[0].ackBy)
+        assertEquals("testNotes", resp.data[0].ackNotes)
+
+        // FETCH trigger and make sure it's still enabled (note - we can't check the mode as that is runtime
+        // info and not supplied in the returned json)
+        resp = client.get(path: "triggers/test-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autoresolve-trigger", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        //assertEquals(Mode.AUTORESOLVE, resp.data.mode)
+
+        // Send in UP avail data to autoresolve the trigger
+        json = "{\"data\":[{\"id\":\"test-lifecycle-avail\",\"timestamp\":" + System.currentTimeMillis() +
+                      ",\"value\"=\"UP\",\"type\"=\"availability\"}]}";
+        busClient.postTopicMessage("HawkularAlertData", json, null);
+        //assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            System.out.println( "SLEEP!" );
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                break;
+            }
+            assert resp.status == 204 : resp.status
+        }
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals("AUTO", resp.data[0].resolvedBy)
+        assert null != resp.data[0].resolvedEvalSets
+    }
+
+}

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/conditions.data
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/conditions.data
@@ -2,28 +2,28 @@
 # <type> == threshold
 # ..., dataId,operator,value
 #
-trigger-1,FIRE,1,1,threshold,NumericData-01,LT,10.0
-trigger-2,FIRE,2,1,threshold,NumericData-01,GTE,15.0
-trigger-2,FIRE,2,2,threshold,NumericData-02,GTE,15.0
+trigger-1,FIRING,1,1,threshold,NumericData-01,LT,10.0
+trigger-2,FIRING,2,1,threshold,NumericData-01,GTE,15.0
+trigger-2,FIRING,2,2,threshold,NumericData-02,GTE,15.0
 #
 # <type> == range
 # ...,dataId,operatorLow,operatorHigh,thresholdLow,thresholdHigh,inRange
 #
-trigger-3,FIRE,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
+trigger-3,FIRING,1,1,range,NumericData-03,INCLUSIVE,INCLUSIVE,10.0,15.0,true
 #
 # <type> == compare
 # ...,dataId,operator,data2Multiplier,data2Id
 #
-trigger-4,FIRE,1,1,compare,NumericData-01,LT,0.5,NumericData-02
+trigger-4,FIRING,1,1,compare,NumericData-01,LT,0.5,NumericData-02
 #
 # <type> == string
 # ...,dataId,operator,pattern,ignoreCase
 #
-trigger-5,FIRE,1,1,string,StringData-01,STARTS_WITH,Fred,false
+trigger-5,FIRING,1,1,string,StringData-01,STARTS_WITH,Fred,false
 #
 # <type> == availability
 # ...,dataId,operator
 #
-trigger-6,FIRE,1,1,availability,Availability-01,NOT_UP
+trigger-6,FIRING,1,1,availability,Availability-01,NOT_UP
 
 

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/dampening.data
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/dampening.data
@@ -1,2 +1,2 @@
 # <triggerId>,<triggerMode>,<type>,<evalTrueSetting>,<evalTotalSetting>,<evalTimeSetting>
-trigger-1,FIRE,STRICT,2,2,0
+trigger-1,FIRING,STRICT,2,2,0

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<safetyEnabled>,<name>,<description>,<firingMatch>,<safetyMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
-trigger-1,true,false,NumericData-01-low,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-2,true,false,NumericData-01-02-high,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-3,true,false,NumericData-03-range,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-4,true,false,CompareData-01-d1-lthalf-d2,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-5,true,false,StringData-01-starts,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,false,Availability-01-NOT-UP,description,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/triggers.data
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/triggers.data
@@ -1,7 +1,7 @@
-# <triggerId>,<enabled>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<name>,<description>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
+# <triggerId>,<enabled>,<name>,<description>,<autoDisable>,<autoResolve>,<autoResolveAlerts>,<firingMatch>,<autoResolveMatch>,<notifierId1>|<notifierId2>|<notifierId3>|...
 trigger-1,true,NumericData-01-low,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-2,true,NumericData-01-02-high,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-3,true,NumericData-03-range,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-4,true,CompareData-01-d1-lthalf-d2,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
 trigger-5,true,StringData-01-starts,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin
-trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-.io|email-to-admin|agpush-to-admin
+trigger-6,true,Availability-01-NOT-UP,description,false,false,true,ALL,ALL,SNMP-Trap-1|SNMP-Trap-2|sms-to-cio|email-to-admin|agpush-to-admin

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
@@ -22,11 +22,15 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ejb.EJB;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -39,7 +43,6 @@ import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.trigger.Tag;
 import org.hawkular.alerts.api.services.AlertsCriteria;
 import org.hawkular.alerts.api.services.AlertsService;
-import org.hawkular.alerts.rest.log.MsgLogger;
 import org.jboss.logging.Logger;
 
 import com.wordnik.swagger.annotations.Api;
@@ -55,7 +58,7 @@ import com.wordnik.swagger.annotations.ApiParam;
 @Path("/")
 @Api(value = "/", description = "Operations about alerts")
 public class AlertsHandler {
-    private final MsgLogger msgLog = MsgLogger.LOGGER;
+    // private final MsgLogger msgLog = MsgLogger.LOGGER;
     private final Logger log = Logger.getLogger(AlertsHandler.class);
 
     public AlertsHandler() {
@@ -81,10 +84,18 @@ public class AlertsHandler {
             @ApiParam(required = false, value = "filter out alerts created after this time, millisecond since epoch")
             @QueryParam("endTime")
             Long endTime,
+            @ApiParam(required = false, value = "filter out alerts for unspecified alertIds, " +
+                    "comma separated list of alert IDs")
+            @QueryParam("alertIds")
+            String alertIds,
             @ApiParam(required = false, value = "filter out alerts for unspecified triggers, " +
                     "comma separated list of trigger IDs")
             @QueryParam("triggerIds")
             String triggerIds,
+            @ApiParam(required = false, value = "filter out alerts for unspecified lifecycle status, " +
+                    "comma separated list of status values")
+            @QueryParam("statuses")
+            String statuses,
             @ApiParam(required = false, value = "filter out alerts for unspecified tags, comma separated list of tags, "
                     + "each tag of format [category|]name")
             @QueryParam("tags")
@@ -94,8 +105,18 @@ public class AlertsHandler {
             AlertsCriteria criteria = new AlertsCriteria();
             criteria.setStartTime(startTime);
             criteria.setEndTime(endTime);
+            if (null != alertIds && !alertIds.trim().isEmpty()) {
+                criteria.setAlertIds(Arrays.asList(alertIds.split(",")));
+            }
             if (null != triggerIds && !triggerIds.trim().isEmpty()) {
                 criteria.setTriggerIds(Arrays.asList(triggerIds.split(",")));
+            }
+            if (null != statuses && !statuses.trim().isEmpty()) {
+                Set<Alert.Status> statusSet = new HashSet<>();
+                for (String s : statuses.split(",")) {
+                    statusSet.add(Alert.Status.valueOf(s));
+                }
+                criteria.setStatusSet(statusSet);
             }
             if (null != tags && !tags.trim().isEmpty()) {
                 String[] tagTokens = tags.split(",");
@@ -129,9 +150,11 @@ public class AlertsHandler {
     @GET
     @Path("/reload")
     @ApiOperation(value = "Reload all definitions into the alerts service",
-                  notes = "This service is temporal for demos/poc, this functionality will be handled internally" +
-                          "between definitions and alerts services")
-    public void reloadAlerts(@Suspended final AsyncResponse response) {
+            notes = "This service is temporal for demos/poc, this functionality will be handled internally" +
+                    "between definitions and alerts services")
+    public void reloadAlerts(
+            @Suspended
+            final AsyncResponse response) {
         alerts.reload();
         response.resume(Response.status(Response.Status.OK).build());
     }
@@ -139,9 +162,87 @@ public class AlertsHandler {
     @GET
     @Path("/reload/{triggerId}")
     @ApiOperation(value = "Reload a specific trigger into the alerts service")
-    public void reloadTrigger(@Suspended final AsyncResponse response,
-                              @PathParam("triggerId") String triggerId) {
+    public void reloadTrigger(
+            @Suspended
+            final AsyncResponse response,
+            @PathParam("triggerId")
+            String triggerId) {
         alerts.reloadTrigger(triggerId);
         response.resume(Response.status(Response.Status.OK).build());
     }
+
+    @PUT
+    @Path("/ack")
+    @Consumes(APPLICATION_JSON)
+    @ApiOperation(value = "Set one or more alerts Acknowledged")
+    public void ackAlerts(
+            @Suspended
+            final AsyncResponse response,
+            @ApiParam(required = true, value = "comma separated list of alertIds to Ack")
+            @QueryParam("alertIds")
+            String alertIds,
+            @ApiParam(required = false, value = "user acknowledging the alerts")
+            @QueryParam("ackBy")
+            String ackBy,
+            @ApiParam(required = false, value = "additional notes asscoiated with the acknowledgement")
+            @QueryParam("ackNotes")
+            String ackNotes) {
+        try {
+            if (alertIds != null && !alertIds.isEmpty()) {
+                log.debugf("PUT - ackAlerts : %s ", alertIds);
+                alerts.ackAlerts(Arrays.asList(alertIds.split(",")), ackBy, ackNotes);
+                response.resume(Response.status(Response.Status.OK).build());
+            } else {
+                log.debugf("PUT - ackAlerts - alertIds required.");
+                Map<String, String> errors = new HashMap<String, String>();
+                errors.put("errorMsg", "alertIds required");
+                response.resume(Response.status(Response.Status.NOT_FOUND)
+                        .entity(errors).type(APPLICATION_JSON_TYPE).build());
+            }
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            Map<String, String> errors = new HashMap<String, String>();
+            errors.put("errorMsg", "Internal Error: " + e.getMessage());
+            response.resume(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(errors).type(APPLICATION_JSON_TYPE).build());
+        }
+    }
+
+    @PUT
+    @Path("/resolve")
+    @Consumes(APPLICATION_JSON)
+    @ApiOperation(value = "Set one or more alerts Resolved")
+    public void resolveAlerts(
+            @Suspended
+            final AsyncResponse response,
+            @ApiParam(required = true, value = "comma separated list of alertIds to set Resolved")
+            @QueryParam("alertIds")
+            String alertIds,
+            @ApiParam(required = false, value = "user resolving the alerts")
+            @QueryParam("resolvedBy")
+            String resolvedBy,
+            @ApiParam(required = false, value = "additional notes asscoiated with the resolution")
+            @QueryParam("resolvedNotes")
+            String resolvedNotes) {
+        try {
+            if (alertIds != null && !alertIds.isEmpty()) {
+                log.debugf("PUT - resolveAlerts : %s ", alertIds);
+                alerts.resolveAlerts(Arrays.asList(alertIds.split(",")), resolvedBy, resolvedNotes, null);
+                response.resume(Response.status(Response.Status.OK).build());
+            } else {
+                log.debugf("PUT - resolveAlerts - alertIds required.");
+                Map<String, String> errors = new HashMap<String, String>();
+                errors.put("errorMsg", "alertIds required");
+                response.resume(Response.status(Response.Status.NOT_FOUND)
+                        .entity(errors).type(APPLICATION_JSON_TYPE).build());
+            }
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            Map<String, String> errors = new HashMap<String, String>();
+            errors.put("errorMsg", "Internal Error: " + e.getMessage());
+            response.resume(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(errors).type(APPLICATION_JSON_TYPE).build());
+        }
+    }
+
 }


### PR DESCRIPTION
Add Ack and Resolved lifecycle support for alerts.  Also, replace Trigger
"safety" mode with AutoResolve.  And add AutoDisable support as well.
The following commits were squashed into this commit:

WIP Hawkular-35
- finish initial coding for alert lifecycle support
- adding tests, more tests pending
- converted some existing testcode from java asserts to junit asserts
  because java asserts are ignored unless explicitly enabled for the JVM,
  making it dangerous for test code. The java assertions may not get
  processed.

WIP Hawkular-35: Add REST support for new alert fetch criteria

WIP Hawkular-35 - ready for review
- Add rest services for ack and resolve
- Add groovy integration tests for autoDisable, autoResolve, manual
  ack and manual resolve.
- fix bugs
- add more properties to pom for finer control over the base uri segments.
  This allows use of the bus' RestClient to send messages to the bus
  (because the groovyx client can't handle the response given by the activeMQ
  rest.war.

NOTE: Had to currently comment out the start/stop of the WFly server. I was
      getting a trange VersionResolver error from Maven. Also, we need a
      way to disable this with a prop other than skipTests, so that we can
      run the server manually.