### PR TITLE
HWKALERTS-56 : Need a way to fetch Alerts without the evaluations

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -16,6 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Set;
 
@@ -29,6 +33,14 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  * @author Lucas Ponce
  */
 public class Alert {
+
+    /**
+     * Used to annotate fields that should be thinned in order to return/deserialize a lightweight Alert
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface Thin {
+    }
 
     public enum Status {
         OPEN, ACKNOWLEDGED, RESOLVED
@@ -48,6 +60,7 @@ public class Alert {
     private long ctime;
 
     @JsonInclude(Include.NON_EMPTY)
+    @Thin
     private List<Set<ConditionEval>> evalSets;
 
     @JsonInclude
@@ -72,6 +85,7 @@ public class Alert {
     private String resolvedNotes;
 
     @JsonInclude(Include.NON_EMPTY)
+    @Thin
     private List<Set<ConditionEval>> resolvedEvalSets;
 
     public Alert() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -38,6 +38,7 @@ public class AlertsCriteria {
     Collection<String> triggerIds = null;
     Tag tag = null;
     Collection<Tag> tags = null;
+    boolean thin = false;
 
     public AlertsCriteria() {
         super();
@@ -141,6 +142,14 @@ public class AlertsCriteria {
         this.tags = tags;
     }
 
+    public boolean isThin() {
+        return thin;
+    }
+
+    public void setThin(boolean thin) {
+        this.thin = thin;
+    }
+
     public boolean hasCriteria() {
         return null != startTime || //
                 null != endTime || //
@@ -156,9 +165,9 @@ public class AlertsCriteria {
 
     @Override
     public String toString() {
-        return "AlertsCriteria [startTime=" + startTime + ", endTime=" + endTime + ", triggerId=" + triggerId
-                + ", triggerIds=" + triggerIds + ", tag=" + tag + ", tags=" + tags + ", status=" + status + ", " +
-                "statusSet=" + statusSet + "]";
+        return "AlertsCriteria [startTime=" + startTime + ", endTime=" + endTime + ", alertId=" + alertId
+                + ", alertIds=" + alertIds + ", status=" + status + ", statusSet=" + statusSet + ", triggerId="
+                + triggerId + ", triggerIds=" + triggerIds + ", tag=" + tag + ", tags=" + tags + ", thin=" + thin
+                + "]";
     }
-
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -249,8 +249,21 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals("RESOLVED", resp.data[0].status)
         assertEquals("AUTO", resp.data[0].resolvedBy)
+        assert null != resp.data[0].evalSets
         assert null != resp.data[0].resolvedEvalSets
+        assert !resp.data[0].evalSets.isEmpty()
+        assert !resp.data[0].resolvedEvalSets.isEmpty()
 
+        // take this opportunity to test result thinning
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:true] )
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals("AUTO", resp.data[0].resolvedBy)
+        assert null == resp.data[0].evalSets
+        assert null == resp.data[0].resolvedEvalSets
+
+        // Throw in a status filter test
         resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"OPEN"] )
         assertEquals(204, resp.status)
     }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -29,21 +29,27 @@ import static org.hawkular.alerts.api.model.condition.AvailabilityCondition.Oper
 import static org.hawkular.alerts.api.model.trigger.Trigger.Mode
 import static org.junit.Assert.assertEquals
 
+import org.junit.FixMethodOrder
 import org.junit.Test
+
+import static org.junit.runners.MethodSorters.NAME_ASCENDING
 
 /**
  * Alerts REST tests.
  *
  * @author Jay Shaughnessy
  */
+@FixMethodOrder(NAME_ASCENDING)
 class LifecycleITest extends AbstractITestBase {
 
     static host = System.getProperty('hawkular.host') ?: '127.0.0.1'
     static port = Integer.valueOf(System.getProperty('hawkular.port') ?: "8080")
+    static t01Start = String.valueOf(System.currentTimeMillis())
+    static t02Start;
 
     @Test
-    void disableTest() {
-        String start = String.valueOf(System.currentTimeMillis());
+    void t01_disableTest() {
+        String start = t01Start;
 
         // CREATE the trigger
         def resp = client.get(path: "")
@@ -63,7 +69,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // ADD Firing condition
         AvailabilityCondition firingCond = new AvailabilityCondition("test-autodisable-trigger",
-                Mode.FIRING, "test-lifecycle-avail", Operator.NOT_UP);
+                Mode.FIRING, "test-autodisable-avail", Operator.NOT_UP);
 
         resp = client.post(path: "triggers/test-autodisable-trigger/conditions", body: firingCond)
         assertEquals(200, resp.status)
@@ -90,14 +96,14 @@ class LifecycleITest extends AbstractITestBase {
         // Note, the groovyx rest c;lient seems incapable of allowing a JSON payload and a TEXT response (which is what
         // we get back from the activemq rest client used by the bus), so use the bus' java rest client to do this.
         RestClient busClient = new RestClient(host, port);
-        String json = "{\"data\":[{\"id\":\"test-lifecycle-avail\",\"timestamp\":" + System.currentTimeMillis() +
+        String json = "{\"data\":[{\"id\":\"test-autodisable-avail\",\"timestamp\":" + System.currentTimeMillis() +
                       ",\"value\"=\"DOWN\",\"type\"=\"availability\"}]}";
         busClient.postTopicMessage("HawkularAlertData", json, null);
         //assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
         for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
+            // println "SLEEP!" ;
             Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
@@ -130,8 +136,8 @@ class LifecycleITest extends AbstractITestBase {
     }
 
     @Test
-    void autoResolveTest() {
-        String start = String.valueOf(System.currentTimeMillis());
+    void t02_autoResolveTest() {
+        String start = t02Start = String.valueOf(System.currentTimeMillis());
 
         // CREATE the trigger
         def resp = client.get(path: "")
@@ -152,7 +158,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // ADD Firing condition
         AvailabilityCondition firingCond = new AvailabilityCondition("test-autoresolve-trigger",
-                Mode.FIRING, "test-lifecycle-avail", Operator.NOT_UP);
+                Mode.FIRING, "test-autoresolve-avail", Operator.NOT_UP);
 
         resp = client.post(path: "triggers/test-autoresolve-trigger/conditions", body: firingCond)
         assertEquals(200, resp.status)
@@ -160,7 +166,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // ADD AutoResolve condition
         AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-autoresolve-trigger",
-                Mode.AUTORESOLVE, "test-lifecycle-avail", Operator.UP);
+                Mode.AUTORESOLVE, "test-autoresolve-avail", Operator.UP);
 
         resp = client.post(path: "triggers/test-autoresolve-trigger/conditions", body: autoResolveCond)
         assertEquals(200, resp.status)
@@ -187,7 +193,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // Send in DOWN avail data to fire the trigger
         // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
-        Availability avail = new Availability("test-lifecycle-avail", System.currentTimeMillis(), "DOWN");
+        Availability avail = new Availability("test-autoresolve-avail", System.currentTimeMillis(), "DOWN");
         MixedData mixedData = new MixedData();
         mixedData.getAvailability().add(avail);
         resp = client.post(path: "data", body: mixedData);
@@ -195,7 +201,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // The alert processing happens async, so give it a little time before failing...
         for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
+            // println "SLEEP!" ;
             Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
@@ -224,11 +230,10 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals("test-autoresolve-trigger", resp.data.name)
         assertEquals(true, resp.data.enabled)
-        //assertEquals(Mode.AUTORESOLVE, resp.data.mode)
 
         // Send in UP avail data to autoresolve the trigger
         // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
-        avail = new Availability("test-lifecycle-avail", System.currentTimeMillis(), "UP");
+        avail = new Availability("test-autoresolve-avail", System.currentTimeMillis(), "UP");
         mixedData.clear();
         mixedData.getAvailability().add(avail);
         resp = client.post(path: "data", body: mixedData);
@@ -236,7 +241,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // The alert processing happens async, so give it a little time before failing...
         for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
+            // println "SLEEP!" ;
             Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
@@ -249,28 +254,11 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals("RESOLVED", resp.data[0].status)
         assertEquals("AUTO", resp.data[0].resolvedBy)
-        assert null != resp.data[0].evalSets
-        assert null != resp.data[0].resolvedEvalSets
-        assert !resp.data[0].evalSets.isEmpty()
-        assert !resp.data[0].resolvedEvalSets.isEmpty()
-
-        // take this opportunity to test result thinning
-        resp = client.get(path: "",
-            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:true] )
-        assertEquals(200, resp.status)
-        assertEquals("RESOLVED", resp.data[0].status)
-        assertEquals("AUTO", resp.data[0].resolvedBy)
-        assert null == resp.data[0].evalSets
-        assert null == resp.data[0].resolvedEvalSets
-
-        // Throw in a status filter test
-        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"OPEN"] )
-        assertEquals(204, resp.status)
     }
 
 
     @Test
-    void manualResolutionTest() {
+    void t03_manualResolutionTest() {
         String start = String.valueOf(System.currentTimeMillis());
 
         // CREATE the trigger
@@ -292,7 +280,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // ADD Firing condition
         AvailabilityCondition firingCond = new AvailabilityCondition("test-manual-trigger",
-                Mode.FIRING, "test-lifecycle-avail", Operator.NOT_UP);
+                Mode.FIRING, "test-manual-avail", Operator.NOT_UP);
 
         resp = client.post(path: "triggers/test-manual-trigger/conditions", body: firingCond)
         assertEquals(200, resp.status)
@@ -320,7 +308,7 @@ class LifecycleITest extends AbstractITestBase {
         // Send in DOWN avail data to fire the trigger
         // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
         for (int i=0; i<5; i++) {
-            Availability avail = new Availability("test-lifecycle-avail", System.currentTimeMillis(), "DOWN");
+            Availability avail = new Availability("test-manual-avail", System.currentTimeMillis(), "DOWN");
             MixedData mixedData = new MixedData();
             mixedData.getAvailability().add(avail);
             resp = client.post(path: "data", body: mixedData);
@@ -329,7 +317,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // The alert processing happens async, so give it a little time before failing...
         for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
+            // println "SLEEP!" ;
             Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 5
@@ -356,5 +344,96 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(1, resp.data.size())
     }
 
+    // Given name ordering this test runs after tests 1..3, it uses the alerts generated in those tests
+    // to test alert queries and updates.
+    @Test
+    void t04_fetchTest() {
+        // queries will look for alerts generated in this test tun
+        String start = t01Start;
 
+        // FETCH alerts for bogus trigger, should not be any
+        def resp = client.get(path: "", query: [startTime:start,triggerIds:"XXX"] )
+        assertEquals(204, resp.status)
+
+        // FETCH alerts for bogus alert id, should not be any
+        resp = client.get(path: "", query: [startTime:start,alertIds:"XXX,YYY"] )
+        assertEquals(204, resp.status)
+
+        // FETCH alerts for bogus tag, should not be any
+        resp = client.get(path: "", query: [startTime:start,tags:"XXX"] )
+        assertEquals(204, resp.status)
+
+        // FETCH alerts for bogus category|tag, should not be any
+        resp = client.get(path: "", query: [startTime:start,tags:"XXX|YYY"] )
+        assertEquals(204, resp.status)
+
+        // FETCH alerts for just triggers generated in test t01, by time, should be 1
+        resp = client.get(path: "", query: [startTime:t01Start,endTime:t02Start] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("test-autodisable-trigger", resp.data[0].triggerId)
+
+        // FETCH the alert above again, this time by alert id
+        def alertId = resp.data[0].alertId
+        resp = client.get(path: "", query: [startTime:start,alertIds:"XXX,"+alertId] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals(alertId, resp.data[0].alertId)
+
+        // FETCH the alert above again, this time by tag
+        resp = client.get(path: "", query: [startTime:start,tags:"dataId|test-autodisable-avail"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals(alertId, resp.data[0].alertId)
+
+        // FETCH the alert above again, this time by union of (good) triggerId and (bad) tag
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger",tags:"XXX"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals(alertId, resp.data[0].alertId)
+
+        // FETCH alerts for test-manual-trigger, there should be 5 from the earlier test
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        // 4 OPEN and 1 RESOLVED
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED,ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals(4, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"ACKNOWLEDGED"] )
+        assertEquals(204, resp.status)
+
+        // test thinning as well as verifying the RESOLVED status fetch (using the autoresolve alert)
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:false] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals("AUTO", resp.data[0].resolvedBy)
+        assert null != resp.data[0].evalSets
+        assert null != resp.data[0].resolvedEvalSets
+        assert !resp.data[0].evalSets.isEmpty()
+        assert !resp.data[0].resolvedEvalSets.isEmpty()
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:true] )
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals("AUTO", resp.data[0].resolvedBy)
+        assert null == resp.data[0].evalSets
+        assert null == resp.data[0].resolvedEvalSets
+    }
 }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
@@ -108,7 +108,10 @@ public class AlertsHandler {
             @ApiParam(required = false, value = "filter out alerts for unspecified tags, comma separated list of tags, "
                     + "each tag of format [category|]name")
             @QueryParam("tags")
-            final String tags) {
+            final String tags,
+            @ApiParam(required = false, value = "return only thin alerts, do not include: evalSets, resolvedEvalSets")
+            @QueryParam("thin")
+            final Boolean thin) {
         if (!checkPersona()) {
             return ResponseUtil.internalError("No persona found");
         }
@@ -146,6 +149,9 @@ public class AlertsHandler {
                     }
                 }
                 criteria.setTags(tagList);
+            }
+            if (null != thin) {
+                criteria.setThin(thin.booleanValue());
             }
 
             List<Alert> alertList = alertsService.getAlerts(persona.getId(), criteria);


### PR DESCRIPTION
Add a "thin" query param to Alerts GET endpoint.  It currently will remove
the evalSets and resolvedEvalSets from the Alerts returned from the fetch.
This can be a good option for an initial list of alerts, where a more
robust pull of alert details can be deferred.