### PR TITLE
don't push empty REST documentation

### DIFF
--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -17,10 +17,14 @@
 #
 
 # generate the docs
-mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip
+mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip -Dlicense.skip
 
 FILE_NAME="rest-alerts.adoc"
 FILE_PATH="hawkular-alerts-rest/target/generated/$FILE_NAME"
+
+# don't push the empty docs
+[[ -s $FILE_PATH ]] || echo "$FILE_PATH is empty" && exit 1
+
 REPO="hawkular/hawkular.github.io"
 BRANCH="swagger"
 SHA=`curl -Ls https://api.github.com/repos/$REPO/contents/$FILE_NAME?ref=$BRANCH | grep '"sha"' | cut -d '"' -f4`


### PR DESCRIPTION
Check on the consumer side is made also here https://github.com/hawkular/hawkular.github.io/blob/pages/.travis.swagger.sh#L23