### PR TITLE
HAWKULAR-428 Reduce swagger packaging

### DIFF
--- a/hawkular-alerts-api/pom.xml
+++ b/hawkular-alerts-api/pom.xml
@@ -73,10 +73,13 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-core_2.10</artifactId>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/hawkular-alerts-engine/pom.xml
+++ b/hawkular-alerts-engine/pom.xml
@@ -64,6 +64,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
       <version>${version.org.drools}</version>

--- a/hawkular-alerts-rest/pom.xml
+++ b/hawkular-alerts-rest/pom.xml
@@ -91,10 +91,12 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-core_2.10</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Tests -->


### PR DESCRIPTION
This solves the alerts component only.  Change the wordnik (swagger)
dependency scopes to provided. The -Pdocgen stuff is performed at
compile-time only.  We don't need the support at runtime so using
'provided' is the way to limit the transitive imports.  Note that the
engine module was actually depending on the transitive deps via the
api module, so we needed to add fasterxml deps to engine. We do this
via resteasy, which we can set as provided by WFly.  (although, I'm not
sure if we may want to use explicit fasterxml deps in the future to be
more explicit and to potentially protect against actually needed resteasy)