### PR TITLE
Moving the mustache template (for the rest docs) to build tools 

### DIFF
--- a/hawkular-alerts-rest/pom.xml
+++ b/hawkular-alerts-rest/pom.xml
@@ -135,6 +135,30 @@
         <!-- Document generation from the Annotations on the REST-API. -->
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.hawkular</groupId>
+                      <artifactId>hawkular-build-tools</artifactId>
+                      <version>${version.org.hawkular.hawkular-build-tools}</version>
+                      <type>jar</type>
+                      <includes>**/*.mustache</includes>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>com.github.kongchen</groupId>
             <artifactId>swagger-maven-plugin</artifactId>
             <configuration>
@@ -143,7 +167,7 @@
                   <locations>org.hawkular.alerts.rest</locations>
                   <apiVersion>1.0</apiVersion>
                   <basePath>http://localhost:8080/hawkular/alerts</basePath>
-                  <outputTemplate>https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/asciidoc.mustache</outputTemplate>
+                  <outputTemplate>${project.build.directory}/dependency/hawkular-documentation/asciidoc.mustache</outputTemplate>
                   <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
                   <swaggerInternalFilter>org.hawkular.alerts.rest.swagger.filter.JaxRsFilter</swaggerInternalFilter>
                   <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>


### PR DESCRIPTION
To enable generation of docs when offline. Currently there is a ling to github, this won't work without connection to internet. I've moved the template file into build tools repo. Parent module depends on it, and everything depends on parent module, so it should be cached in local mvn repo for all hawkular modules.