### PR TITLE
HWKALERTS-44 Add a standalone factory

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine;
+
+import org.hawkular.alerts.api.services.ActionsService;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.engine.impl.CassAlertsServiceImpl;
+import org.hawkular.alerts.engine.impl.CassDefinitionsServiceImpl;
+import org.hawkular.alerts.engine.impl.DroolsRulesEngineImpl;
+import org.hawkular.alerts.engine.impl.MemActionsServiceImpl;
+
+/**
+ * Factory helper for standalone use cases.
+ *
+ * @author Lucas Ponce
+ */
+public class StandaloneAlerts {
+
+    private static StandaloneAlerts instance = null;
+
+    private MemActionsServiceImpl actions = null;
+    private CassAlertsServiceImpl alerts = null;
+    private CassDefinitionsServiceImpl definitions = null;
+    private DroolsRulesEngineImpl rules = null;
+
+    private StandaloneAlerts() {
+        actions = new MemActionsServiceImpl();
+        rules = new DroolsRulesEngineImpl();
+        definitions = new CassDefinitionsServiceImpl();
+        alerts = new CassAlertsServiceImpl();
+
+        definitions.setAlertsService(alerts);
+        alerts.setDefinitions(definitions);
+        alerts.setActions(actions);
+        alerts.setRules(rules);
+
+        definitions.init();
+        alerts.initServices();
+    }
+
+    public static synchronized DefinitionsService getDefinitionsService() {
+        if (instance == null) {
+            instance = new StandaloneAlerts();
+        }
+        return instance.definitions;
+    }
+
+    public static synchronized AlertsService getAlertsService() {
+        if (instance == null) {
+            instance = new StandaloneAlerts();
+        }
+        return instance.alerts;
+    }
+
+    public static synchronized ActionsService getActionsService() {
+        if (instance == null) {
+            instance = new StandaloneAlerts();
+        }
+        return instance.actions;
+    }
+}

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -116,6 +116,30 @@ public class CassAlertsServiceImpl implements AlertsService {
         period = new Integer(AlertProperties.getProperty(ENGINE_PERIOD, "2000"));
     }
 
+    public ActionsService getActions() {
+        return actions;
+    }
+
+    public void setActions(ActionsService actions) {
+        this.actions = actions;
+    }
+
+    public DefinitionsService getDefinitions() {
+        return definitions;
+    }
+
+    public void setDefinitions(DefinitionsService definitions) {
+        this.definitions = definitions;
+    }
+
+    public RulesEngine getRules() {
+        return rules;
+    }
+
+    public void setRules(RulesEngine rules) {
+        this.rules = rules;
+    }
+
     @PostConstruct
     public void initServices() {
         try {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -115,14 +115,29 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
     private PreparedStatement selectTag;
     private PreparedStatement deleteTagsTriggers;
 
-    public CassDefinitionsServiceImpl() {
+    public CassDefinitionsServiceImpl() { }
 
+    public AlertsService getAlertsService() {
+        return alertsService;
     }
 
-    public CassDefinitionsServiceImpl(AlertsService alertsService, Session session, String keyspace) {
-        this();
+    public void setAlertsService(AlertsService alertsService) {
         this.alertsService = alertsService;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public void setSession(Session session) {
         this.session = session;
+    }
+
+    public String getKeyspace() {
+        return keyspace;
+    }
+
+    public void setKeyspace(String keyspace) {
         this.keyspace = keyspace;
     }
 

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/CassTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/CassTest.java
@@ -40,9 +40,8 @@ import org.hawkular.alerts.api.model.trigger.Tag;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.alerts.api.services.AlertsCriteria;
 import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.engine.impl.AlertProperties;
-import org.hawkular.alerts.engine.impl.CassAlertsServiceImpl;
-import org.hawkular.alerts.engine.impl.CassDefinitionsServiceImpl;
 import org.hawkular.alerts.engine.impl.CassCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -60,8 +59,8 @@ import com.datastax.driver.core.Session;
 public class CassTest {
 
     static Session session;
-    static CassDefinitionsServiceImpl cassDefinitions;
-    static CassAlertsServiceImpl cassAlerts;
+    static DefinitionsService cassDefinitions;
+    static AlertsService cassAlerts;
     static String keyspace;
 
     @BeforeClass
@@ -73,12 +72,8 @@ public class CassTest {
         session = CassCluster.getSession();
         keyspace = AlertProperties.getProperty("hawkular-alerts.cassandra-keyspace", "hawkular_alerts_test");
 
-        AlertsService emptyAlertsService = new EmptyAlertsService();
-        cassDefinitions = new CassDefinitionsServiceImpl(emptyAlertsService, session, keyspace);
-        cassAlerts = new CassAlertsServiceImpl();
-
-        cassDefinitions.init();
-        cassAlerts.initServices();
+        cassDefinitions = StandaloneAlerts.getDefinitionsService();
+        cassAlerts = StandaloneAlerts.getAlertsService();
     }
 
     @Test


### PR DESCRIPTION
Small commit to add a helper factory for standalone cases.
It is mainly used for tests/demo purposes but I think it is more clear rather than invoking directly the implementations.
I have thought to do it in a pure SPI style but inter-dependencies have to be resolved manually in anycase so I decided to bring a small factory for it.