### PR TITLE
HWKALERTS-62 Allow any data to store contextual information

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityConditionEval.java
@@ -16,10 +16,11 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.hawkular.alerts.api.model.data.Availability;
 import org.hawkular.alerts.api.model.data.Availability.AvailabilityType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An evaluation state for availability condition.
@@ -36,13 +37,13 @@ public class AvailabilityConditionEval extends ConditionEval {
     private AvailabilityType value;
 
     public AvailabilityConditionEval() {
-        super(false, 0);
+        super(false, 0, null);
         this.condition = null;
         this.value = null;
     }
 
     public AvailabilityConditionEval(AvailabilityCondition condition, Availability avail) {
-        super(condition.match(avail.getValue()), avail.getTimestamp());
+        super(condition.match(avail.getValue()), avail.getTimestamp(), avail.getContext());
         this.condition = condition;
         this.value = avail.getValue();
         if (this.condition != null) {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareConditionEval.java
@@ -16,10 +16,12 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+
 import org.hawkular.alerts.api.model.data.NumericData;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An evaluation state for compare condition.
@@ -38,22 +40,28 @@ public class CompareConditionEval extends ConditionEval {
     @JsonInclude(Include.NON_NULL)
     private Double value2;
 
+    @JsonInclude(Include.NON_EMPTY)
+    protected Map<String, String> context2;
+
     public CompareConditionEval() {
-        super(false, 0);
+        super(false, 0, null);
         this.condition = null;
         this.value1 = null;
         this.value2 = null;
+        this.context2 = null;
     }
 
     public CompareConditionEval(CompareCondition condition, NumericData data1, NumericData data2) {
         super(condition.match(data1.getValue(), data2.getValue()),
-                ((data1.getTimestamp() > data1.getTimestamp()) ? data1.getTimestamp() : data2.getTimestamp()));
+                ((data1.getTimestamp() > data1.getTimestamp()) ? data1.getTimestamp() : data2.getTimestamp()),
+                data1.getContext());
         this.condition = condition;
         this.value1 = data1.getValue();
         this.value2 = data2.getValue();
         if (this.condition != null) {
             this.type = this.condition.getType();
         }
+        this.context2 = data2.getContext();
     }
 
     public CompareCondition getCondition() {
@@ -93,6 +101,14 @@ public class CompareConditionEval extends ConditionEval {
     @Override
     public int getConditionSetIndex() {
         return condition.getConditionSetIndex();
+    }
+
+    public Map<String, String> getContext2() {
+        return context2;
+    }
+
+    public void setContext2(Map<String, String> context2) {
+        this.context2 = context2;
     }
 
     @Override

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
@@ -16,8 +16,11 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An evaluation state of a specific condition.
@@ -46,15 +49,19 @@ public abstract class ConditionEval {
     @JsonInclude
     protected Condition.Type type;
 
+    @JsonInclude(Include.NON_EMPTY)
+    protected Map<String, String> context;
+
     public ConditionEval() {
         // for json assembly
     }
 
-    public ConditionEval(boolean match, long dataTimestamp) {
+    public ConditionEval(boolean match, long dataTimestamp, Map<String, String> context) {
         this.match = match;
         this.dataTimestamp = dataTimestamp;
         this.evalTimestamp = System.currentTimeMillis();
         this.used = false;
+        this.context = context;
     }
 
     public boolean isMatch() {
@@ -95,6 +102,14 @@ public abstract class ConditionEval {
 
     public void setType(Condition.Type type) {
         this.type = type;
+    }
+
+    public Map<String, String> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String, String> context) {
+        this.context = context;
     }
 
     @JsonIgnore

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalConditionEval.java
@@ -37,13 +37,13 @@ public class ExternalConditionEval extends ConditionEval {
     private String value;
 
     public ExternalConditionEval() {
-        super(false, 0);
+        super(false, 0, null);
         this.condition = null;
         this.value = null;
     }
 
     public ExternalConditionEval(ExternalCondition condition, StringData data) {
-        super(condition.match(data.getValue()), data.getTimestamp());
+        super(condition.match(data.getValue()), data.getTimestamp(), data.getContext());
         this.condition = condition;
         this.value = data.getValue();
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringConditionEval.java
@@ -16,10 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.StringData;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An evaluation state for string condition.
@@ -36,13 +36,13 @@ public class StringConditionEval extends ConditionEval {
     private String value;
 
     public StringConditionEval() {
-        super(false, 0);
+        super(false, 0, null);
         this.condition = null;
         this.value = null;
     }
 
     public StringConditionEval(StringCondition condition, StringData data) {
-        super(condition.match(data.getValue()), data.getTimestamp());
+        super(condition.match(data.getValue()), data.getTimestamp(), data.getContext());
         this.condition = condition;
         this.value = data.getValue();
         if (this.condition != null) {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdConditionEval.java
@@ -16,10 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import org.hawkular.alerts.api.model.data.NumericData;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-import org.hawkular.alerts.api.model.data.NumericData;
 
 /**
  * An evaluation state for threshold condition.
@@ -36,11 +36,12 @@ public class ThresholdConditionEval extends ConditionEval {
     private Double value;
 
     public ThresholdConditionEval() {
-        super();
+        super(false, 0, null);
+        this.value = Double.NaN;
     }
 
     public ThresholdConditionEval(ThresholdCondition condition, NumericData data) {
-        super(condition.match(data.getValue()), data.getTimestamp());
+        super(condition.match(data.getValue()), data.getTimestamp(), data.getContext());
         this.condition = condition;
         this.value = data.getValue();
         if (this.condition != null) {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeConditionEval.java
@@ -16,10 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hawkular.alerts.api.model.data.NumericData;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An evaluation state for threshold range condition.
@@ -36,13 +36,13 @@ public class ThresholdRangeConditionEval extends ConditionEval {
     private Double value;
 
     public ThresholdRangeConditionEval() {
-        super(false, 0);
+        super(false, 0, null);
         this.condition = null;
         this.value = null;
     }
 
     public ThresholdRangeConditionEval(ThresholdRangeCondition condition, NumericData data) {
-        super(condition.match(data.getValue()), data.getTimestamp());
+        super(condition.match(data.getValue()), data.getTimestamp(), data.getContext());
         this.condition = condition;
         this.value = data.getValue();
         if (this.condition != null) {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Availability.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import java.util.Map;
+
 /**
  * An availability incoming data.
  *
@@ -29,7 +31,7 @@ public class Availability extends Data {
     }
 
     public Availability() {
-        this(null, 0, AvailabilityType.UP);
+        this(null, 0, AvailabilityType.UP, null);
     }
 
     /**
@@ -38,12 +40,26 @@ public class Availability extends Data {
      * @param value Must be a valid {@link AvailabilityType} name.
      */
     public Availability(String id, long timestamp, String value) {
-        super(id, timestamp, (null == value) ? AvailabilityType.UP : AvailabilityType.valueOf(value),
-                Type.AVAILABILITY);
+        this(id, timestamp, value, null);
     }
 
     public Availability(String id, long timestamp, AvailabilityType value) {
-        super(id, timestamp, (null == value) ? AvailabilityType.UP : value, Type.AVAILABILITY);
+        this(id, timestamp, value, null);
+    }
+
+    /**
+     * @param id the id
+     * @param timestamp the timestamp
+     * @param value Must be a valid {@link AvailabilityType} name.
+     * @param context optional, contextual name-value pairs to be stored with the data.
+     */
+    public Availability(String id, long timestamp, String value, Map<String, String> context) {
+        super(id, timestamp, (null == value) ? AvailabilityType.UP : AvailabilityType.valueOf(value),
+                Type.AVAILABILITY, context);
+    }
+
+    public Availability(String id, long timestamp, AvailabilityType value, Map<String, String> context) {
+        super(id, timestamp, (null == value) ? AvailabilityType.UP : value, Type.AVAILABILITY, context);
     }
 
     public AvailabilityType getValue() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -48,10 +51,11 @@ public abstract class Data implements Comparable<Data> {
     @JsonInclude
     protected Type type;
 
+    @JsonInclude(Include.NON_EMPTY)
+    protected Map<String, String> context;
+
+    // Default constructor is needed for JSON libraries in JAX-RS context.
     public Data() {
-        /*
-            Default constructor is needed for JSON libraries in JAX-RS context.
-         */
         this.id = null;
     }
 
@@ -62,10 +66,22 @@ public abstract class Data implements Comparable<Data> {
      * @param type the type of data
      */
     public Data(String id, long timestamp, Object value, Type type) {
+        this(id, timestamp, value, type, null);
+    }
+
+    /**
+     * @param id not null
+     * @param timestamp in millis, if less than 1 assigned currentTime.
+     * @param value the value
+     * @param type the type of data
+     * @param context optional, contextual name-value pairs to be stored with the data.
+     */
+    public Data(String id, long timestamp, Object value, Type type, Map<String, String> context) {
         this.id = id;
         this.timestamp = (timestamp <= 0) ? System.currentTimeMillis() : timestamp;
         this.value = value;
         this.type = type;
+        this.context = context;
     }
 
     public String getId() {
@@ -103,12 +119,30 @@ public abstract class Data implements Comparable<Data> {
         this.type = type;
     }
 
+    public Map<String, String> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String, String> context) {
+        this.context = context;
+    }
+
+    public void addProperty(String name, String value) {
+        if (null == name || null == value) {
+            throw new IllegalArgumentException("Propety must have non-null name and value");
+        }
+        if (null == context) {
+            context = new HashMap<>();
+        }
+        context.put(name, value);
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = prime * result + (int)(timestamp ^ (timestamp >>> 32));
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
     }
@@ -121,7 +155,7 @@ public abstract class Data implements Comparable<Data> {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        Data other = (Data) obj;
+        Data other = (Data)obj;
         if (id == null) {
             if (other.id != null)
                 return false;
@@ -139,7 +173,7 @@ public abstract class Data implements Comparable<Data> {
 
     @Override
     public String toString() {
-        return "Data [id=" + id + ", timestamp=" + timestamp + ", value=" + value + "]";
+        return "Data [id=" + id + ", timestamp=" + timestamp + ", value=" + value + ", context=" + context + "]";
     }
 
     @Override

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/NumericData.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import java.util.Map;
+
 /**
  * A numeric incoming data.
  *
@@ -24,15 +26,17 @@ package org.hawkular.alerts.api.model.data;
  */
 public class NumericData extends Data {
 
+    // Default constructor is needed for JSON libraries in JAX-RS context.
     public NumericData() {
-        /*
-            Default constructor is needed for JSON libraries in JAX-RS context.
-         */
-        this(null, 0, Double.NaN);
+        this(null, 0, Double.NaN, null);
     }
 
     public NumericData(String id, long timestamp, Double value) {
-        super(id, timestamp, (null == value) ? Double.NaN : value, Type.NUMERIC);
+        this(id, timestamp, value, null);
+    }
+
+    public NumericData(String id, long timestamp, Double value, Map<String, String> context) {
+        super(id, timestamp, (null == value) ? Double.NaN : value, Type.NUMERIC, context);
     }
 
     public Double getValue() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/StringData.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import java.util.Map;
+
 /**
  * A string incoming data.
  *
@@ -24,15 +26,17 @@ package org.hawkular.alerts.api.model.data;
  */
 public class StringData extends Data {
 
+    // Default constructor is needed for JSON libraries in JAX-RS context.
     public StringData() {
-        /*
-            Default constructor is needed for JSON libraries in JAX-RS context.
-         */
-        this(null, 0, "");
+        this(null, 0, "", null);
     }
 
     public StringData(String id, long timestamp, String value) {
-        super(id, timestamp, (null == value) ? "" : value, Type.STRING);
+        this(id, timestamp, value, null);
+    }
+
+    public StringData(String id, long timestamp, String value, Map<String, String> context) {
+        super(id, timestamp, (null == value) ? "" : value, Type.STRING, context);
     }
 
     public String getValue() {

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonJacksonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonJacksonTest.java
@@ -190,7 +190,7 @@ public class JsonJacksonTest {
         String str = "{\"evalTimestamp\":1,\"dataTimestamp\":1," +
                 "\"condition\":" +
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\",\"dataId\":\"Default\",\"operator\":\"UP\"}," +
-                "\"value\":\"UP\"}";
+                "\"value\":\"UP\",\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         AvailabilityConditionEval eval = objectMapper.readValue(str, AvailabilityConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -201,6 +201,9 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getDataId().equals("Default"));
         assertTrue(eval.getCondition().getOperator().equals(AvailabilityCondition.Operator.UP));
         assertTrue(eval.getValue().equals(AvailabilityType.UP));
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
     }
 
     @Test
@@ -294,7 +297,7 @@ public class JsonJacksonTest {
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default1\",\"operator\":\"LT\",\"data2Id\":\"Default2\",\"data2Multiplier\":1.2}," +
                 "\"value1\":10.0," +
-                "\"value2\":15.0}";
+                "\"value2\":15.0,\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"},\"context2\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         CompareConditionEval eval = objectMapper.readValue(str, CompareConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -306,6 +309,12 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getOperator().equals(CompareCondition.Operator.LT));
         assertTrue(eval.getValue1().equals(10.0));
         assertTrue(eval.getValue2().equals(15.0));
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
+        assertTrue(eval.getContext2().size() == 2);
+        assertTrue(eval.getContext2().get("n1").equals("v1"));
+        assertTrue(eval.getContext2().get("n2").equals("v2"));
     }
 
     @Test
@@ -396,7 +405,7 @@ public class JsonJacksonTest {
                 "\"condition\":" +
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"MATCH\",\"pattern\":\"test-pattern\",\"ignoreCase\":false}," +
-                "\"value\":\"test-value\"}";
+                "\"value\":\"test-value\",\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         StringConditionEval eval = objectMapper.readValue(str, StringConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -409,6 +418,9 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getPattern().equals("test-pattern"));
         assertFalse(eval.getCondition().isIgnoreCase());
         assertTrue(eval.getValue().equals("test-value"));
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
     }
 
     @Test
@@ -488,7 +500,7 @@ public class JsonJacksonTest {
                 "\"condition\":" +
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operator\":\"LT\",\"threshold\":10.5}," +
-                "\"value\":1.0}";
+                "\"value\":1.0,\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         ThresholdConditionEval eval = objectMapper.readValue(str, ThresholdConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -500,6 +512,9 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getOperator().equals(ThresholdCondition.Operator.LT));
         assertTrue(eval.getCondition().getThreshold() == 10.5);
         assertTrue(eval.getValue() == 1.0);
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
     }
 
     @Test
@@ -626,7 +641,7 @@ public class JsonJacksonTest {
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"operatorLow\":\"INCLUSIVE\",\"operatorHigh\":\"INCLUSIVE\"," +
                 "\"thresholdLow\":10.5,\"thresholdHigh\":20.5,\"inRange\":true}," +
-                "\"value\":1.0}";
+                "\"value\":1.0,\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         ThresholdRangeConditionEval eval = objectMapper.readValue(str, ThresholdRangeConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -640,6 +655,9 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getThresholdLow() == 10.5);
         assertTrue(eval.getCondition().getThresholdHigh() == 20.5);
         assertTrue(eval.getValue() == 1.0);
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
     }
 
     @Test
@@ -668,7 +686,7 @@ public class JsonJacksonTest {
                 "{\"triggerId\":\"test\",\"triggerMode\":\"FIRING\"," +
                 "\"dataId\":\"Default\",\"systemId\":\"HawkularMetrics\"," +
                 "\"expression\":\"metric:5:avg(foo > 100.5)\"}," +
-                "\"value\":\"foo\"}";
+                "\"value\":\"foo\",\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         ExternalConditionEval eval = objectMapper.readValue(str, ExternalConditionEval.class);
 
         assertTrue(eval.getEvalTimestamp() == 1);
@@ -680,6 +698,9 @@ public class JsonJacksonTest {
         assertTrue(eval.getCondition().getSystemId().equals("HawkularMetrics"));
         assertTrue(eval.getCondition().getExpression().equals("metric:5:avg(foo > 100.5)"));
         assertTrue(eval.getValue().equals("foo"));
+        assertTrue(eval.getContext().size() == 2);
+        assertTrue(eval.getContext().get("n1").equals("v1"));
+        assertTrue(eval.getContext().get("n2").equals("v2"));
     }
 
     @Test
@@ -730,41 +751,59 @@ public class JsonJacksonTest {
 
     @Test
     public void jsonDataTest() throws Exception {
-        String str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"UNAVAILABLE\"}";
+        String str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"UP\",\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         Availability aData = objectMapper.readValue(str, Availability.class);
 
         assertTrue(aData.getId().equals("test"));
         assertTrue(aData.getTimestamp() == 1);
-        assertTrue(aData.getValue().equals(AvailabilityType.UNAVAILABLE));
+        assertTrue(aData.getValue().equals(AvailabilityType.UP));
+        assertTrue(aData.getContext() != null);
+        assertTrue(aData.getContext().size() == 2);
+        assertTrue(aData.getContext().get("n1").equals("v1"));
+        assertTrue(aData.getContext().get("n2").equals("v2"));
 
         String output = objectMapper.writeValueAsString(aData);
 
         assertTrue(output.contains("type"));
         assertTrue(output.contains("AVAILABILITY"));
+        assertTrue(output.contains("n1"));
+        assertTrue(output.contains("v1"));
 
-        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":10.45}";
+        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":10.45,\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         NumericData nData = objectMapper.readValue(str, NumericData.class);
 
         assertTrue(nData.getId().equals("test"));
         assertTrue(nData.getTimestamp() == 1);
         assertTrue(nData.getValue() == 10.45);
+        assertTrue(nData.getContext() != null);
+        assertTrue(nData.getContext().size() == 2);
+        assertTrue(nData.getContext().get("n1").equals("v1"));
+        assertTrue(nData.getContext().get("n2").equals("v2"));
 
         output = objectMapper.writeValueAsString(nData);
 
         assertTrue(output.contains("type"));
         assertTrue(output.contains("NUMERIC"));
+        assertTrue(output.contains("n1"));
+        assertTrue(output.contains("v1"));
 
-        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"test-value\"}";
+        str = "{\"id\":\"test\",\"timestamp\":1,\"value\":\"test-value\",\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
         StringData sData = objectMapper.readValue(str, StringData.class);
 
         assertTrue(sData.getId().equals("test"));
         assertTrue(sData.getTimestamp() == 1);
         assertTrue(sData.getValue().equals("test-value"));
+        assertTrue(sData.getContext() != null);
+        assertTrue(sData.getContext().size() == 2);
+        assertTrue(sData.getContext().get("n1").equals("v1"));
+        assertTrue(sData.getContext().get("n2").equals("v2"));
 
         output = objectMapper.writeValueAsString(sData);
 
         assertTrue(output.contains("type"));
         assertTrue(output.contains("STRING"));
+        assertTrue(output.contains("n1"));
+        assertTrue(output.contains("v1"));
     }
 
     @Test

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/MemActionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/MemActionsServiceImpl.java
@@ -16,15 +16,16 @@
  */
 package org.hawkular.alerts.engine.impl;
 
-import org.hawkular.alerts.api.model.action.Action;
-import org.hawkular.alerts.api.services.ActionsService;
-import org.hawkular.alerts.api.services.ActionListener;
-import org.hawkular.alerts.engine.log.MsgLogger;
-import org.jboss.logging.Logger;
-
-import javax.ejb.Singleton;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.ejb.Singleton;
+
+import org.hawkular.alerts.api.model.action.Action;
+import org.hawkular.alerts.api.services.ActionListener;
+import org.hawkular.alerts.api.services.ActionsService;
+import org.hawkular.alerts.engine.log.MsgLogger;
+import org.jboss.logging.Logger;
 
 /**
  * A memory implementation of {@link org.hawkular.alerts.api.services.ActionsService}.


### PR DESCRIPTION
Allow any datum sent into Alerting for evaluation to carry optional,
non-matching contextual data.  This data can then be used by Alert
consumers, via the "evalsSet", to better understand the context in
which the data was collected.  For example, for a slow Tx, perhaps the
TxId, or even a query string.