### PR TITLE
Hwkalerts 54

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
@@ -32,27 +32,12 @@ import org.hawkular.alerts.api.model.data.Data;
  */
 public interface AlertsService {
 
-    void sendData(Data data);
-
-    void sendData(Collection<Data> data);
-
     /**
-     * Reset session state.
+     * Persist the provided alerts.
+     * @param alerts Set of unpersisted Alerts.
+     * @throws Exception any problem
      */
-    void clear();
-
-    /**
-     * Reload all Triggers.
-     */
-    void reload();
-
-    /**
-     * Reload the specified Trigger.  Removes any existing definition from the engine.  If enabled then loads the firing
-     * condition set and dampening.  If safetyEnabled then also loads the safety condition set and dampening.
-     * @param tenantId Tenant where Trigger is stored
-     * @param triggerId Trigger id to be reloaded
-     */
-    void reloadTrigger(String tenantId, String triggerId);
+    void addAlerts(Collection<Alert> alerts) throws Exception;
 
     /**
      * @param tenantId Tenant where alerts are stored
@@ -61,13 +46,6 @@ public interface AlertsService {
      * @throws Exception any problem
      */
     List<Alert> getAlerts(String tenantId, AlertsCriteria criteria) throws Exception;
-
-    /**
-     * Persist the provided alerts.
-     * @param alerts Set of unpersisted Alerts.
-     * @throws Exception any problem
-     */
-    void addAlerts(Collection<Alert> alerts) throws Exception;
 
     /**
      * The alerts must already have been added. Set the alerts to ACKNOWLEDGED status. The ackTime will be set to the
@@ -105,5 +83,21 @@ public interface AlertsService {
      */
     void resolveAlertsForTrigger(String tenantId, String triggerId, String resolvedBy, String resolvedNotes,
             List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
+
+    /**
+     * Send data into the alerting system for evaluation.
+     *
+     * @param data Not Null.  The data to be evaluated by the alerting engine.
+     * @throws Exception any problem.
+     */
+    void sendData(Data data) throws Exception;
+
+    /**
+     * Send data into the alerting system for evaluation.
+     *
+     * @param data Not Null.  The data to be evaluated by the alerting engine.
+     * @throws Exception any problem.
+     */
+    void sendData(Collection<Data> data) throws Exception;
 
 }

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AlertDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AlertDataListener.java
@@ -24,7 +24,6 @@ import javax.jms.MessageListener;
 import org.hawkular.alerts.api.services.AlertsService;
 import org.hawkular.alerts.bus.messages.AlertDataMessage;
 import org.hawkular.bus.common.consumer.BasicMessageListener;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -45,6 +44,10 @@ public class AlertDataListener extends BasicMessageListener<AlertDataMessage> {
     @Override
     protected void onBasicMessage(AlertDataMessage msg) {
         log.debugf("Message received: [%s]", msg);
-        alerts.sendData(msg.getData());
+        try {
+            alerts.sendData(msg.getData());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AvailDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AvailDataListener.java
@@ -72,7 +72,6 @@ public class AvailDataListener extends BasicMessageListener<AvailDataMessage> {
         return activeAvailabilityIds.contains(id);
     }
 
-
     @Override
     protected void onBasicMessage(AvailDataMessage msg) {
         log.debugf("Message received: [%s]", msg);
@@ -89,7 +88,11 @@ public class AvailDataListener extends BasicMessageListener<AvailDataMessage> {
         }
 
         log.debugf("Sending: [%s]", alertData);
-        alerts.sendData(alertData);
+        try {
+            alerts.sendData(alertData);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // just dumps the expected json

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/MetricDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/MetricDataListener.java
@@ -28,7 +28,6 @@ import javax.jms.MessageListener;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.data.NumericData;
 import org.hawkular.alerts.api.services.AlertsService;
-import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.bus.init.CacheManager;
 import org.hawkular.alerts.bus.messages.MetricDataMessage;
 import org.hawkular.alerts.bus.messages.MetricDataMessage.MetricData;
@@ -56,9 +55,6 @@ public class MetricDataListener extends BasicMessageListener<MetricDataMessage> 
 
     @EJB
     AlertsService alerts;
-
-    @EJB
-    DefinitionsService definitions;
 
     @EJB
     CacheManager cacheManager;
@@ -91,6 +87,10 @@ public class MetricDataListener extends BasicMessageListener<MetricDataMessage> 
         }
 
         log.debugf("Sending: [%s]", alertData);
-        alerts.sendData(alertData);
+        try {
+            alerts.sendData(alertData);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
@@ -19,6 +19,7 @@ package org.hawkular.alerts.engine;
 import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.api.services.AlertsService;
 import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.engine.impl.AlertsEngineImpl;
 import org.hawkular.alerts.engine.impl.CassAlertsServiceImpl;
 import org.hawkular.alerts.engine.impl.CassDefinitionsServiceImpl;
 import org.hawkular.alerts.engine.impl.DroolsRulesEngineImpl;
@@ -36,18 +37,20 @@ public class StandaloneAlerts {
     private MemActionsServiceImpl actions = null;
     private CassAlertsServiceImpl alerts = null;
     private CassDefinitionsServiceImpl definitions = null;
+    private AlertsEngineImpl engine = null;
     private DroolsRulesEngineImpl rules = null;
 
     private StandaloneAlerts() {
         actions = new MemActionsServiceImpl();
         rules = new DroolsRulesEngineImpl();
+        engine = new AlertsEngineImpl();
         definitions = new CassDefinitionsServiceImpl();
         alerts = new CassAlertsServiceImpl();
 
-        definitions.setAlertsService(alerts);
-        alerts.setDefinitions(definitions);
-        alerts.setActions(actions);
-        alerts.setRules(rules);
+        definitions.setAlertsEngine(engine);
+        engine.setDefinitions(definitions);
+        engine.setActions(actions);
+        engine.setRules(rules);
 
         definitions.init();
         alerts.initServices();

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.ActionsService;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.engine.log.MsgLogger;
+import org.hawkular.alerts.engine.rules.RulesEngine;
+import org.hawkular.alerts.engine.service.AlertsEngine;
+import org.jboss.logging.Logger;
+
+import com.datastax.driver.core.Session;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Cassandra implementation for {@link org.hawkular.alerts.api.services.AlertsService}.
+ * This implementation processes data asynchronously using a buffer queue.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Singleton
+public class AlertsEngineImpl implements AlertsEngine {
+    private final MsgLogger msgLog = MsgLogger.LOGGER;
+    private final Logger log = Logger.getLogger(AlertsEngineImpl.class);
+
+    private static final String ENGINE_DELAY = "hawkular-alerts.engine-delay";
+    private static final String ENGINE_PERIOD = "hawkular-alerts.engine-period";
+    private static final String CASSANDRA_KEYSPACE = "hawkular-alerts.cassandra-keyspace";
+
+    private int delay;
+    private int period;
+
+    private Session session;
+    private String keyspace;
+
+    private final List<Data> pendingData;
+    private final List<Alert> alerts;
+    private final Set<Dampening> pendingTimeouts;
+    private final Map<Trigger, List<Set<ConditionEval>>> autoResolvedTriggers;
+    private final Set<Trigger> disabledTriggers;
+
+    private final Timer wakeUpTimer;
+    private TimerTask rulesTask;
+
+    @EJB
+    RulesEngine rules;
+
+    @EJB
+    DefinitionsService definitions;
+
+    @EJB
+    ActionsService actions;
+
+    @EJB
+    AlertsService alertsService;
+
+    public AlertsEngineImpl() {
+        pendingData = new ArrayList<>();
+        alerts = new ArrayList<>();
+        pendingTimeouts = new HashSet<>();
+        autoResolvedTriggers = new HashMap<>();
+        disabledTriggers = new HashSet<>();
+
+        wakeUpTimer = new Timer("CassAlertsServiceImpl-Timer");
+
+        delay = new Integer(AlertProperties.getProperty(ENGINE_DELAY, "1000"));
+        period = new Integer(AlertProperties.getProperty(ENGINE_PERIOD, "2000"));
+    }
+
+    public RulesEngine getRules() {
+        return rules;
+    }
+
+    public void setRules(RulesEngine rules) {
+        this.rules = rules;
+    }
+
+    public DefinitionsService getDefinitions() {
+        return definitions;
+    }
+
+    public void setDefinitions(DefinitionsService definitions) {
+        this.definitions = definitions;
+    }
+
+    public ActionsService getActions() {
+        return actions;
+    }
+
+    public void setActions(ActionsService actions) {
+        this.actions = actions;
+    }
+
+    public AlertsService getAlertsService() {
+        return alertsService;
+    }
+
+    public void setAlertsService(AlertsService alertsService) {
+        this.alertsService = alertsService;
+    }
+
+    @PostConstruct
+    public void initServices() {
+        try {
+            if (this.keyspace == null) {
+                this.keyspace = AlertProperties.getProperty(CASSANDRA_KEYSPACE, "hawkular_alerts");
+            }
+
+            if (session == null) {
+                session = CassCluster.getSession();
+            }
+
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            gsonBuilder.registerTypeHierarchyAdapter(ConditionEval.class, new GsonAdapter<ConditionEval>());
+
+            reload();
+        } catch (Throwable t) {
+            if (log.isDebugEnabled()) {
+                t.printStackTrace();
+            }
+            msgLog.errorCannotInitializeAlertsService(t.getMessage());
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (session != null) {
+            session.close();
+        }
+    }
+
+    public void clear() {
+        rulesTask.cancel();
+
+        rules.clear();
+
+        pendingData.clear();
+        alerts.clear();
+        pendingTimeouts.clear();
+        autoResolvedTriggers.clear();
+        disabledTriggers.clear();
+
+        rulesTask = new RulesInvoker();
+        wakeUpTimer.schedule(rulesTask, delay, period);
+    }
+
+    @Override
+    public void reload() {
+        rules.reset();
+        if (rulesTask != null) {
+            rulesTask.cancel();
+        }
+
+        Collection<Trigger> triggers = null;
+        try {
+            triggers = definitions.getAllTriggers();
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            msgLog.errorDefinitionsService("Triggers", e.getMessage());
+        }
+        if (triggers != null && !triggers.isEmpty()) {
+            triggers.stream().filter(Trigger::isEnabled).forEach(this::reloadTrigger);
+        }
+
+        rules.addGlobal("log", log);
+        rules.addGlobal("actions", actions);
+        rules.addGlobal("alerts", alerts);
+        rules.addGlobal("pendingTimeouts", pendingTimeouts);
+        rules.addGlobal("autoResolvedTriggers", autoResolvedTriggers);
+        rules.addGlobal("disabledTriggers", disabledTriggers);
+
+        rulesTask = new RulesInvoker();
+        wakeUpTimer.schedule(rulesTask, delay, period);
+    }
+
+    public void reloadTrigger(final String tenantId, final String triggerId) {
+        if (isEmpty(tenantId)) {
+            throw new IllegalArgumentException("TenantId must be not null");
+        }
+        if (isEmpty(triggerId)) {
+            throw new IllegalArgumentException("TriggerId must be not null");
+        }
+
+        Trigger trigger = null;
+        try {
+            trigger = definitions.getTrigger(tenantId, triggerId);
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            msgLog.errorDefinitionsService("Trigger", e.getMessage());
+        }
+        if (null == trigger) {
+            log.debugf("Trigger not found for triggerId [" + triggerId + "], removing from rulebase if it exists");
+            Trigger doomedTrigger = new Trigger(triggerId, "doomed");
+            removeTrigger(doomedTrigger);
+            return;
+        }
+
+        reloadTrigger(trigger);
+    }
+
+    private void reloadTrigger(Trigger trigger) {
+        if (null == trigger) {
+            throw new IllegalArgumentException("Trigger must be not null");
+        }
+
+        // Look for the Trigger in the rules engine, if it is there then remove everything about it
+        removeTrigger(trigger);
+
+        if (trigger.isEnabled()) {
+            try {
+                Collection<Condition> conditionSet = definitions.getTriggerConditions(trigger.getTenantId(),
+                        trigger.getId(), null);
+                Collection<Dampening> dampenings = definitions.getTriggerDampenings(trigger.getTenantId(),
+                        trigger.getId(), null);
+
+                rules.addFact(trigger);
+                rules.addFacts(conditionSet);
+                if (!dampenings.isEmpty()) {
+                    rules.addFacts(dampenings);
+                }
+            } catch (Exception e) {
+                log.debugf(e.getMessage(), e);
+                msgLog.errorDefinitionsService("Conditions/Dampening", e.getMessage());
+            }
+        }
+    }
+
+    private void removeTrigger(Trigger trigger) {
+        if (null != rules.getFact(trigger)) {
+            // First remove the related Trigger facts from the engine
+            rules.removeFact(trigger);
+
+            // then remove everything else.
+            // We may want to do this with rules, because as is, we need to loop through every Fact in
+            // the rules engine doing a relatively slow check.
+            final String triggerId = trigger.getId();
+            rules.removeFacts(t -> {
+                if (t instanceof Dampening) {
+                    return ((Dampening) t).getTriggerId().equals(triggerId);
+                } else if (t instanceof Condition) {
+                    return ((Condition) t).getTriggerId().equals(triggerId);
+                }
+                return false;
+            });
+        } else {
+            log.debugf("Trigger not found. Not removed from rulebase %s", trigger);
+        }
+    }
+
+    @Override
+    public void sendData(Collection<Data> data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Data must be not null");
+        }
+        addPendingData(data);
+    }
+
+    @Override
+    public void sendData(Data data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Data must be not null");
+        }
+        addPendingData(data);
+    }
+
+    private synchronized void addPendingData(Collection<Data> data) {
+        pendingData.addAll(data);
+    }
+
+    private synchronized void addPendingData(Data data) {
+        pendingData.add(data);
+    }
+
+    private synchronized Collection<Data> getAndClearPendingData() {
+        Collection<Data> result = new ArrayList<>(pendingData);
+        pendingData.clear();
+        return result;
+    }
+
+    private class RulesInvoker extends TimerTask {
+        @Override
+        public void run() {
+            int numTimeouts = checkPendingTimeouts();
+
+            if (!pendingData.isEmpty() || numTimeouts > 0) {
+                Collection<Data> newData = getAndClearPendingData();
+
+                log.debugf("Executing rules engine on [%1d] datums and [%2d] dampening timeouts.", newData.size(),
+                        numTimeouts);
+
+                try {
+                    if (newData.isEmpty()) {
+                        rules.fireNoData();
+
+                    } else {
+                        rules.addData(newData);
+                        newData.clear();
+                    }
+
+                    rules.fire();
+                    alertsService.addAlerts(alerts);
+                    alerts.clear();
+                    handleDisabledTriggers();
+                    handleAutoResolvedTriggers();
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.debugf("Error on rules processing: " + e);
+                    msgLog.errorProcessingRules(e.getMessage());
+                } finally {
+                    alerts.clear();
+                }
+            }
+        }
+
+        private int checkPendingTimeouts() {
+            if (pendingTimeouts.isEmpty()) {
+                return 0;
+            }
+
+            long now = System.currentTimeMillis();
+            Set<Dampening> timeouts = null;
+            for (Dampening d : pendingTimeouts) {
+                if (now < d.getTrueEvalsStartTime() + d.getEvalTimeSetting()) {
+                    continue;
+                }
+
+                d.setSatisfied(true);
+                try {
+                    log.debugf("Dampening Timeout Hit! %s", d.toString());
+                    rules.updateFact(d);
+                    if (null == timeouts) {
+                        timeouts = new HashSet<>();
+                    }
+                    timeouts.add(d);
+                } catch (Exception e) {
+                    log.error("Unable to update Dampening Fact on Timeout! " + d.toString(), e);
+                }
+
+            }
+
+            if (null == timeouts) {
+                return 0;
+            }
+
+            pendingTimeouts.removeAll(timeouts);
+            return timeouts.size();
+        }
+    }
+
+    private void handleDisabledTriggers() {
+        try {
+            for (Trigger t : disabledTriggers) {
+                try {
+                    t.setEnabled(false);
+                    definitions.updateTrigger(t.getTenantId(), t);
+
+                } catch (Exception e) {
+                    log.errorf("Failed to persist updated trigger. Could not autoDisable %s", t);
+                }
+            }
+        } finally {
+            disabledTriggers.clear();
+        }
+    }
+
+    private void handleAutoResolvedTriggers() {
+        try {
+            for (Map.Entry<Trigger, List<Set<ConditionEval>>> entry : autoResolvedTriggers.entrySet()) {
+                Trigger t = entry.getKey();
+                try {
+                    if (t.isAutoResolveAlerts()) {
+                        alertsService.resolveAlertsForTrigger(t.getTenantId(), t.getId(), "AUTO", null,
+                                entry.getValue());
+                    }
+                } catch (Exception e) {
+                    log.errorf("Failed to resolve Alerts. Could not AutoResolve alerts for trigger %s", t);
+                }
+            }
+        } finally {
+            autoResolvedTriggers.clear();
+        }
+    }
+
+    private boolean isEmpty(String s) {
+        return null == s || s.trim().isEmpty();
+    }
+
+}

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -159,11 +159,11 @@ public class AlertsEngineImpl implements AlertsEngine {
         }
     }
 
+    // Note, the cassandra cluster shutdown should be performed only once and is performed here because
+    // this is a singleton bean and is likely to stay that way.
     @PreDestroy
     public void shutdown() {
-        if (session != null) {
-            session.close();
-        }
+        CassCluster.shutdown();
     }
 
     public void clear() {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 
@@ -86,13 +85,6 @@ public class CassAlertsServiceImpl implements AlertsService {
                 t.printStackTrace();
             }
             msgLog.errorCannotInitializeAlertsService(t.getMessage());
-        }
-    }
-
-    @PreDestroy
-    public void shutdown() {
-        if (session != null) {
-            session.close();
         }
     }
 

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -117,7 +117,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
 
     @PreDestroy
     public void shutdown() {
-        CassCluster.shutdown();
+        if (session != null) {
+            session.close();
+        }
     }
 
     private void initialData() throws IOException {
@@ -948,7 +950,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectTriggerDampenings = CassStatement.get(session, CassStatement.SELECT_TRIGGER_DAMPENINGS);
+        PreparedStatement selectTriggerDampenings = CassStatement
+                .get(session, CassStatement.SELECT_TRIGGER_DAMPENINGS);
         PreparedStatement selectTriggerDampeningsMode = CassStatement.get(session,
                 CassStatement.SELECT_TRIGGER_DAMPENINGS_MODE);
         if (selectTriggerDampenings == null || selectTriggerDampeningsMode == null) {
@@ -1254,7 +1257,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             return;
         }
         PreparedStatement insertTag = CassStatement.get(session, CassStatement.INSERT_TAG);
-        if (insertTag == null)  {
+        if (insertTag == null) {
             throw new RuntimeException("insertTag PreparedStatement is null");
         }
         session.execute(insertTag.bind(tenantId, triggerId, category, name, visible));
@@ -1275,7 +1278,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             if (!triggers.contains(triggerId)) {
                 triggers.add(triggerId);
                 PreparedStatement updateTagsTriggers = CassStatement.get(session, CassStatement.UPDATE_TAGS_TRIGGERS);
-                if (updateTagsTriggers  == null) {
+                if (updateTagsTriggers == null) {
                     throw new RuntimeException("updateTagsTriggers PreparedStatement is null");
                 }
                 session.execute(updateTagsTriggers.bind(triggers, tenantId, name));
@@ -1430,7 +1433,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                 session.execute(updateTagsTriggers.bind(triggers, tag.getTenantId(), tag.getName()));
             } else {
                 PreparedStatement deleteTagsTriggers = CassStatement.get(session, CassStatement.DELETE_TAGS_TRIGGERS);
-                if (deleteTagsTriggers  == null) {
+                if (deleteTagsTriggers == null) {
                     throw new RuntimeException("deleteTagsTriggers PreparedStatement is null");
                 }
                 session.execute(deleteTagsTriggers.bind(tag.getTenantId(), tag.getName()));
@@ -1481,7 +1484,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectTriggerConditions = CassStatement.get(session, CassStatement.SELECT_TRIGGER_CONDITIONS);
+        PreparedStatement selectTriggerConditions = CassStatement
+                .get(session, CassStatement.SELECT_TRIGGER_CONDITIONS);
         PreparedStatement selectTriggerConditionsTriggerMode = CassStatement.get(session,
                 CassStatement.SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE);
         if (selectTriggerConditions == null || selectTriggerConditionsTriggerMode == null) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -626,7 +626,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectTenantTriggers = CassStatement.get(session, CassStatement.SELECT_TENANT_TRIGGERS);
+        PreparedStatement selectTenantTriggers = CassStatement.get(session, CassStatement.SELECT_TRIGGERS_TENANT);
         if (selectTenantTriggers == null) {
             throw new RuntimeException("selectTenantTriggers PreparedStatement is null");
         }
@@ -650,7 +650,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectAllTriggers = CassStatement.get(session, CassStatement.SELECT_ALL_TRIGGERS);
+        PreparedStatement selectAllTriggers = CassStatement.get(session, CassStatement.SELECT_TRIGGERS_ALL);
         if (selectAllTriggers == null) {
             throw new RuntimeException("selectAllTriggers PreparedStatement is null");
         }
@@ -976,7 +976,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectAllDampenings = CassStatement.get(session, CassStatement.SELECT_ALL_DAMPENINGS);
+        PreparedStatement selectAllDampenings = CassStatement.get(session, CassStatement.SELECT_DAMPENINGS_ALL);
         if (selectAllDampenings == null) {
             throw new RuntimeException("selectAllDampenings PreparedStatement is null");
         }
@@ -1000,7 +1000,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new RuntimeException("Cassandra session is null");
         }
         PreparedStatement selectAllDampeningsByTenant = CassStatement.get(session,
-                CassStatement.SELECT_ALL_DAMPENINGS_BY_TENANT);
+                CassStatement.SELECT_DAMPENINGS_TENANT);
         if (selectAllDampeningsByTenant == null) {
             throw new RuntimeException("selectAllDampeningsByTenant PreparedStatement is null");
         }
@@ -1147,13 +1147,13 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new RuntimeException("Cassandra session is null");
         }
         PreparedStatement insertAvailabilityCondition = CassStatement.get(session,
-                CassStatement.INSERT_AVAILABILITY_CONDITION);
-        PreparedStatement insertCompareCondition = CassStatement.get(session, CassStatement.INSERT_COMPARE_CONDITION);
-        PreparedStatement insertStringCondition = CassStatement.get(session, CassStatement.INSERT_STRING_CONDITION);
+                CassStatement.INSERT_CONDITION_AVAILABILITY);
+        PreparedStatement insertCompareCondition = CassStatement.get(session, CassStatement.INSERT_CONDITION_COMPARE);
+        PreparedStatement insertStringCondition = CassStatement.get(session, CassStatement.INSERT_CONDITION_STRING);
         PreparedStatement insertThresholdCondition = CassStatement.get(session,
-                CassStatement.INSERT_THRESHOLD_CONDITION);
+                CassStatement.INSERT_CONDITION_THRESHOLD);
         PreparedStatement insertThresholdRangeCondition = CassStatement.get(session,
-                CassStatement.INSERT_THRESHOLD_RANGE_CONDITION);
+                CassStatement.INSERT_CONDITION_THRESHOLD_RANGE);
         if (insertAvailabilityCondition == null
                 || insertCompareCondition == null
                 || insertStringCondition == null
@@ -1510,7 +1510,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectAllConditions = CassStatement.get(session, CassStatement.SELECT_ALL_CONDITIONS);
+        PreparedStatement selectAllConditions = CassStatement.get(session, CassStatement.SELECT_CONDITIONS_ALL);
         if (selectAllConditions == null) {
             throw new RuntimeException("selectAllConditions PreparedStatement is null");
         }
@@ -1534,7 +1534,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new RuntimeException("Cassandra session is null");
         }
         PreparedStatement selectAllConditionsByTenant = CassStatement.get(session,
-                CassStatement.SELECT_ALL_CONDITIONS_BY_TENANT);
+                CassStatement.SELECT_CONDITIONS_TENANT);
         if (selectAllConditionsByTenant == null) {
             throw new RuntimeException("selectAllConditionsByTenant PreparedStatement is null");
         }
@@ -1811,7 +1811,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
-        PreparedStatement selectAllActions = CassStatement.get(session, CassStatement.SELECT_ALL_ACTIONS);
+        PreparedStatement selectAllActions = CassStatement.get(session, CassStatement.SELECT_ACTIONS_ALL);
         if (selectAllActions == null) {
             throw new RuntimeException("selectAllActions PreparedStatement is null");
         }
@@ -1846,7 +1846,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new RuntimeException("Cassandra session is null");
         }
         PreparedStatement selectAllActionsByTenant = CassStatement.get(session,
-                CassStatement.SELECT_ALL_ACTIONS_BY_TENANT);
+                CassStatement.SELECT_ACTIONS_BY_TENANT);
         if (selectAllActionsByTenant == null) {
             throw new RuntimeException("selectAllActionsByTenant PreparedStatement is null");
         }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -79,59 +79,6 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
 
     private List<DefinitionsListener> listeners = new ArrayList<>();
 
-    private PreparedStatement insertTrigger;
-    private PreparedStatement insertTriggerActions;
-    private PreparedStatement selectTriggerConditions;
-    private PreparedStatement selectTriggerConditionsTriggerMode;
-    private PreparedStatement deleteConditionsMode;
-    private PreparedStatement insertAvailabilityCondition;
-    private PreparedStatement insertCompareCondition;
-    private PreparedStatement insertStringCondition;
-    private PreparedStatement insertThresholdCondition;
-    private PreparedStatement insertThresholdRangeCondition;
-    private PreparedStatement insertTag;
-    private PreparedStatement insertDampening;
-    private PreparedStatement insertAction;
-    private PreparedStatement selectAllTriggers;
-    private PreparedStatement selectTriggerActions;
-    private PreparedStatement selectTenantTriggers;
-    private PreparedStatement selectAllConditions;
-    private PreparedStatement selectAllConditionsByTenant;
-    private PreparedStatement selectAllDampenings;
-    private PreparedStatement selectAllDampeningsByTenant;
-    private PreparedStatement selectAllActions;
-    private PreparedStatement selectAllActionsByTenant;
-    private PreparedStatement selectTrigger;
-    private PreparedStatement selectTriggerDampenings;
-    private PreparedStatement selectTriggerDampeningsMode;
-    private PreparedStatement deleteDampenings;
-    private PreparedStatement deleteConditions;
-    private PreparedStatement deleteTriggers;
-    private PreparedStatement updateTrigger;
-    private PreparedStatement deleteTriggerActions;
-    private PreparedStatement deleteDampeningId;
-    private PreparedStatement selectDampeningId;
-    private PreparedStatement updateDampeningId;
-    private PreparedStatement selectConditionId;
-    private PreparedStatement insertActionPlugin;
-    private PreparedStatement deleteActionPlugin;
-    private PreparedStatement updateActionPlugin;
-    private PreparedStatement selectActionPlugins;
-    private PreparedStatement selectActionPlugin;
-    private PreparedStatement deleteAction;
-    private PreparedStatement updateAction;
-    private PreparedStatement selectActionsPlugin;
-    private PreparedStatement selectAction;
-    private PreparedStatement insertTagsTriggers;
-    private PreparedStatement updateTagsTriggers;
-    private PreparedStatement deleteTagsTriggers;
-    private PreparedStatement selectTags;
-    private PreparedStatement selectTagsByCategoryAndName;
-    private PreparedStatement selectTagsByCategory;
-    private PreparedStatement selectTagsByName;
-    private PreparedStatement deleteTags;
-    private PreparedStatement deleteTagsByName;
-
     @EJB
     AlertsEngine alertsEngine;
 
@@ -157,8 +104,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                 session = CassCluster.getSession();
             }
 
-            initPreparedStatements();
-
+            /*
+                Initial data works here because we are in a singleton
+             */
             initialData();
 
         } catch (Throwable t) {
@@ -169,9 +117,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
 
     @PreDestroy
     public void shutdown() {
-        if (session != null) {
-            session.close();
-        }
+        CassCluster.shutdown();
     }
 
     private void initialData() throws IOException {
@@ -183,261 +129,6 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         String folder = data + "/" + INIT_FOLDER;
         initFiles(folder);
         initialized = true;
-    }
-
-    // TODO: This approach is fine because this is a singleton bean and therefore the statements are not
-    // repeatedly prepared by numerous pooled beans.  But, to avoid duplication and consolidate prepared
-    // statements it make sense to move these to CassStatement...
-    private void initPreparedStatements() {
-        if (insertTrigger == null) {
-            insertTrigger = session.prepare("INSERT INTO " + keyspace + ".triggers " +
-                    "(name, description, autoDisable, autoResolve, autoResolveAlerts, firingMatch, " +
-                    "autoResolveMatch, id, enabled, tenantId) " +
-                    "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertTriggerActions == null) {
-            insertTriggerActions = session.prepare("INSERT INTO " + keyspace + ".triggers_actions " +
-                    "(tenantId, triggerId, actionPlugin, actions) VALUES (?, ?, ?, ?) ");
-        }
-        if (selectTriggerConditions == null) {
-            selectTriggerConditions = session.prepare("SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                    "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                    "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId"
-                    +
-                    " FROM " + keyspace + ".conditions " +
-                    "WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, triggerMode, type");
-        }
-        if (selectTriggerConditionsTriggerMode == null) {
-            selectTriggerConditionsTriggerMode = session.prepare("SELECT triggerId, triggerMode, type, " +
-                    "conditionSetSize, conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, " +
-                    "pattern, ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange,"
-                    +
-                    " tenantId " +
-                    "FROM " + keyspace + ".conditions " +
-                    "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? " +
-                    "ORDER BY triggerId, triggerMode, type");
-        }
-        if (deleteConditionsMode == null) {
-            deleteConditionsMode = session.prepare("DELETE FROM " + keyspace + ".conditions " +
-                    "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ");
-        }
-        if (insertAvailabilityCondition == null) {
-            insertAvailabilityCondition = session.prepare("INSERT INTO " + keyspace + ".conditions " +
-                    "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                    "dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?) ");
-        }
-        if (insertCompareCondition == null) {
-            insertCompareCondition = session.prepare("INSERT INTO " + keyspace + ".conditions " +
-                    "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                    "dataId, operator, data2Id, data2Multiplier) VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertStringCondition == null) {
-            insertStringCondition = session.prepare("INSERT INTO " + keyspace + ".conditions " +
-                    "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                    "dataId, operator, pattern, ignoreCase) VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertThresholdCondition == null) {
-            insertThresholdCondition = session.prepare("INSERT INTO " + keyspace + ".conditions " +
-                    "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                    "dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertThresholdRangeCondition == null) {
-            insertThresholdRangeCondition = session.prepare("INSERT INTO " + keyspace + ".conditions " +
-                    "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                    "dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) " +
-                    "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertTag == null) {
-            insertTag = session.prepare("INSERT INTO " + keyspace + ".tags " +
-                    "(tenantId, triggerId, category, name, visible) VALUES (?, ?, ?, ?, ?) ");
-        }
-        if (insertDampening == null) {
-            insertDampening = session.prepare("INSERT INTO " + keyspace + ".dampenings " +
-                    "(triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting, " +
-                    "dampeningId, tenantId) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ");
-        }
-        if (insertAction == null) {
-            insertAction = session.prepare("INSERT INTO " + keyspace + ".actions " +
-                    "(tenantId, actionPlugin, actionId, properties) VALUES (?, ?, ?, ?) ");
-        }
-        if (selectAllTriggers == null) {
-            selectAllTriggers = session.prepare("SELECT name, description, autoDisable, autoResolve, " +
-                    "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                    "FROM " + keyspace + ".triggers ");
-        }
-        if (selectTriggerActions == null) {
-            selectTriggerActions = session.prepare("SELECT tenantId, triggerId, actionPlugin, actions " +
-                    "FROM " + keyspace + ".triggers_actions " +
-                    "WHERE tenantId = ? AND triggerId = ? ");
-        }
-
-        if (selectTenantTriggers == null) {
-            selectTenantTriggers = session.prepare("SELECT name, description, autoDisable, autoResolve, " +
-                    "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                    "FROM " + keyspace + ".triggers WHERE tenantId = ? ");
-        }
-        if (selectAllConditions == null) {
-            selectAllConditions = session.prepare("SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                    "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                    "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
-                    "tenantId FROM " + keyspace + ".conditions ");
-        }
-        if (selectAllConditionsByTenant == null) {
-            selectAllConditionsByTenant = session.prepare("SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                    "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                    "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
-                    "tenantId FROM " + keyspace + ".conditions WHERE tenantId = ? ");
-        }
-        if (selectAllDampenings == null) {
-            selectAllDampenings = session.prepare("SELECT tenantId, triggerId, triggerMode, type, evalTrueSetting, " +
-                    "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings ");
-        }
-        if (selectAllDampeningsByTenant == null) {
-            selectAllDampeningsByTenant = session.prepare("SELECT tenantId, triggerId, triggerMode, type, " +
-                    "evalTrueSetting, " +
-                    "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? ");
-        }
-        if (selectAllActions == null) {
-            selectAllActions = session.prepare("SELECT tenantId, actionPlugin, actionId " +
-                    "FROM " + keyspace + ".actions ");
-        }
-        if (selectAllActionsByTenant == null) {
-            selectAllActionsByTenant = session.prepare("SELECT actionPlugin, actionId " +
-                    "FROM " + keyspace + ".actions WHERE tenantId = ? ");
-        }
-        if (selectTrigger == null) {
-            selectTrigger = session.prepare("SELECT name, description, autoDisable, autoResolve, " +
-                    "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                    "FROM " + keyspace + ".triggers WHERE tenantId = ? AND id = ? ");
-        }
-        if (selectTriggerDampenings == null) {
-            selectTriggerDampenings = session.prepare("SELECT tenantId, triggerId, triggerMode, type, " +
-                    "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
-                    "FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? AND triggerId = ? ");
-        }
-        if (selectTriggerDampeningsMode == null) {
-            selectTriggerDampeningsMode = session.prepare("SELECT tenantId, triggerId, triggerMode, type, " +
-                    "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
-                    "FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? AND triggerId = ? and triggerMode = ? ");
-        }
-        if (deleteDampenings == null) {
-            deleteDampenings = session.prepare("DELETE FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? AND triggerId = ? ");
-        }
-        if (deleteConditions == null) {
-            deleteConditions = session.prepare("DELETE FROM " + keyspace + ".conditions " +
-                    "WHERE tenantId = ? AND triggerId = ? ");
-        }
-        if (deleteTriggers == null) {
-            deleteTriggers = session.prepare("DELETE FROM " + keyspace + ".triggers " +
-                    "WHERE tenantId = ? AND id = ? ");
-        }
-        if (updateTrigger == null) {
-            updateTrigger = session.prepare("UPDATE " + keyspace + ".triggers " +
-                    "SET name = ?, description = ?, autoDisable = ?, autoResolve = ?, autoResolveAlerts = ?, " +
-                    "firingMatch = ?, autoResolveMatch = ?, enabled = ? " +
-                    "WHERE tenantId = ? AND id = ? ");
-        }
-        if (deleteTriggerActions == null) {
-            deleteTriggerActions = session.prepare("DELETE FROM " + keyspace + ".triggers_actions " +
-                    "WHERE tenantId = ? AND triggerId = ? ");
-        }
-        if (deleteDampeningId == null) {
-            deleteDampeningId = session.prepare("DELETE FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ");
-        }
-        if (selectDampeningId == null) {
-            selectDampeningId = session.prepare("SELECT triggerId, triggerMode, type, evalTrueSetting, " +
-                    "evalTotalSetting, evalTimeSetting, dampeningId, tenantId FROM " + keyspace + ".dampenings " +
-                    "WHERE tenantId = ? AND dampeningId = ? ");
-        }
-        if (updateDampeningId == null) {
-            updateDampeningId = session.prepare("UPDATE " + keyspace + ".dampenings " +
-                    "SET type = ?, evalTrueSetting = ?, evalTotalSetting = ?, evalTimeSetting = ? " +
-                    "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ");
-        }
-        if (selectConditionId == null) {
-            selectConditionId = session.prepare("SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                    "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                    "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, " +
-                    "tenantId " +
-                    "FROM " + keyspace + ".conditions WHERE tenantId = ? AND conditionId = ? ");
-        }
-        if (insertActionPlugin == null) {
-            insertActionPlugin = session.prepare("INSERT INTO " + keyspace + ".action_plugins (actionPlugin, " +
-                    "properties) VALUES (?, ?) ");
-        }
-        if (deleteActionPlugin == null) {
-            deleteActionPlugin = session
-                    .prepare("DELETE FROM " + keyspace + ".action_plugins WHERE actionPlugin = ? ");
-        }
-        if (updateActionPlugin == null) {
-            updateActionPlugin = session.prepare("UPDATE " + keyspace + ".action_plugins " +
-                    "SET properties = ? WHERE actionPlugin = ? ");
-        }
-        if (selectActionPlugins == null) {
-            selectActionPlugins = session.prepare("SELECT actionPlugin FROM " + keyspace + ".action_plugins ");
-        }
-        if (selectActionPlugin == null) {
-            selectActionPlugin = session.prepare("SELECT properties FROM " + keyspace + ".action_plugins " +
-                    "WHERE actionPlugin = ? ");
-        }
-        if (deleteAction == null) {
-            deleteAction = session.prepare("DELETE FROM " + keyspace + ".actions " +
-                    "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ");
-        }
-        if (updateAction == null) {
-            updateAction = session.prepare("UPDATE " + keyspace + ".actions " +
-                    "SET properties = ? " +
-                    "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ");
-        }
-        if (selectActionsPlugin == null) {
-            selectActionsPlugin = session.prepare("SELECT actionId FROM " + keyspace + ".actions " +
-                    "WHERE tenantId = ? AND actionPlugin = ? ");
-        }
-        if (selectAction == null) {
-            selectAction = session.prepare("SELECT properties FROM " + keyspace + ".actions " +
-                    "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ");
-        }
-        if (insertTagsTriggers == null) {
-            insertTagsTriggers = session.prepare("INSERT INTO " + keyspace + ".tags_triggers " +
-                    "(tenantId, category, name, triggers) VALUES (?, ?, ?, ?) ");
-        }
-        if (updateTagsTriggers == null) {
-            updateTagsTriggers = session.prepare("UPDATE " + keyspace + ".tags_triggers " +
-                    "SET triggers = ? " +
-                    "WHERE tenantId = ? AND name = ? ");
-        }
-        if (deleteTagsTriggers == null) {
-            deleteTagsTriggers = session.prepare("DELETE FROM " + keyspace + ".tags_triggers " +
-                    "WHERE tenantId = ? AND name = ? ");
-        }
-        if (selectTags == null) {
-            selectTags = session.prepare("SELECT tenantId, triggerId, category, name, visible FROM " + keyspace +
-                    ".tags WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, name ");
-        }
-        if (selectTagsByCategoryAndName == null) {
-            selectTagsByCategoryAndName = session.prepare("SELECT tenantId, triggerId, category, name, visible FROM " +
-                    keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? AND name = ? ");
-        }
-        if (selectTagsByCategory == null) {
-            selectTagsByCategory = session.prepare("SELECT tenantId, triggerId, category, name, visible FROM " +
-                    keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? ");
-        }
-        if (selectTagsByName == null) {
-            selectTagsByName = session.prepare("SELECT tenantId, triggerId, category, name, visible FROM " +
-                    keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND name = ? ");
-        }
-        if (deleteTags == null) {
-            deleteTags = session.prepare("DELETE FROM " + keyspace + ".tags WHERE tenantId = ? AND triggerId = ? ");
-        }
-        if (deleteTagsByName == null) {
-            deleteTagsByName = session.prepare("DELETE FROM " + keyspace + ".tags " +
-                    "WHERE tenantId = ? AND triggerId = ? AND name = ?");
-        }
     }
 
     private void initFiles(String folder) {
@@ -761,6 +452,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement insertAction = CassStatement.get(session, CassStatement.INSERT_ACTION);
         if (insertAction == null) {
             throw new RuntimeException("insertAction PreparedStatement is null");
         }
@@ -785,6 +477,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement insertTrigger = CassStatement.get(session, CassStatement.INSERT_TRIGGER);
         if (insertTrigger == null) {
             throw new RuntimeException("insertTrigger PreparedStatement is null");
         }
@@ -804,6 +497,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
     }
 
     private void insertTriggerActions(Trigger trigger) throws Exception {
+        PreparedStatement insertTriggerActions = CassStatement.get(session, CassStatement.INSERT_TRIGGER_ACTIONS);
         if (insertTriggerActions == null) {
             throw new RuntimeException("insertTriggerActions PreparedStatement is null");
         }
@@ -829,6 +523,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement deleteDampenings = CassStatement.get(session, CassStatement.DELETE_DAMPENINGS);
+        PreparedStatement deleteConditions = CassStatement.get(session, CassStatement.DELETE_CONDITIONS);
+        PreparedStatement deleteTriggers = CassStatement.get(session, CassStatement.DELETE_TRIGGERS);
         if (deleteDampenings == null || deleteConditions == null || deleteTriggers == null) {
             throw new RuntimeException("delete*Triggers PreparedStatement is null");
         }
@@ -857,6 +554,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement updateTrigger = CassStatement.get(session, CassStatement.UPDATE_TRIGGER);
         if (updateTrigger == null) {
             throw new RuntimeException("updateTrigger PreparedStatement is null");
         }
@@ -882,6 +580,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
     }
 
     private void deleteTriggerActions(Trigger trigger) throws Exception {
+        PreparedStatement deleteTriggerActions = CassStatement.get(session, CassStatement.DELETE_TRIGGER_ACTIONS);
         if (deleteTriggerActions == null) {
             throw new RuntimeException("updateTrigger PreparedStatement is null");
         }
@@ -899,6 +598,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectTrigger = CassStatement.get(session, CassStatement.SELECT_TRIGGER);
         if (selectTrigger == null) {
             throw new RuntimeException("selectTrigger PreparedStatement is null");
         }
@@ -926,6 +626,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectTenantTriggers = CassStatement.get(session, CassStatement.SELECT_TENANT_TRIGGERS);
         if (selectTenantTriggers == null) {
             throw new RuntimeException("selectTenantTriggers PreparedStatement is null");
         }
@@ -949,6 +650,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllTriggers = CassStatement.get(session, CassStatement.SELECT_ALL_TRIGGERS);
         if (selectAllTriggers == null) {
             throw new RuntimeException("selectAllTriggers PreparedStatement is null");
         }
@@ -971,6 +673,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (trigger == null) {
             throw new IllegalArgumentException("Trigger must be not null");
         }
+        PreparedStatement selectTriggerActions = CassStatement.get(session, CassStatement.SELECT_TRIGGER_ACTIONS);
         if (selectTriggerActions == null) {
             throw new RuntimeException("selectTriggerActions PreparedStatement is null");
         }
@@ -1107,6 +810,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement insertDampening = CassStatement.get(session, CassStatement.INSERT_DAMPENING);
         if (insertDampening == null) {
             throw new RuntimeException("insertDampening PreparedStatement is null");
         }
@@ -1140,6 +844,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement deleteDampeningId = CassStatement.get(session, CassStatement.DELETE_DAMPENING_ID);
         if (deleteDampeningId == null) {
             throw new RuntimeException("deleteDampeningId PreparedStatement is null");
         }
@@ -1177,6 +882,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement updateDampeningId = CassStatement.get(session, CassStatement.UPDATE_DAMPENING_ID);
         if (updateDampeningId == null) {
             throw new RuntimeException("updateDampeningId PreparedStatement is null");
         }
@@ -1210,6 +916,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectDampeningId = CassStatement.get(session, CassStatement.SELECT_DAMPENING_ID);
         if (selectDampeningId == null) {
             throw new RuntimeException("selectDampeningId PreparedStatement is null");
         }
@@ -1241,6 +948,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectTriggerDampenings = CassStatement.get(session, CassStatement.SELECT_TRIGGER_DAMPENINGS);
+        PreparedStatement selectTriggerDampeningsMode = CassStatement.get(session,
+                CassStatement.SELECT_TRIGGER_DAMPENINGS_MODE);
         if (selectTriggerDampenings == null || selectTriggerDampeningsMode == null) {
             throw new RuntimeException("selectTriggerDampenings* PreparedStatement is null");
         }
@@ -1266,6 +976,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllDampenings = CassStatement.get(session, CassStatement.SELECT_ALL_DAMPENINGS);
         if (selectAllDampenings == null) {
             throw new RuntimeException("selectAllDampenings PreparedStatement is null");
         }
@@ -1288,6 +999,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllDampeningsByTenant = CassStatement.get(session,
+                CassStatement.SELECT_ALL_DAMPENINGS_BY_TENANT);
         if (selectAllDampeningsByTenant == null) {
             throw new RuntimeException("selectAllDampeningsByTenant PreparedStatement is null");
         }
@@ -1433,6 +1146,14 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement insertAvailabilityCondition = CassStatement.get(session,
+                CassStatement.INSERT_AVAILABILITY_CONDITION);
+        PreparedStatement insertCompareCondition = CassStatement.get(session, CassStatement.INSERT_COMPARE_CONDITION);
+        PreparedStatement insertStringCondition = CassStatement.get(session, CassStatement.INSERT_STRING_CONDITION);
+        PreparedStatement insertThresholdCondition = CassStatement.get(session,
+                CassStatement.INSERT_THRESHOLD_CONDITION);
+        PreparedStatement insertThresholdRangeCondition = CassStatement.get(session,
+                CassStatement.INSERT_THRESHOLD_RANGE_CONDITION);
         if (insertAvailabilityCondition == null
                 || insertCompareCondition == null
                 || insertStringCondition == null
@@ -1532,7 +1253,10 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (!getTags(tenantId, triggerId, category, name).isEmpty()) {
             return;
         }
-
+        PreparedStatement insertTag = CassStatement.get(session, CassStatement.INSERT_TAG);
+        if (insertTag == null)  {
+            throw new RuntimeException("insertTag PreparedStatement is null");
+        }
         session.execute(insertTag.bind(tenantId, triggerId, category, name, visible));
         insertTriggerByTagIndex(tenantId, category, name, triggerId);
     }
@@ -1542,10 +1266,18 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         triggers = new HashSet<>(triggers);
         if (triggers.isEmpty()) {
             triggers.add(triggerId);
+            PreparedStatement insertTagsTriggers = CassStatement.get(session, CassStatement.INSERT_TAGS_TRIGGERS);
+            if (insertTagsTriggers == null) {
+                throw new RuntimeException("insertTagsTriggers PreparedStatement is null");
+            }
             session.execute(insertTagsTriggers.bind(tenantId, category, name, triggers));
         } else {
             if (!triggers.contains(triggerId)) {
                 triggers.add(triggerId);
+                PreparedStatement updateTagsTriggers = CassStatement.get(session, CassStatement.UPDATE_TAGS_TRIGGERS);
+                if (updateTagsTriggers  == null) {
+                    throw new RuntimeException("updateTagsTriggers PreparedStatement is null");
+                }
                 session.execute(updateTagsTriggers.bind(triggers, tenantId, name));
             }
         }
@@ -1557,6 +1289,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
 
         PreparedStatement selectTagsTriggers = CassStatement.get(session,
                 CassStatement.SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME);
+        if (selectTagsTriggers == null) {
+            throw new RuntimeException("selectTagsTriggers PreparedStatement is null");
+        }
         ResultSet rsTriggersTags = session.execute(selectTagsTriggers.bind(tenantId, category, name));
         for (Row row : rsTriggersTags) {
             triggerTags = row.getSet("triggers", String.class);
@@ -1568,12 +1303,26 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throws Exception {
         BoundStatement boundTags;
         if (!isEmpty(category) && !isEmpty(name)) {
+            PreparedStatement selectTagsByCategoryAndName = CassStatement.get(session,
+                    CassStatement.SELECT_TAGS_BY_CATEGORY_AND_NAME);
+            if (selectTagsByCategoryAndName == null) {
+                throw new RuntimeException("selectTagsByCategoryAndName PreparedStatement is null");
+            }
             boundTags = selectTagsByCategoryAndName.bind(tenantId, triggerId, category, name);
         } else if (!isEmpty(category)) {
+            PreparedStatement selectTagsByCategory = CassStatement.get(session, CassStatement.SELECT_TAGS_BY_CATEGORY);
+            if (selectTagsByCategory == null) {
+                throw new RuntimeException("selectTagsByCategory PreparedStatement is null");
+            }
             boundTags = selectTagsByCategory.bind(tenantId, triggerId, category);
         } else if (!isEmpty(name)) {
+            PreparedStatement selectTagsByName = CassStatement.get(session, CassStatement.SELECT_TAGS_BY_NAME);
+            if (selectTagsByName == null) {
+                throw new RuntimeException("selectTagsByName PreparedStatement is null");
+            }
             boundTags = selectTagsByName.bind(tenantId, triggerId, name);
         } else {
+            PreparedStatement selectTags = CassStatement.get(session, CassStatement.SELECT_TAGS);
             boundTags = selectTags.bind(tenantId, triggerId);
         }
 
@@ -1612,6 +1361,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement deleteConditionsMode = CassStatement.get(session, CassStatement.DELETE_CONDITIONS_MODE);
         if (deleteConditionsMode == null) {
             throw new RuntimeException("deleteConditionsMode PreparedStatement is null");
         }
@@ -1633,8 +1383,16 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         }
         BoundStatement boundTags;
         if (!isEmpty(name)) {
+            PreparedStatement deleteTagsByName = CassStatement.get(session, CassStatement.DELETE_TAGS_BY_NAME);
+            if (deleteTagsByName == null) {
+                throw new RuntimeException("deleteTagsByName PreparedStatement is null");
+            }
             boundTags = deleteTagsByName.bind(tenantId, triggerId, name);
         } else {
+            PreparedStatement deleteTags = CassStatement.get(session, CassStatement.DELETE_TAGS);
+            if (deleteTags == null) {
+                throw new RuntimeException("deleteTags PreparedStatement is null");
+            }
             boundTags = deleteTags.bind(tenantId, triggerId);
         }
         try {
@@ -1665,8 +1423,16 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             if (triggers.size() > 1) {
                 Set<String> updateTriggers = new HashSet<>(triggers);
                 updateTriggers.remove(triggerId);
+                PreparedStatement updateTagsTriggers = CassStatement.get(session, CassStatement.UPDATE_TAGS_TRIGGERS);
+                if (updateTagsTriggers == null) {
+                    throw new RuntimeException("updateTagsTriggers PreparedStatement is null");
+                }
                 session.execute(updateTagsTriggers.bind(triggers, tag.getTenantId(), tag.getName()));
             } else {
+                PreparedStatement deleteTagsTriggers = CassStatement.get(session, CassStatement.DELETE_TAGS_TRIGGERS);
+                if (deleteTagsTriggers  == null) {
+                    throw new RuntimeException("deleteTagsTriggers PreparedStatement is null");
+                }
                 session.execute(deleteTagsTriggers.bind(tag.getTenantId(), tag.getName()));
             }
         }
@@ -1683,6 +1449,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectConditionId = CassStatement.get(session, CassStatement.SELECT_CONDITION_ID);
         if (selectConditionId == null) {
             throw new RuntimeException("selectConditionId PreparedStatement is null");
         }
@@ -1714,6 +1481,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectTriggerConditions = CassStatement.get(session, CassStatement.SELECT_TRIGGER_CONDITIONS);
+        PreparedStatement selectTriggerConditionsTriggerMode = CassStatement.get(session,
+                CassStatement.SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE);
         if (selectTriggerConditions == null || selectTriggerConditionsTriggerMode == null) {
             throw new RuntimeException("selectTriggerConditions* PreparedStatement is null");
         }
@@ -1740,6 +1510,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllConditions = CassStatement.get(session, CassStatement.SELECT_ALL_CONDITIONS);
         if (selectAllConditions == null) {
             throw new RuntimeException("selectAllConditions PreparedStatement is null");
         }
@@ -1762,6 +1533,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllConditionsByTenant = CassStatement.get(session,
+                CassStatement.SELECT_ALL_CONDITIONS_BY_TENANT);
         if (selectAllConditionsByTenant == null) {
             throw new RuntimeException("selectAllConditionsByTenant PreparedStatement is null");
         }
@@ -1870,6 +1643,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement insertActionPlugin = CassStatement.get(session, CassStatement.INSERT_ACTION_PLUGIN);
         if (insertActionPlugin == null) {
             throw new RuntimeException("insertActionPlugin PreparedStatement is null");
         }
@@ -1889,6 +1663,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement deleteActionPlugin = CassStatement.get(session, CassStatement.DELETE_ACTION_PLUGIN);
         if (deleteActionPlugin == null) {
             throw new RuntimeException("deleteActionPlugin PreparedStatement is null");
         }
@@ -1911,6 +1686,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement updateActionPlugin = CassStatement.get(session, CassStatement.UPDATE_ACTION_PLUGIN);
         if (updateActionPlugin == null) {
             throw new RuntimeException("updateActionPlugin PreparedStatement is null");
         }
@@ -1927,6 +1703,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectActionPlugins = CassStatement.get(session, CassStatement.SELECT_ACTION_PLUGINS);
         if (selectActionPlugins == null) {
             throw new RuntimeException("selectActionPlugins PreparedStatement is null");
         }
@@ -1951,6 +1728,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectActionPlugin = CassStatement.get(session, CassStatement.SELECT_ACTION_PLUGIN);
         if (selectActionPlugin == null) {
             throw new RuntimeException("selectActionPlugin PreparedStatement is null");
         }
@@ -1983,6 +1761,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement deleteAction = CassStatement.get(session, CassStatement.DELETE_ACTION);
         if (deleteAction == null) {
             throw new RuntimeException("deleteAction PreparedStatement is null");
         }
@@ -2015,6 +1794,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement updateAction = CassStatement.get(session, CassStatement.UPDATE_ACTION);
         if (updateAction == null) {
             throw new RuntimeException("updateAction PreparedStatement is null");
         }
@@ -2031,6 +1811,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllActions = CassStatement.get(session, CassStatement.SELECT_ALL_ACTIONS);
         if (selectAllActions == null) {
             throw new RuntimeException("selectAllActions PreparedStatement is null");
         }
@@ -2064,6 +1845,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAllActionsByTenant = CassStatement.get(session,
+                CassStatement.SELECT_ALL_ACTIONS_BY_TENANT);
         if (selectAllActionsByTenant == null) {
             throw new RuntimeException("selectAllActionsByTenant PreparedStatement is null");
         }
@@ -2096,6 +1879,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectActionsPlugin = CassStatement.get(session, CassStatement.SELECT_ACTIONS_PLUGIN);
         if (selectActionsPlugin == null) {
             throw new RuntimeException("selectActionsPlugin PreparedStatement is null");
         }
@@ -2126,6 +1910,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (session == null) {
             throw new RuntimeException("Cassandra session is null");
         }
+        PreparedStatement selectAction = CassStatement.get(session, CassStatement.SELECT_ACTION);
         if (selectAction == null) {
             throw new RuntimeException("selectAction PreparedStatement is null");
         }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -36,82 +36,117 @@ public class CassStatement {
 
     private static final Map<String, PreparedStatement> statementMap = new HashMap<>();
 
+    public static final String DELETE_ACTION;
+    public static final String DELETE_ACTION_PLUGIN;
     public static final String DELETE_ALERT_STATUS;
+    public static final String DELETE_CONDITIONS;
+    public static final String DELETE_CONDITIONS_MODE;
+    public static final String DELETE_DAMPENING_ID;
+    public static final String DELETE_DAMPENINGS;
+    public static final String DELETE_TAGS;
+    public static final String DELETE_TAGS_BY_NAME;
+    public static final String DELETE_TAGS_TRIGGERS;
+    public static final String DELETE_TRIGGER_ACTIONS;
+    public static final String DELETE_TRIGGERS;
+
+    public static final String INSERT_ACTION;
+    public static final String INSERT_ACTION_PLUGIN;
     public static final String INSERT_ALERT;
     public static final String INSERT_ALERT_TRIGGER;
     public static final String INSERT_ALERT_CTIME;
     public static final String INSERT_ALERT_STATUS;
+    public static final String INSERT_CONDITION_AVAILABILITY;
+    public static final String INSERT_CONDITION_COMPARE;
+    public static final String INSERT_CONDITION_STRING;
+    public static final String INSERT_CONDITION_THRESHOLD;
+    public static final String INSERT_CONDITION_THRESHOLD_RANGE;
+    public static final String INSERT_DAMPENING;
+    public static final String INSERT_TAG;
+    public static final String INSERT_TAGS_TRIGGERS;
+    public static final String INSERT_TRIGGER;
+    public static final String INSERT_TRIGGER_ACTIONS;
+
+    public static final String SELECT_ACTION;
+    public static final String SELECT_ACTIONS_ALL;
+    public static final String SELECT_ACTIONS_BY_TENANT;
+    public static final String SELECT_ACTION_PLUGIN;
+    public static final String SELECT_ACTION_PLUGINS;
+    public static final String SELECT_ACTIONS_PLUGIN;
+    public static final String SELECT_ALERT_CTIME_END;
+    public static final String SELECT_ALERT_CTIME_START;
+    public static final String SELECT_ALERT_CTIME_START_END;
     public static final String SELECT_ALERT_STATUS;
+    public static final String SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS;
     public static final String SELECT_ALERTS_BY_TENANT;
     public static final String SELECT_ALERTS_BY_TENANT_AND_ALERT;
     public static final String SELECT_ALERTS_TRIGGERS;
-    public static final String SELECT_ALERT_CTIME_START_END;
-    public static final String SELECT_ALERT_CTIME_START;
-    public static final String SELECT_ALERT_CTIME_END;
-    public static final String SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS;
-    public static final String SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME;
+    public static final String SELECT_CONDITION_ID;
+    public static final String SELECT_CONDITIONS_ALL;
+    public static final String SELECT_CONDITIONS_TENANT;
+    public static final String SELECT_DAMPENING_ID;
+    public static final String SELECT_DAMPENINGS_ALL;
+    public static final String SELECT_DAMPENINGS_TENANT;
+    public static final String SELECT_TAGS;
+    public static final String SELECT_TAGS_BY_CATEGORY;
+    public static final String SELECT_TAGS_BY_CATEGORY_AND_NAME;
+    public static final String SELECT_TAGS_BY_NAME;
     public static final String SELECT_TAGS_TRIGGERS_BY_CATEGORY;
+    public static final String SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME;
     public static final String SELECT_TAGS_TRIGGERS_BY_NAME;
-    public static final String UPDATE_ALERT;
-
-    public static final String INSERT_TRIGGER;
-    public static final String INSERT_TRIGGER_ACTIONS;
+    public static final String SELECT_TRIGGER;
+    public static final String SELECT_TRIGGER_ACTIONS;
     public static final String SELECT_TRIGGER_CONDITIONS;
     public static final String SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE;
-    public static final String DELETE_CONDITIONS_MODE;
-    public static final String INSERT_AVAILABILITY_CONDITION;
-    public static final String INSERT_COMPARE_CONDITION;
-    public static final String INSERT_STRING_CONDITION;
-    public static final String INSERT_THRESHOLD_CONDITION;
-    public static final String INSERT_THRESHOLD_RANGE_CONDITION;
-    public static final String INSERT_TAG;
-    public static final String INSERT_DAMPENING;
-    public static final String INSERT_ACTION;
-    public static final String SELECT_ALL_TRIGGERS;
-    public static final String SELECT_TRIGGER_ACTIONS;
-    public static final String SELECT_TENANT_TRIGGERS;
-    public static final String SELECT_ALL_CONDITIONS;
-    public static final String SELECT_ALL_CONDITIONS_BY_TENANT;
-    public static final String SELECT_ALL_DAMPENINGS;
-    public static final String SELECT_ALL_DAMPENINGS_BY_TENANT;
-    public static final String SELECT_ALL_ACTIONS;
-    public static final String SELECT_ALL_ACTIONS_BY_TENANT;
-    public static final String SELECT_TRIGGER;
     public static final String SELECT_TRIGGER_DAMPENINGS;
     public static final String SELECT_TRIGGER_DAMPENINGS_MODE;
-    public static final String DELETE_DAMPENINGS;
-    public static final String DELETE_CONDITIONS;
-    public static final String DELETE_TRIGGERS;
-    public static final String UPDATE_TRIGGER;
-    public static final String DELETE_TRIGGER_ACTIONS;
-    public static final String DELETE_DAMPENING_ID;
-    public static final String SELECT_DAMPENING_ID;
-    public static final String UPDATE_DAMPENING_ID;
-    public static final String SELECT_CONDITION_ID;
-    public static final String INSERT_ACTION_PLUGIN;
-    public static final String DELETE_ACTION_PLUGIN;
-    public static final String UPDATE_ACTION_PLUGIN;
-    public static final String SELECT_ACTION_PLUGINS;
-    public static final String SELECT_ACTION_PLUGIN;
-    public static final String DELETE_ACTION;
+    public static final String SELECT_TRIGGERS_ALL;
+    public static final String SELECT_TRIGGERS_TENANT;
+
     public static final String UPDATE_ACTION;
-    public static final String SELECT_ACTIONS_PLUGIN;
-    public static final String SELECT_ACTION;
-    public static final String INSERT_TAGS_TRIGGERS;
+    public static final String UPDATE_ACTION_PLUGIN;
+    public static final String UPDATE_ALERT;
+    public static final String UPDATE_DAMPENING_ID;
     public static final String UPDATE_TAGS_TRIGGERS;
-    public static final String DELETE_TAGS_TRIGGERS;
-    public static final String SELECT_TAGS;
-    public static final String SELECT_TAGS_BY_CATEGORY_AND_NAME;
-    public static final String SELECT_TAGS_BY_CATEGORY;
-    public static final String SELECT_TAGS_BY_NAME;
-    public static final String DELETE_TAGS;
-    public static final String DELETE_TAGS_BY_NAME;
+    public static final String UPDATE_TRIGGER;
 
     static {
         keyspace = AlertProperties.getProperty(CASSANDRA_KEYSPACE, "hawkular_alerts");
 
+        DELETE_ACTION = "DELETE FROM " + keyspace + ".actions "
+                + "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
+
+        DELETE_ACTION_PLUGIN = "DELETE FROM " + keyspace + ".action_plugins WHERE actionPlugin = ? ";
+
         DELETE_ALERT_STATUS = "DELETE FROM " + keyspace + ".alerts_statuses "
                 + "WHERE tenantId = ? AND status = ? AND alertId = ? ";
+
+        DELETE_CONDITIONS = "DELETE FROM " + keyspace + ".conditions " + "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_CONDITIONS_MODE = "DELETE FROM " + keyspace + ".conditions "
+                + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
+
+        DELETE_DAMPENING_ID = "DELETE FROM " + keyspace + ".dampenings "
+                + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
+
+        DELETE_DAMPENINGS = "DELETE FROM " + keyspace + ".dampenings " + "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_TAGS = "DELETE FROM " + keyspace + ".tags WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_TAGS_BY_NAME = "DELETE FROM " + keyspace + ".tags "
+                + "WHERE tenantId = ? AND triggerId = ? AND name = ?";
+
+        DELETE_TAGS_TRIGGERS = "DELETE FROM " + keyspace + ".tags_triggers " + "WHERE tenantId = ? AND name = ? ";
+
+        DELETE_TRIGGER_ACTIONS = "DELETE FROM " + keyspace + ".triggers_actions "
+                + "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_TRIGGERS = "DELETE FROM " + keyspace + ".triggers " + "WHERE tenantId = ? AND id = ? ";
+
+        INSERT_ACTION = "INSERT INTO " + keyspace + ".actions "
+                + "(tenantId, actionPlugin, actionId, properties) VALUES (?, ?, ?, ?) ";
+
+        INSERT_ACTION_PLUGIN = "INSERT INTO " + keyspace + ".action_plugins "
+                + "(actionPlugin, properties) VALUES (?, ?) ";
 
         INSERT_ALERT = "INSERT INTO " + keyspace + ".alerts " + "(tenantId, alertId, payload) VALUES (?, ?, ?) ";
 
@@ -124,234 +159,198 @@ public class CassStatement {
         INSERT_ALERT_STATUS = "INSERT INTO " + keyspace + ".alerts_statuses "
                 + "(tenantId, alertId, status) VALUES (?, ?, ?) ";
 
+        INSERT_CONDITION_AVAILABILITY = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
+                + "dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?) ";
+
+        INSERT_CONDITION_COMPARE = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
+                + "dataId, operator, data2Id, data2Multiplier) VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_CONDITION_STRING = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
+                + "dataId, operator, pattern, ignoreCase) VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_CONDITION_THRESHOLD = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
+                + "dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_CONDITION_THRESHOLD_RANGE = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
+                + "dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) "
+                + "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_DAMPENING = "INSERT INTO " + keyspace + ".dampenings "
+                + "(triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting, "
+                + "dampeningId, tenantId) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_TAG = "INSERT INTO " + keyspace + ".tags "
+                + "(tenantId, triggerId, category, name, visible) VALUES (?, ?, ?, ?, ?) ";
+
+        INSERT_TAGS_TRIGGERS = "INSERT INTO " + keyspace + ".tags_triggers "
+                + "(tenantId, category, name, triggers) VALUES (?, ?, ?, ?) ";
+
+        INSERT_TRIGGER = "INSERT INTO " + keyspace + ".triggers " +
+                "(name, description, autoDisable, autoResolve, autoResolveAlerts, firingMatch, " +
+                "autoResolveMatch, id, enabled, tenantId) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_TRIGGER_ACTIONS = "INSERT INTO " + keyspace + ".triggers_actions "
+                + "(tenantId, triggerId, actionPlugin, actions) VALUES (?, ?, ?, ?) ";
+
+        SELECT_ACTION = "SELECT properties FROM " + keyspace + ".actions "
+                + "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
+
+        SELECT_ACTIONS_ALL = "SELECT tenantId, actionPlugin, actionId " + "FROM " + keyspace + ".actions ";
+
+        SELECT_ACTIONS_BY_TENANT = "SELECT actionPlugin, actionId " + "FROM " + keyspace + ".actions "
+                + "WHERE tenantId = ? ";
+
+        SELECT_ACTION_PLUGIN = "SELECT properties FROM " + keyspace + ".action_plugins " + "WHERE actionPlugin = ? ";
+
+        SELECT_ACTION_PLUGINS = "SELECT actionPlugin FROM " + keyspace + ".action_plugins";
+
+        SELECT_ACTIONS_PLUGIN = "SELECT actionId FROM " + keyspace + ".actions "
+                + "WHERE tenantId = ? AND actionPlugin = ? ";
+
+        SELECT_ALERT_CTIME_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime <= ? ";
+
+        SELECT_ALERT_CTIME_START = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime >= ? ";
+
+        SELECT_ALERT_CTIME_START_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime >= ? AND ctime <= ? ";
+
         SELECT_ALERT_STATUS = "SELECT alertId, status FROM " + keyspace + ".alerts_statuses "
                 + "WHERE tenantId = ? AND status = ? AND alertId = ? ";
+
+        SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS = "SELECT alertId FROM " + keyspace + ".alerts_statuses "
+                + "WHERE tenantId = ? AND status = ? ";
 
         SELECT_ALERTS_BY_TENANT = "SELECT payload FROM " + keyspace + ".alerts " + "WHERE tenantId = ? ";
 
         SELECT_ALERTS_BY_TENANT_AND_ALERT = "SELECT payload FROM " + keyspace + ".alerts "
                 + "WHERE tenantId = ? AND alertId = ? ";
 
-        SELECT_ALERTS_TRIGGERS = "SELECT alertId FROM " + keyspace + ".alerts_triggers " + "WHERE tenantId = ? AND "
-                + "triggerId = ? ";
+        SELECT_ALERTS_TRIGGERS = "SELECT alertId FROM " + keyspace + ".alerts_triggers "
+                + "WHERE tenantId = ? AND triggerId = ? ";
 
-        SELECT_ALERT_CTIME_START_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
-                + "WHERE tenantId = ? AND ctime >= ? AND ctime <= ? ";
+        SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+                + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "FROM " + keyspace + ".conditions "
+                + "WHERE tenantId = ? AND conditionId = ? ";
 
-        SELECT_ALERT_CTIME_START = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
-                + "WHERE tenantId = ? AND ctime >= ? ";
+        SELECT_CONDITIONS_ALL = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+                + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "FROM " + keyspace + ".conditions ";
 
-        SELECT_ALERT_CTIME_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
-                + "WHERE tenantId = ? AND ctime <= ? ";
+        SELECT_CONDITIONS_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+                + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "FROM " + keyspace + ".conditions "
+                + "WHERE tenantId = ? ";
 
-        SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS = "SELECT alertId FROM " + keyspace + ""
-                + ".alerts_statuses WHERE tenantId = ? AND status = ? ";
+        SELECT_DAMPENING_ID = "SELECT triggerId, triggerMode, type, evalTrueSetting, "
+                + "evalTotalSetting, evalTimeSetting, dampeningId, tenantId "
+                + "FROM " + keyspace + ".dampenings "
+                + "WHERE tenantId = ? AND dampeningId = ? ";
 
-        SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME = "SELECT triggers FROM " + keyspace + ""
-                + ".tags_triggers WHERE tenantId = ? AND category = ? AND name = ? ";
+        SELECT_DAMPENINGS_ALL = "SELECT tenantId, triggerId, triggerMode, type, evalTrueSetting, "
+                + "evalTotalSetting, evalTimeSetting, dampeningId "
+                + "FROM " + keyspace + ".dampenings ";
+
+        SELECT_DAMPENINGS_TENANT = "SELECT tenantId, triggerId, triggerMode, type, " + "evalTrueSetting, "
+                + "evalTotalSetting, evalTimeSetting, dampeningId "
+                + "FROM " + keyspace + ".dampenings "
+                + "WHERE tenantId = ? ";
+
+        SELECT_TAGS = "SELECT tenantId, triggerId, category, name, visible "
+                + "FROM " + keyspace + ".tags "
+                + "WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, name ";
+
+        SELECT_TAGS_BY_CATEGORY = "SELECT tenantId, triggerId, category, name, visible "
+                + "FROM " + keyspace + ".tags "
+                + "WHERE tenantId = ? AND triggerId = ? AND category = ? ";
+
+        SELECT_TAGS_BY_CATEGORY_AND_NAME = "SELECT tenantId, triggerId, category, name, visible "
+                + "FROM " + keyspace + ".tags "
+                + "WHERE tenantId = ? AND triggerId = ? AND category = ? AND name = ? ";
+
+        SELECT_TAGS_BY_NAME = "SELECT tenantId, triggerId, category, name, visible "
+                + "FROM " + keyspace + ".tags "
+                + "WHERE tenantId = ? AND triggerId = ? AND name = ? ";
 
         SELECT_TAGS_TRIGGERS_BY_CATEGORY = "SELECT triggers FROM " + keyspace + ""
                 + ".tags_triggers WHERE tenantId = ? AND category = ? ";
 
-        SELECT_TAGS_TRIGGERS_BY_NAME = "SELECT triggers FROM " + keyspace + ""
-                + ".tags_triggers WHERE tenantId = ? AND name = ? ";
+        SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME = "SELECT triggers "
+                + "FROM " + keyspace + ".tags_triggers "
+                + "WHERE tenantId = ? AND category = ? AND name = ? ";
 
-        UPDATE_ALERT = "UPDATE " + keyspace + ".alerts " + "SET payload = ? WHERE tenantId = ? AND alertId = ? ";
+        SELECT_TAGS_TRIGGERS_BY_NAME = "SELECT triggers "
+                + "FROM " + keyspace + ".tags_triggers "
+                + "WHERE tenantId = ? AND name = ? ";
 
-        INSERT_TRIGGER = "INSERT INTO " + keyspace + ".triggers " +
-                "(name, description, autoDisable, autoResolve, autoResolveAlerts, firingMatch, " +
-                "autoResolveMatch, id, enabled, tenantId) " +
-                "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+        SELECT_TRIGGER = "SELECT name, description, autoDisable, autoResolve, "
+                + "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId "
+                + "FROM " + keyspace + ".triggers "
+                + "WHERE tenantId = ? AND id = ? ";
 
-        INSERT_TRIGGER_ACTIONS = "INSERT INTO " + keyspace + ".triggers_actions " +
-                "(tenantId, triggerId, actionPlugin, actions) VALUES (?, ?, ?, ?) ";
+        SELECT_TRIGGER_ACTIONS = "SELECT tenantId, triggerId, actionPlugin, actions "
+                + "FROM " + keyspace + ".triggers_actions "
+                + "WHERE tenantId = ? AND triggerId = ? ";
 
-        SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId"
-                +
-                " FROM " + keyspace + ".conditions " +
-                "WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, triggerMode, type";
+        SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+                + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "FROM " + keyspace + ".conditions "
+                + "WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, triggerMode, type";
 
-        SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, " +
-                "conditionSetSize, conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, " +
-                "pattern, ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange,"
-                +
-                " tenantId " +
-                "FROM " + keyspace + ".conditions " +
-                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? " +
-                "ORDER BY triggerId, triggerMode, type";
+        SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+                + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, ignoreCase, "
+                + "threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "FROM " + keyspace + ".conditions "
+                + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? "
+                + "ORDER BY triggerId, triggerMode, type";
 
-        DELETE_CONDITIONS_MODE = "DELETE FROM " + keyspace + ".conditions " +
-                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
+        SELECT_TRIGGER_DAMPENINGS = "SELECT tenantId, triggerId, triggerMode, type, "
+                + "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId "
+                + "FROM " + keyspace + ".dampenings "
+                + "WHERE tenantId = ? AND triggerId = ? ";
 
-        INSERT_AVAILABILITY_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
-                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                "dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?) ";
+        SELECT_TRIGGER_DAMPENINGS_MODE = "SELECT tenantId, triggerId, triggerMode, type, "
+                + "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId "
+                + "FROM " + keyspace + ".dampenings "
+                + "WHERE tenantId = ? AND triggerId = ? and triggerMode = ? ";
 
-        INSERT_COMPARE_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
-                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                "dataId, operator, data2Id, data2Multiplier) VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?) ";
+        SELECT_TRIGGERS_ALL = "SELECT name, description, autoDisable, autoResolve, "
+                + "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId "
+                + "FROM " + keyspace + ".triggers ";
 
-        INSERT_STRING_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
-                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                "dataId, operator, pattern, ignoreCase) VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?) ";
+        SELECT_TRIGGERS_TENANT = "SELECT name, description, autoDisable, autoResolve, "
+                + "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId "
+                + "FROM " + keyspace + ".triggers WHERE tenantId = ? ";
 
-        INSERT_THRESHOLD_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
-                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                "dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?) ";
+        UPDATE_ACTION = "UPDATE " + keyspace + ".actions SET properties = ? "
+                + "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
 
-        INSERT_THRESHOLD_RANGE_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
-                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
-                "dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) " +
-                "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+        UPDATE_ACTION_PLUGIN = "UPDATE " + keyspace + ".action_plugins SET properties = ? WHERE actionPlugin = ? ";
 
-        INSERT_TAG = "INSERT INTO " + keyspace + ".tags " +
-                "(tenantId, triggerId, category, name, visible) VALUES (?, ?, ?, ?, ?) ";
+        UPDATE_ALERT = "UPDATE " + keyspace + ".alerts SET payload = ? WHERE tenantId = ? AND alertId = ? ";
 
-        INSERT_DAMPENING = "INSERT INTO " + keyspace + ".dampenings " +
-                "(triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting, " +
-                "dampeningId, tenantId) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ";
+        UPDATE_DAMPENING_ID = "UPDATE " + keyspace + ".dampenings "
+                + "SET type = ?, evalTrueSetting = ?, evalTotalSetting = ?, evalTimeSetting = ? "
+                + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
 
-        INSERT_ACTION = "INSERT INTO " + keyspace + ".actions " +
-                "(tenantId, actionPlugin, actionId, properties) VALUES (?, ?, ?, ?) ";
+        UPDATE_TAGS_TRIGGERS = "UPDATE " + keyspace + ".tags_triggers SET triggers = ? "
+                + "WHERE tenantId = ? AND name = ? ";
 
-        SELECT_ALL_TRIGGERS = "SELECT name, description, autoDisable, autoResolve, " +
-                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                "FROM " + keyspace + ".triggers ";
+        UPDATE_TRIGGER = "UPDATE " + keyspace + ".triggers "
+                + "SET name = ?, description = ?, autoDisable = ?, autoResolve = ?, autoResolveAlerts = ?, "
+                + "firingMatch = ?, autoResolveMatch = ?, enabled = ? " + "WHERE tenantId = ? AND id = ? ";
 
-        SELECT_TRIGGER_ACTIONS = "SELECT tenantId, triggerId, actionPlugin, actions " +
-                "FROM " + keyspace + ".triggers_actions " +
-                "WHERE tenantId = ? AND triggerId = ? ";
-
-        SELECT_TENANT_TRIGGERS = "SELECT name, description, autoDisable, autoResolve, " +
-                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                "FROM " + keyspace + ".triggers WHERE tenantId = ? ";
-
-        SELECT_ALL_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
-                "tenantId FROM " + keyspace + ".conditions ";
-
-        SELECT_ALL_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
-                "tenantId FROM " + keyspace + ".conditions WHERE tenantId = ? ";
-
-        SELECT_ALL_DAMPENINGS = "SELECT tenantId, triggerId, triggerMode, type, evalTrueSetting, " +
-                "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings ";
-
-        SELECT_ALL_DAMPENINGS_BY_TENANT = "SELECT tenantId, triggerId, triggerMode, type, " +
-                "evalTrueSetting, " +
-                "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? ";
-
-        SELECT_ALL_ACTIONS = "SELECT tenantId, actionPlugin, actionId " +
-                "FROM " + keyspace + ".actions ";
-
-        SELECT_ALL_ACTIONS_BY_TENANT = "SELECT actionPlugin, actionId " +
-                "FROM " + keyspace + ".actions WHERE tenantId = ? ";
-
-        SELECT_TRIGGER = "SELECT name, description, autoDisable, autoResolve, " +
-                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
-                "FROM " + keyspace + ".triggers WHERE tenantId = ? AND id = ? ";
-
-        SELECT_TRIGGER_DAMPENINGS = "SELECT tenantId, triggerId, triggerMode, type, " +
-                "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
-                "FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? AND triggerId = ? ";
-
-        SELECT_TRIGGER_DAMPENINGS_MODE = "SELECT tenantId, triggerId, triggerMode, type, " +
-                "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
-                "FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? AND triggerId = ? and triggerMode = ? ";
-
-        DELETE_DAMPENINGS = "DELETE FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? AND triggerId = ? ";
-
-        DELETE_CONDITIONS = "DELETE FROM " + keyspace + ".conditions " +
-                "WHERE tenantId = ? AND triggerId = ? ";
-
-        DELETE_TRIGGERS = "DELETE FROM " + keyspace + ".triggers " +
-                "WHERE tenantId = ? AND id = ? ";
-
-        UPDATE_TRIGGER = "UPDATE " + keyspace + ".triggers " +
-                "SET name = ?, description = ?, autoDisable = ?, autoResolve = ?, autoResolveAlerts = ?, " +
-                "firingMatch = ?, autoResolveMatch = ?, enabled = ? " +
-                "WHERE tenantId = ? AND id = ? ";
-
-        DELETE_TRIGGER_ACTIONS = "DELETE FROM " + keyspace + ".triggers_actions " +
-                "WHERE tenantId = ? AND triggerId = ? ";
-
-        DELETE_DAMPENING_ID = "DELETE FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
-
-        SELECT_DAMPENING_ID = "SELECT triggerId, triggerMode, type, evalTrueSetting, " +
-                "evalTotalSetting, evalTimeSetting, dampeningId, tenantId FROM " + keyspace + ".dampenings " +
-                "WHERE tenantId = ? AND dampeningId = ? ";
-
-        UPDATE_DAMPENING_ID = "UPDATE " + keyspace + ".dampenings " +
-                "SET type = ?, evalTrueSetting = ?, evalTotalSetting = ?, evalTimeSetting = ? " +
-                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
-
-        SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
-                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
-                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, " +
-                "tenantId " +
-                "FROM " + keyspace + ".conditions WHERE tenantId = ? AND conditionId = ? ";
-
-        INSERT_ACTION_PLUGIN = "INSERT INTO " + keyspace + ".action_plugins (actionPlugin, " +
-                "properties) VALUES (?, ?) ";
-
-        DELETE_ACTION_PLUGIN = "DELETE FROM " + keyspace + ".action_plugins WHERE actionPlugin = ? ";
-
-        UPDATE_ACTION_PLUGIN = "UPDATE " + keyspace + ".action_plugins " +
-                "SET properties = ? WHERE actionPlugin = ? ";
-
-        SELECT_ACTION_PLUGINS = "SELECT actionPlugin FROM " + keyspace + ".action_plugins";
-
-        SELECT_ACTION_PLUGIN = "SELECT properties FROM " + keyspace + ".action_plugins " +
-                "WHERE actionPlugin = ? ";
-
-        DELETE_ACTION = "DELETE FROM " + keyspace + ".actions " +
-                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
-
-        UPDATE_ACTION = "UPDATE " + keyspace + ".actions " +
-                "SET properties = ? " +
-                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
-
-        SELECT_ACTIONS_PLUGIN = "SELECT actionId FROM " + keyspace + ".actions " +
-                "WHERE tenantId = ? AND actionPlugin = ? ";
-
-        SELECT_ACTION = "SELECT properties FROM " + keyspace + ".actions " +
-                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
-
-        INSERT_TAGS_TRIGGERS = "INSERT INTO " + keyspace + ".tags_triggers " +
-                "(tenantId, category, name, triggers) VALUES (?, ?, ?, ?) ";
-
-        UPDATE_TAGS_TRIGGERS = "UPDATE " + keyspace + ".tags_triggers " +
-                "SET triggers = ? " +
-                "WHERE tenantId = ? AND name = ? ";
-
-        DELETE_TAGS_TRIGGERS = "DELETE FROM " + keyspace + ".tags_triggers " +
-                "WHERE tenantId = ? AND name = ? ";
-
-        SELECT_TAGS = "SELECT tenantId, triggerId, category, name, visible FROM " + keyspace +
-                ".tags WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, name ";
-
-        SELECT_TAGS_BY_CATEGORY_AND_NAME = "SELECT tenantId, triggerId, category, name, visible FROM " +
-                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? AND name = ? ";
-
-        SELECT_TAGS_BY_CATEGORY = "SELECT tenantId, triggerId, category, name, visible FROM " +
-                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? ";
-
-        SELECT_TAGS_BY_NAME = "SELECT tenantId, triggerId, category, name, visible FROM " +
-                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND name = ? ";
-
-        DELETE_TAGS = "DELETE FROM " + keyspace + ".tags WHERE tenantId = ? AND triggerId = ? ";
-
-        DELETE_TAGS_BY_NAME = "DELETE FROM " + keyspace + ".tags " +
-                "WHERE tenantId = ? AND triggerId = ? AND name = ?";
     }
 
     public static synchronized PreparedStatement get(Session session, String statement) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -82,10 +82,10 @@ public class CassStatement {
     public static final String SELECT_ALERTS_TRIGGERS;
     public static final String SELECT_CONDITION_ID;
     public static final String SELECT_CONDITIONS_ALL;
-    public static final String SELECT_CONDITIONS_TENANT;
+    public static final String SELECT_CONDITIONS_BY_TENANT;
     public static final String SELECT_DAMPENING_ID;
     public static final String SELECT_DAMPENINGS_ALL;
-    public static final String SELECT_DAMPENINGS_TENANT;
+    public static final String SELECT_DAMPENINGS_BY_TENANT;
     public static final String SELECT_TAGS;
     public static final String SELECT_TAGS_BY_CATEGORY;
     public static final String SELECT_TAGS_BY_CATEGORY_AND_NAME;
@@ -246,7 +246,7 @@ public class CassStatement {
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
                 + "FROM " + keyspace + ".conditions ";
 
-        SELECT_CONDITIONS_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
+        SELECT_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
                 + "FROM " + keyspace + ".conditions "
@@ -261,7 +261,7 @@ public class CassStatement {
                 + "evalTotalSetting, evalTimeSetting, dampeningId "
                 + "FROM " + keyspace + ".dampenings ";
 
-        SELECT_DAMPENINGS_TENANT = "SELECT tenantId, triggerId, triggerMode, type, " + "evalTrueSetting, "
+        SELECT_DAMPENINGS_BY_TENANT = "SELECT tenantId, triggerId, triggerMode, type, " + "evalTrueSetting, "
                 + "evalTotalSetting, evalTimeSetting, dampeningId "
                 + "FROM " + keyspace + ".dampenings "
                 + "WHERE tenantId = ? ";

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+/**
+ * PreparedStatements need to be prepared only one time for the Datastax driver.  Avoid overhead and warnings by
+ * caching the PreparedStatements in one place.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class CassStatement {
+    private static final String CASSANDRA_KEYSPACE = "hawkular-alerts.cassandra-keyspace";
+
+    private static final String keyspace;
+
+    private static final Map<String, PreparedStatement> statementMap = new HashMap<>();
+
+    public static final String DELETE_ALERT_STATUS;
+    public static final String INSERT_ALERT;
+    public static final String INSERT_ALERT_TRIGGER;
+    public static final String INSERT_ALERT_CTIME;
+    public static final String INSERT_ALERT_STATUS;
+    public static final String SELECT_ALERT_STATUS;
+    public static final String SELECT_ALERTS_BY_TENANT;
+    public static final String SELECT_ALERTS_BY_TENANT_AND_ALERT;
+    public static final String SELECT_ALERTS_TRIGGERS;
+    public static final String SELECT_ALERT_CTIME_START_END;
+    public static final String SELECT_ALERT_CTIME_START;
+    public static final String SELECT_ALERT_CTIME_END;
+    public static final String SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS;
+    public static final String SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME;
+    public static final String SELECT_TAGS_TRIGGERS_BY_CATEGORY;
+    public static final String SELECT_TAGS_TRIGGERS_BY_NAME;
+    public static final String UPDATE_ALERT;
+
+    static {
+        keyspace = AlertProperties.getProperty(CASSANDRA_KEYSPACE, "hawkular_alerts");
+
+        DELETE_ALERT_STATUS = "DELETE FROM " + keyspace + ".alerts_statuses "
+                + "WHERE tenantId = ? AND status = ? AND alertId = ? ";
+
+        INSERT_ALERT = "INSERT INTO " + keyspace + ".alerts " + "(tenantId, alertId, payload) VALUES (?, ?, ?) ";
+
+        INSERT_ALERT_TRIGGER = "INSERT INTO " + keyspace + ".alerts_triggers "
+                + "(tenantId, alertId, triggerId) VALUES (?, ?, ?) ";
+
+        INSERT_ALERT_CTIME = "INSERT INTO " + keyspace + ".alerts_ctimes "
+                + "(tenantId, alertId, ctime) VALUES (?, ?, ?) ";
+
+        INSERT_ALERT_STATUS = "INSERT INTO " + keyspace + ".alerts_statuses "
+                + "(tenantId, alertId, status) VALUES (?, ?, ?) ";
+
+        SELECT_ALERT_STATUS = "SELECT alertId, status FROM " + keyspace + ".alerts_statuses "
+                + "WHERE tenantId = ? AND status = ? AND alertId = ? ";
+
+        SELECT_ALERTS_BY_TENANT = "SELECT payload FROM " + keyspace + ".alerts " + "WHERE tenantId = ? ";
+
+        SELECT_ALERTS_BY_TENANT_AND_ALERT = "SELECT payload FROM " + keyspace + ".alerts "
+                + "WHERE tenantId = ? AND alertId = ? ";
+
+        SELECT_ALERTS_TRIGGERS = "SELECT alertId FROM " + keyspace + ".alerts_triggers " + "WHERE tenantId = ? AND "
+                + "triggerId = ? ";
+
+        SELECT_ALERT_CTIME_START_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime >= ? AND ctime <= ? ";
+
+        SELECT_ALERT_CTIME_START = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime >= ? ";
+
+        SELECT_ALERT_CTIME_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
+                + "WHERE tenantId = ? AND ctime <= ? ";
+
+        SELECT_ALERT_STATUS_BY_TENANT_AND_STATUS = "SELECT alertId FROM " + keyspace + ""
+                + ".alerts_statuses WHERE tenantId = ? AND status = ? ";
+
+        SELECT_TAGS_TRIGGERS_BY_CATEGORY_AND_NAME = "SELECT triggers FROM " + keyspace + ""
+                + ".tags_triggers WHERE tenantId = ? AND category = ? AND name = ? ";
+
+        SELECT_TAGS_TRIGGERS_BY_CATEGORY = "SELECT triggers FROM " + keyspace + ""
+                + ".tags_triggers WHERE tenantId = ? AND category = ? ";
+
+        SELECT_TAGS_TRIGGERS_BY_NAME = "SELECT triggers FROM " + keyspace + ""
+                + ".tags_triggers WHERE tenantId = ? AND name = ? ";
+
+        UPDATE_ALERT = "UPDATE " + keyspace + ".alerts " + "SET payload = ? WHERE tenantId = ? AND alertId = ? ";
+    }
+
+    public static synchronized PreparedStatement get(Session session, String statement) {
+        PreparedStatement result = statementMap.get(statement);
+        if (null == result) {
+            result = session.prepare(statement);
+            statementMap.put(statement, result);
+        }
+        return result;
+    }
+}

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -54,6 +54,59 @@ public class CassStatement {
     public static final String SELECT_TAGS_TRIGGERS_BY_NAME;
     public static final String UPDATE_ALERT;
 
+    public static final String INSERT_TRIGGER;
+    public static final String INSERT_TRIGGER_ACTIONS;
+    public static final String SELECT_TRIGGER_CONDITIONS;
+    public static final String SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE;
+    public static final String DELETE_CONDITIONS_MODE;
+    public static final String INSERT_AVAILABILITY_CONDITION;
+    public static final String INSERT_COMPARE_CONDITION;
+    public static final String INSERT_STRING_CONDITION;
+    public static final String INSERT_THRESHOLD_CONDITION;
+    public static final String INSERT_THRESHOLD_RANGE_CONDITION;
+    public static final String INSERT_TAG;
+    public static final String INSERT_DAMPENING;
+    public static final String INSERT_ACTION;
+    public static final String SELECT_ALL_TRIGGERS;
+    public static final String SELECT_TRIGGER_ACTIONS;
+    public static final String SELECT_TENANT_TRIGGERS;
+    public static final String SELECT_ALL_CONDITIONS;
+    public static final String SELECT_ALL_CONDITIONS_BY_TENANT;
+    public static final String SELECT_ALL_DAMPENINGS;
+    public static final String SELECT_ALL_DAMPENINGS_BY_TENANT;
+    public static final String SELECT_ALL_ACTIONS;
+    public static final String SELECT_ALL_ACTIONS_BY_TENANT;
+    public static final String SELECT_TRIGGER;
+    public static final String SELECT_TRIGGER_DAMPENINGS;
+    public static final String SELECT_TRIGGER_DAMPENINGS_MODE;
+    public static final String DELETE_DAMPENINGS;
+    public static final String DELETE_CONDITIONS;
+    public static final String DELETE_TRIGGERS;
+    public static final String UPDATE_TRIGGER;
+    public static final String DELETE_TRIGGER_ACTIONS;
+    public static final String DELETE_DAMPENING_ID;
+    public static final String SELECT_DAMPENING_ID;
+    public static final String UPDATE_DAMPENING_ID;
+    public static final String SELECT_CONDITION_ID;
+    public static final String INSERT_ACTION_PLUGIN;
+    public static final String DELETE_ACTION_PLUGIN;
+    public static final String UPDATE_ACTION_PLUGIN;
+    public static final String SELECT_ACTION_PLUGINS;
+    public static final String SELECT_ACTION_PLUGIN;
+    public static final String DELETE_ACTION;
+    public static final String UPDATE_ACTION;
+    public static final String SELECT_ACTIONS_PLUGIN;
+    public static final String SELECT_ACTION;
+    public static final String INSERT_TAGS_TRIGGERS;
+    public static final String UPDATE_TAGS_TRIGGERS;
+    public static final String DELETE_TAGS_TRIGGERS;
+    public static final String SELECT_TAGS;
+    public static final String SELECT_TAGS_BY_CATEGORY_AND_NAME;
+    public static final String SELECT_TAGS_BY_CATEGORY;
+    public static final String SELECT_TAGS_BY_NAME;
+    public static final String DELETE_TAGS;
+    public static final String DELETE_TAGS_BY_NAME;
+
     static {
         keyspace = AlertProperties.getProperty(CASSANDRA_KEYSPACE, "hawkular_alerts");
 
@@ -104,6 +157,201 @@ public class CassStatement {
                 + ".tags_triggers WHERE tenantId = ? AND name = ? ";
 
         UPDATE_ALERT = "UPDATE " + keyspace + ".alerts " + "SET payload = ? WHERE tenantId = ? AND alertId = ? ";
+
+        INSERT_TRIGGER = "INSERT INTO " + keyspace + ".triggers " +
+                "(name, description, autoDisable, autoResolve, autoResolveAlerts, firingMatch, " +
+                "autoResolveMatch, id, enabled, tenantId) " +
+                "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_TRIGGER_ACTIONS = "INSERT INTO " + keyspace + ".triggers_actions " +
+                "(tenantId, triggerId, actionPlugin, actions) VALUES (?, ?, ?, ?) ";
+
+        SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
+                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
+                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId"
+                +
+                " FROM " + keyspace + ".conditions " +
+                "WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, triggerMode, type";
+
+        SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, " +
+                "conditionSetSize, conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, " +
+                "pattern, ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange,"
+                +
+                " tenantId " +
+                "FROM " + keyspace + ".conditions " +
+                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? " +
+                "ORDER BY triggerId, triggerMode, type";
+
+        DELETE_CONDITIONS_MODE = "DELETE FROM " + keyspace + ".conditions " +
+                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
+
+        INSERT_AVAILABILITY_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
+                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
+                "dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?) ";
+
+        INSERT_COMPARE_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
+                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
+                "dataId, operator, data2Id, data2Multiplier) VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_STRING_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
+                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
+                "dataId, operator, pattern, ignoreCase) VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_THRESHOLD_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
+                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
+                "dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_THRESHOLD_RANGE_CONDITION = "INSERT INTO " + keyspace + ".conditions " +
+                "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, " +
+                "dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) " +
+                "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_TAG = "INSERT INTO " + keyspace + ".tags " +
+                "(tenantId, triggerId, category, name, visible) VALUES (?, ?, ?, ?, ?) ";
+
+        INSERT_DAMPENING = "INSERT INTO " + keyspace + ".dampenings " +
+                "(triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting, " +
+                "dampeningId, tenantId) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        INSERT_ACTION = "INSERT INTO " + keyspace + ".actions " +
+                "(tenantId, actionPlugin, actionId, properties) VALUES (?, ?, ?, ?) ";
+
+        SELECT_ALL_TRIGGERS = "SELECT name, description, autoDisable, autoResolve, " +
+                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
+                "FROM " + keyspace + ".triggers ";
+
+        SELECT_TRIGGER_ACTIONS = "SELECT tenantId, triggerId, actionPlugin, actions " +
+                "FROM " + keyspace + ".triggers_actions " +
+                "WHERE tenantId = ? AND triggerId = ? ";
+
+        SELECT_TENANT_TRIGGERS = "SELECT name, description, autoDisable, autoResolve, " +
+                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
+                "FROM " + keyspace + ".triggers WHERE tenantId = ? ";
+
+        SELECT_ALL_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
+                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
+                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
+                "tenantId FROM " + keyspace + ".conditions ";
+
+        SELECT_ALL_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
+                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
+                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange," +
+                "tenantId FROM " + keyspace + ".conditions WHERE tenantId = ? ";
+
+        SELECT_ALL_DAMPENINGS = "SELECT tenantId, triggerId, triggerMode, type, evalTrueSetting, " +
+                "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings ";
+
+        SELECT_ALL_DAMPENINGS_BY_TENANT = "SELECT tenantId, triggerId, triggerMode, type, " +
+                "evalTrueSetting, " +
+                "evalTotalSetting, evalTimeSetting, dampeningId FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? ";
+
+        SELECT_ALL_ACTIONS = "SELECT tenantId, actionPlugin, actionId " +
+                "FROM " + keyspace + ".actions ";
+
+        SELECT_ALL_ACTIONS_BY_TENANT = "SELECT actionPlugin, actionId " +
+                "FROM " + keyspace + ".actions WHERE tenantId = ? ";
+
+        SELECT_TRIGGER = "SELECT name, description, autoDisable, autoResolve, " +
+                "autoResolveAlerts, firingMatch, autoResolveMatch, id, enabled, tenantId " +
+                "FROM " + keyspace + ".triggers WHERE tenantId = ? AND id = ? ";
+
+        SELECT_TRIGGER_DAMPENINGS = "SELECT tenantId, triggerId, triggerMode, type, " +
+                "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
+                "FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? AND triggerId = ? ";
+
+        SELECT_TRIGGER_DAMPENINGS_MODE = "SELECT tenantId, triggerId, triggerMode, type, " +
+                "evalTrueSetting, evalTotalSetting, evalTimeSetting, dampeningId " +
+                "FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? AND triggerId = ? and triggerMode = ? ";
+
+        DELETE_DAMPENINGS = "DELETE FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_CONDITIONS = "DELETE FROM " + keyspace + ".conditions " +
+                "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_TRIGGERS = "DELETE FROM " + keyspace + ".triggers " +
+                "WHERE tenantId = ? AND id = ? ";
+
+        UPDATE_TRIGGER = "UPDATE " + keyspace + ".triggers " +
+                "SET name = ?, description = ?, autoDisable = ?, autoResolve = ?, autoResolveAlerts = ?, " +
+                "firingMatch = ?, autoResolveMatch = ?, enabled = ? " +
+                "WHERE tenantId = ? AND id = ? ";
+
+        DELETE_TRIGGER_ACTIONS = "DELETE FROM " + keyspace + ".triggers_actions " +
+                "WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_DAMPENING_ID = "DELETE FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
+
+        SELECT_DAMPENING_ID = "SELECT triggerId, triggerMode, type, evalTrueSetting, " +
+                "evalTotalSetting, evalTimeSetting, dampeningId, tenantId FROM " + keyspace + ".dampenings " +
+                "WHERE tenantId = ? AND dampeningId = ? ";
+
+        UPDATE_DAMPENING_ID = "UPDATE " + keyspace + ".dampenings " +
+                "SET type = ?, evalTrueSetting = ?, evalTotalSetting = ?, evalTimeSetting = ? " +
+                "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? AND dampeningId = ? ";
+
+        SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, " +
+                "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, " +
+                "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, " +
+                "tenantId " +
+                "FROM " + keyspace + ".conditions WHERE tenantId = ? AND conditionId = ? ";
+
+        INSERT_ACTION_PLUGIN = "INSERT INTO " + keyspace + ".action_plugins (actionPlugin, " +
+                "properties) VALUES (?, ?) ";
+
+        DELETE_ACTION_PLUGIN = "DELETE FROM " + keyspace + ".action_plugins WHERE actionPlugin = ? ";
+
+        UPDATE_ACTION_PLUGIN = "UPDATE " + keyspace + ".action_plugins " +
+                "SET properties = ? WHERE actionPlugin = ? ";
+
+        SELECT_ACTION_PLUGINS = "SELECT actionPlugin FROM " + keyspace + ".action_plugins";
+
+        SELECT_ACTION_PLUGIN = "SELECT properties FROM " + keyspace + ".action_plugins " +
+                "WHERE actionPlugin = ? ";
+
+        DELETE_ACTION = "DELETE FROM " + keyspace + ".actions " +
+                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
+
+        UPDATE_ACTION = "UPDATE " + keyspace + ".actions " +
+                "SET properties = ? " +
+                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
+
+        SELECT_ACTIONS_PLUGIN = "SELECT actionId FROM " + keyspace + ".actions " +
+                "WHERE tenantId = ? AND actionPlugin = ? ";
+
+        SELECT_ACTION = "SELECT properties FROM " + keyspace + ".actions " +
+                "WHERE tenantId = ? AND actionPlugin = ? AND actionId = ? ";
+
+        INSERT_TAGS_TRIGGERS = "INSERT INTO " + keyspace + ".tags_triggers " +
+                "(tenantId, category, name, triggers) VALUES (?, ?, ?, ?) ";
+
+        UPDATE_TAGS_TRIGGERS = "UPDATE " + keyspace + ".tags_triggers " +
+                "SET triggers = ? " +
+                "WHERE tenantId = ? AND name = ? ";
+
+        DELETE_TAGS_TRIGGERS = "DELETE FROM " + keyspace + ".tags_triggers " +
+                "WHERE tenantId = ? AND name = ? ";
+
+        SELECT_TAGS = "SELECT tenantId, triggerId, category, name, visible FROM " + keyspace +
+                ".tags WHERE tenantId = ? AND triggerId = ? ORDER BY triggerId, name ";
+
+        SELECT_TAGS_BY_CATEGORY_AND_NAME = "SELECT tenantId, triggerId, category, name, visible FROM " +
+                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? AND name = ? ";
+
+        SELECT_TAGS_BY_CATEGORY = "SELECT tenantId, triggerId, category, name, visible FROM " +
+                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND category = ? ";
+
+        SELECT_TAGS_BY_NAME = "SELECT tenantId, triggerId, category, name, visible FROM " +
+                keyspace + ".tags WHERE tenantId = ? AND triggerId = ? AND name = ? ";
+
+        DELETE_TAGS = "DELETE FROM " + keyspace + ".tags WHERE tenantId = ? AND triggerId = ? ";
+
+        DELETE_TAGS_BY_NAME = "DELETE FROM " + keyspace + ".tags " +
+                "WHERE tenantId = ? AND triggerId = ? AND name = ?";
     }
 
     public static synchronized PreparedStatement get(Session session, String statement) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DbAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DbAlertsServiceImpl.java
@@ -27,15 +27,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
@@ -45,18 +38,13 @@ import javax.sql.DataSource;
 
 import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.condition.Alert.Status;
-import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
-import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.Tag;
-import org.hawkular.alerts.api.model.trigger.Trigger;
-import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.api.services.AlertsCriteria;
 import org.hawkular.alerts.api.services.AlertsService;
-import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.engine.log.MsgLogger;
-import org.hawkular.alerts.engine.rules.RulesEngine;
+import org.hawkular.alerts.engine.service.AlertsEngine;
 import org.jboss.logging.Logger;
 
 import com.google.gson.Gson;
@@ -72,92 +60,34 @@ import com.google.gson.GsonBuilder;
 public class DbAlertsServiceImpl implements AlertsService {
     private final MsgLogger msgLog = MsgLogger.LOGGER;
     private final Logger log = Logger.getLogger(DbAlertsServiceImpl.class);
-    private static final int DELAY;
-    private static final int PERIOD;
-
-    private final List<Data> pendingData;
-    private final List<Alert> alerts;
-    private final Set<Dampening> pendingTimeouts;
-    private final Map<Trigger, List<Set<ConditionEval>>> autoResolvedTriggers;
-    private final Set<Trigger> disabledTriggers;
-
-    private final Timer wakeUpTimer;
-    private TimerTask rulesTask;
 
     private Gson gson;
     private final String DS_NAME;
     private DataSource ds;
 
     @EJB
-    RulesEngine rules;
-
-    @EJB
-    DefinitionsService definitions;
-
-    @EJB
-    ActionsService actions;
-
-    /*
-        Init properties
-     */
-    static {
-        String sDelay = System.getProperty("org.hawkular.alerts.engine.DELAY");
-        String sPeriod = System.getProperty("org.hawkular.alerts.engine.PERIOD");
-        int dDelay = 1000;
-        int dPeriod = 2000;
-        try {
-            dDelay = Integer.parseInt(sDelay);
-            dPeriod = Integer.parseInt(sPeriod);
-        } catch (Exception ignored) {
-        }
-        DELAY = dDelay;
-        PERIOD = dPeriod;
-    }
+    AlertsEngine alertsEngine;
 
     public DbAlertsServiceImpl() {
         log.debugf("Creating instance.");
-        pendingData = new CopyOnWriteArrayList<>();
-        alerts = new CopyOnWriteArrayList<>();
-        pendingTimeouts = new CopyOnWriteArraySet<>();
-        autoResolvedTriggers = new HashMap<>();
-        disabledTriggers = new CopyOnWriteArraySet<>();
-        wakeUpTimer = new Timer("DbAlertsServiceImpl-Timer");
 
         DS_NAME = System.getProperty("org.hawkular.alerts.engine.datasource", "java:jboss/datasources/HawkularDS");
     }
 
-    @SuppressWarnings("unused")
-    public ActionsService getActions() {
-        return actions;
-    }
-
-    public void setActions(ActionsService actions) {
-        this.actions = actions;
-    }
-
-    public DefinitionsService getDefinitions() {
-        return definitions;
-    }
-
-    public void setDefinitions(DefinitionsService definitions) {
-        this.definitions = definitions;
-    }
-
-    public RulesEngine getRules() {
-        return rules;
-    }
-
-    public void setRules(RulesEngine rules) {
-        this.rules = rules;
-    }
-
-    @SuppressWarnings("unused")
-    public DataSource getDatasource() {
+    public DataSource getDs() {
         return ds;
     }
 
-    public void setDatasource(DataSource ds) {
+    public void setDs(DataSource ds) {
         this.ds = ds;
+    }
+
+    public AlertsEngine getAlertsEngine() {
+        return alertsEngine;
+    }
+
+    public void setAlertsEngine(AlertsEngine alertsEngine) {
+        this.alertsEngine = alertsEngine;
     }
 
     @PostConstruct
@@ -175,8 +105,6 @@ public class DbAlertsServiceImpl implements AlertsService {
                 msgLog.errorCannotConnectWithDatasource(e.getMessage());
             }
         }
-
-        reload();
     }
 
     @Override
@@ -442,244 +370,6 @@ public class DbAlertsServiceImpl implements AlertsService {
     }
 
     @Override
-    public void clear() {
-        rulesTask.cancel();
-
-        rules.clear();
-
-        pendingData.clear();
-        alerts.clear();
-        pendingTimeouts.clear();
-        autoResolvedTriggers.clear();
-        disabledTriggers.clear();
-
-        rulesTask = new RulesInvoker();
-        wakeUpTimer.schedule(rulesTask, DELAY, PERIOD);
-    }
-
-    @Override
-    public void reload() {
-        rules.reset();
-        if (rulesTask != null) {
-            rulesTask.cancel();
-        }
-
-        Collection<Trigger> triggers = null;
-        try {
-            triggers = definitions.getAllTriggers();
-        } catch (Exception e) {
-            log.debugf(e.getMessage(), e);
-            msgLog.errorDefinitionsService("Triggers", e.getMessage());
-        }
-        if (triggers != null && !triggers.isEmpty()) {
-            triggers.stream().filter(Trigger::isEnabled).forEach(this::reloadTrigger);
-        }
-
-        rules.addGlobal("log", log);
-        rules.addGlobal("actions", actions);
-        rules.addGlobal("alerts", alerts);
-        rules.addGlobal("pendingTimeouts", pendingTimeouts);
-        rules.addGlobal("autoResolvedTriggers", autoResolvedTriggers);
-        rules.addGlobal("disabledTriggers", disabledTriggers);
-
-        rulesTask = new RulesInvoker();
-        wakeUpTimer.schedule(rulesTask, DELAY, PERIOD);
-    }
-
-    @Override
-    public void reloadTrigger(final String tenantId, final String triggerId) {
-        if (isEmpty(tenantId)) {
-            throw new IllegalArgumentException("TenantId must be not null");
-        }
-        if (isEmpty(triggerId)) {
-            throw new IllegalArgumentException("TriggerId must be not null");
-        }
-
-        Trigger trigger = null;
-        try {
-            trigger = definitions.getTrigger(tenantId, triggerId);
-        } catch (Exception e) {
-            log.debugf(e.getMessage(), e);
-            msgLog.errorDefinitionsService("Trigger", e.getMessage());
-        }
-        if (null == trigger) {
-            log.debugf("Trigger not found for triggerId [" + triggerId + "], removing from rulebase if it exists");
-            Trigger doomedTrigger = new Trigger(triggerId, "doomed");
-            removeTrigger(doomedTrigger);
-            return;
-        }
-
-        reloadTrigger(trigger);
-    }
-
-    private void reloadTrigger(Trigger trigger) {
-        if (null == trigger) {
-            throw new IllegalArgumentException("Trigger must be not null");
-        }
-
-        // Look for the Trigger in the rules engine, if it is there then remove everything about it
-        removeTrigger(trigger);
-
-        if (trigger.isEnabled()) {
-            try {
-                Collection<Condition> conditionSet = definitions.getTriggerConditions(trigger.getTenantId(),
-                        trigger.getId(), null);
-                Collection<Dampening> dampenings = definitions.getTriggerDampenings(trigger.getTenantId(),
-                        trigger.getId(), null);
-
-                rules.addFact(trigger);
-                rules.addFacts(conditionSet);
-                if (!dampenings.isEmpty()) {
-                    rules.addFacts(dampenings);
-                }
-            } catch (Exception e) {
-                log.debugf(e.getMessage(), e);
-                msgLog.errorDefinitionsService("Conditions/Dampening", e.getMessage());
-            }
-        }
-    }
-
-    private void removeTrigger(Trigger trigger) {
-        if (null != rules.getFact(trigger)) {
-            // First remove the related Trigger facts from the engine
-            rules.removeFact(trigger);
-
-            // then remove everything else.
-            // We may want to do this with rules, because as is, we need to loop through every Fact in
-            // the rules engine doing a relatively slow check.
-            final String triggerId = trigger.getId();
-            rules.removeFacts(t -> {
-                if (t instanceof Dampening) {
-                    return ((Dampening) t).getTriggerId().equals(triggerId);
-                } else if (t instanceof Condition) {
-                    return ((Condition) t).getTriggerId().equals(triggerId);
-                }
-                return false;
-            });
-        } else {
-            log.debugf("Trigger not found. Not removed from rulebase %s", trigger);
-        }
-    }
-
-    @Override
-    public void sendData(Collection<Data> data) {
-        if (data == null) {
-            throw new IllegalArgumentException("Data must be not null");
-        }
-        pendingData.addAll(data);
-    }
-
-    @Override
-    public void sendData(Data data) {
-        if (data == null) {
-            throw new IllegalArgumentException("Data must be not null");
-        }
-        pendingData.add(data);
-    }
-
-    private class RulesInvoker extends TimerTask {
-        @Override
-        public void run() {
-            int numTimeouts = checkPendingTimeouts();
-            if (!pendingData.isEmpty() || numTimeouts > 0) {
-
-                log.debugf("Executing rules engine on [%1d] datums and [%2d] dampening timeouts.", pendingData.size(),
-                        numTimeouts);
-
-                try {
-                    if (pendingData.isEmpty()) {
-                        rules.fireNoData();
-
-                    } else {
-                        rules.addData(pendingData);
-                        pendingData.clear();
-                    }
-
-                    rules.fire();
-                    addAlerts(alerts);
-                    alerts.clear();
-                    handleDisabledTriggers();
-                    handleAutoResolvedTriggers();
-
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    log.debugf("Error on rules processing: " + e);
-                    msgLog.errorProcessingRules(e.getMessage());
-                } finally {
-                    alerts.clear();
-                }
-            }
-        }
-
-        private int checkPendingTimeouts() {
-            if (pendingTimeouts.isEmpty()) {
-                return 0;
-            }
-
-            long now = System.currentTimeMillis();
-            Set<Dampening> timeouts = null;
-            for (Dampening d : pendingTimeouts) {
-                if (now < d.getTrueEvalsStartTime() + d.getEvalTimeSetting()) {
-                    continue;
-                }
-
-                d.setSatisfied(true);
-                try {
-                    log.debugf("Dampening Timeout Hit! %s", d.toString());
-                    rules.updateFact(d);
-                    if (null == timeouts) {
-                        timeouts = new HashSet<>();
-                    }
-                    timeouts.add(d);
-                } catch (Exception e) {
-                    log.error("Unable to update Dampening Fact on Timeout! " + d.toString(), e);
-                }
-
-            }
-
-            if (null == timeouts) {
-                return 0;
-            }
-
-            pendingTimeouts.removeAll(timeouts);
-            return timeouts.size();
-        }
-    }
-
-    private void handleDisabledTriggers() {
-        try {
-            for (Trigger t : disabledTriggers) {
-                try {
-                    t.setEnabled(false);
-                    definitions.updateTrigger(t.getTenantId(), t);
-
-                } catch (Exception e) {
-                    log.errorf("Failed to persist updated trigger. Could not autoDisable %s", t);
-                }
-            }
-        } finally {
-            disabledTriggers.clear();
-        }
-    }
-
-    private void handleAutoResolvedTriggers() {
-        try {
-            for (Map.Entry<Trigger, List<Set<ConditionEval>>> entry : autoResolvedTriggers.entrySet()) {
-                Trigger t = entry.getKey();
-                try {
-                    if (t.isAutoResolveAlerts()) {
-                        resolveAlertsForTrigger(t.getTenantId(), t.getId(), "AUTO", null, entry.getValue());
-                    }
-                } catch (Exception e) {
-                    log.errorf("Failed to resolve Alerts. Could not AutoResolve alerts for trigger %s", t);
-                }
-            }
-        } finally {
-            autoResolvedTriggers.clear();
-        }
-    }
-
-    @Override
     public void ackAlerts(String tenantId, Collection<String> alertIds, String ackBy, String ackNotes)
             throws Exception {
         if (isEmpty(tenantId)) {
@@ -786,6 +476,16 @@ public class DbAlertsServiceImpl implements AlertsService {
         }
 
         return alert;
+    }
+
+    @Override
+    public void sendData(Data data) throws Exception {
+        alertsEngine.sendData(data);
+    }
+
+    @Override
+    public void sendData(Collection<Data> data) throws Exception {
+        alertsEngine.sendData(data);
     }
 
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/AlertsEngine.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/AlertsEngine.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.service;
+
+import java.util.Collection;
+
+import org.hawkular.alerts.api.model.data.Data;
+
+/**
+ * Interface that allows to send data to the alerts engine and check resulting state.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public interface AlertsEngine {
+
+    /**
+     * Send data into the alerting system for evaluation.
+     *
+     * @param data Not Null.  The data to be evaluated by the alerting engine.
+     * @throws Exception any problem.
+     */
+    void sendData(Data data) throws Exception;
+
+    /**
+     * Send data into the alerting system for evaluation.
+     *
+     * @param data Not Null.  The data to be evaluated by the alerting engine.
+     * @throws Exception any problem.
+     */
+    void sendData(Collection<Data> data) throws Exception;
+
+    /**
+     * Reset session state.
+     */
+    void clear();
+
+    /**
+     * Reload all Triggers.
+     */
+    void reload();
+
+    /**
+     * Reload the specified Trigger.  Removes any existing definition from the engine.  If enabled then loads the firing
+     * condition set and dampening.  If safetyEnabled then also loads the safety condition set and dampening.
+     * @param tenantId Tenant where Trigger is stored
+     * @param triggerId Trigger id to be reloaded
+     */
+    void reloadTrigger(String tenantId, String triggerId);
+
+}

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DbDefinitionsTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DbDefinitionsTest.java
@@ -19,6 +19,7 @@ package org.hawkular.alerts.engine;
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcDataSource;
+import org.hawkular.alerts.engine.impl.AlertsEngineImpl;
 import org.hawkular.alerts.engine.impl.DbAlertsServiceImpl;
 import org.hawkular.alerts.engine.impl.DbDefinitionsServiceImpl;
 import org.hawkular.alerts.engine.impl.DroolsRulesEngineImpl;
@@ -39,6 +40,7 @@ public class DbDefinitionsTest extends DefinitionsTest {
     static DroolsRulesEngineImpl rules = null;
     static DbDefinitionsServiceImpl dbDefinitions;
     static DbAlertsServiceImpl dbAlerts;
+    static AlertsEngineImpl engine = null;
     static DataSource ds;
 
     @BeforeClass
@@ -56,13 +58,13 @@ public class DbDefinitionsTest extends DefinitionsTest {
         rules = new DroolsRulesEngineImpl();
         dbDefinitions = new DbDefinitionsServiceImpl();
         dbAlerts = new DbAlertsServiceImpl();
+        engine = new AlertsEngineImpl();
 
-        dbDefinitions.setDatasource(ds);
-        dbDefinitions.setAlertsService(dbAlerts);
-        dbAlerts.setDatasource(ds);
-        dbAlerts.setDefinitions(dbDefinitions);
-        dbAlerts.setActions(actions);
-        dbAlerts.setRules(rules);
+        dbDefinitions.setDs(ds);
+        dbDefinitions.setAlertsEngine(engine);
+        dbAlerts.setDs(ds);
+        dbAlerts.setAlertsEngine(engine);
+        engine.setRules(rules);
 
         dbDefinitions.init();
         dbAlerts.initServices();

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DefinitionsTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/DefinitionsTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.condition.ConditionEval;

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
@@ -43,6 +43,7 @@ import org.hawkular.alerts.api.model.data.MixedData;
 import org.hawkular.alerts.api.model.trigger.Tag;
 import org.hawkular.alerts.api.services.AlertsCriteria;
 import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.engine.service.AlertsEngine;
 import org.jboss.logging.Logger;
 
 import com.wordnik.swagger.annotations.Api;
@@ -66,7 +67,10 @@ public class AlertsHandler {
     Persona persona;
 
     @EJB
-    AlertsService alerts;
+    AlertsService alertsService;
+
+    @EJB
+    AlertsEngine alertsEngine;
 
     public AlertsHandler() {
         log.debugf("Creating instance.");
@@ -144,53 +148,12 @@ public class AlertsHandler {
                 criteria.setTags(tagList);
             }
 
-            List<Alert> alertList = alerts.getAlerts(persona.getId(), criteria);
+            List<Alert> alertList = alertsService.getAlerts(persona.getId(), criteria);
             log.debugf("Alerts: %s ", alertList);
             if (isEmpty(alertList)) {
                 return ResponseUtil.noContent();
             }
             return ResponseUtil.ok(alertList);
-        } catch (Exception e) {
-            log.debugf(e.getMessage(), e);
-            return ResponseUtil.internalError(e.getMessage());
-        }
-    }
-
-    @GET
-    @Path("/reload")
-    @ApiOperation(
-            value = "Reload all definitions into the alerts service",
-            notes = "This service is temporal for demos/poc, this functionality will be handled internally" +
-                    "between definitions and alerts services")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Success. Reload invoked successfully."),
-            @ApiResponse(code = 500, message = "Internal server error")})
-    public Response reloadAlerts() {
-        if (!checkPersona()) {
-            return ResponseUtil.internalError("No persona found");
-        }
-        try {
-            alerts.reload();
-            return ResponseUtil.ok();
-        } catch (Exception e) {
-            log.debugf(e.getMessage(), e);
-            return ResponseUtil.internalError(e.getMessage());
-        }
-    }
-
-    @GET
-    @Path("/reload/{triggerId}")
-    @ApiOperation(value = "Reload a specific trigger into the alerts service")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Success. Reload invoked successfully."),
-            @ApiResponse(code = 500, message = "Internal server error") })
-    public Response reloadTrigger(@PathParam("triggerId") final String triggerId) {
-        if (!checkPersona()) {
-            return ResponseUtil.internalError("No persona found");
-        }
-        try {
-            alerts.reloadTrigger(persona.getId(), triggerId);
-            return ResponseUtil.ok();
         } catch (Exception e) {
             log.debugf(e.getMessage(), e);
             return ResponseUtil.internalError(e.getMessage());
@@ -219,7 +182,7 @@ public class AlertsHandler {
         }
         try {
             if (!isEmpty(alertIds)) {
-                alerts.ackAlerts(persona.getId(), Arrays.asList(alertIds.split(",")), ackBy, ackNotes);
+                alertsService.ackAlerts(persona.getId(), Arrays.asList(alertIds.split(",")), ackBy, ackNotes);
                 log.debugf("AlertsIds: %s ", alertIds);
                 return ResponseUtil.ok();
             } else {
@@ -253,8 +216,8 @@ public class AlertsHandler {
         }
         try {
             if (!isEmpty(alertIds)) {
-                alerts.resolveAlerts(persona.getId(), Arrays.asList(alertIds.split(",")), resolvedBy, resolvedNotes,
-                        null);
+                alertsService.resolveAlerts(persona.getId(), Arrays.asList(alertIds.split(",")), resolvedBy,
+                        resolvedNotes, null);
                 log.debugf("AlertsIds: %s ", alertIds);
                 return ResponseUtil.ok();
             } else {
@@ -283,10 +246,52 @@ public class AlertsHandler {
             if (isEmpty(mixedData)) {
                 return ResponseUtil.badRequest("Data is empty");
             } else {
-                alerts.sendData(mixedData.asCollection());
+                alertsEngine.sendData(mixedData.asCollection());
                 log.debugf("MixedData: %s ", mixedData);
                 return ResponseUtil.ok();
             }
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            return ResponseUtil.internalError(e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/reload")
+    @ApiOperation(
+            value = "Reload all definitions into the alerts service",
+            notes = "This service is temporal for demos/poc, this functionality will be handled internally" +
+                    "between definitions and alerts services")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success. Reload invoked successfully."),
+            @ApiResponse(code = 500, message = "Internal server error") })
+    public Response reloadAlerts() {
+        if (!checkPersona()) {
+            return ResponseUtil.internalError("No persona found");
+        }
+        try {
+            alertsEngine.reload();
+            return ResponseUtil.ok();
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            return ResponseUtil.internalError(e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/reload/{triggerId}")
+    @ApiOperation(value = "Reload a specific trigger into the alerts service")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success. Reload invoked successfully."),
+            @ApiResponse(code = 500, message = "Internal server error") })
+    public Response reloadTrigger(@PathParam("triggerId")
+    final String triggerId) {
+        if (!checkPersona()) {
+            return ResponseUtil.internalError("No persona found");
+        }
+        try {
+            alertsEngine.reloadTrigger(persona.getId(), triggerId);
+            return ResponseUtil.ok();
         } catch (Exception e) {
             log.debugf(e.getMessage(), e);
             return ResponseUtil.internalError(e.getMessage());


### PR DESCRIPTION
Refactor such that AlertsService and Impl does not handle both client requests and engine running concerns.  Allow client requests (like getAlerts) to be serviced by a pool of beans, while maintaining the singleton for the engine.