### PR TITLE
Hwkalerts 74

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/java/org/hawkular/alerts/actions/file/FilePlugin.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/java/org/hawkular/alerts/actions/file/FilePlugin.java
@@ -46,7 +46,8 @@ public class FilePlugin implements ActionPluginListener {
     private ObjectMapper objectMapper;
 
     public FilePlugin() {
-        defaultProperties.put("path", "/tmp/hawkular/actions/file");
+        defaultProperties.put("path",
+                new File(System.getProperty("java.io.tmpdir"), "hawkular/actions/file").getAbsolutePath());
         objectMapper = new ObjectMapper();
     }
 

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -133,7 +133,7 @@ public class Alert {
         this.ctime = System.currentTimeMillis();
         this.status = Status.OPEN;
 
-        this.alertId = triggerId + "|" + ctime;
+        this.alertId = triggerId + "-" + ctime;
     }
 
     public String getTenantId() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ConditionEval.java
@@ -47,10 +47,6 @@ public abstract class ConditionEval {
     @JsonInclude
     protected long dataTimestamp;
 
-    // flag noting whether this condition eval was used in a tested Tuple and already applied to dampening
-    @JsonIgnore
-    protected boolean used;
-
     @JsonInclude
     protected Condition.Type type;
 
@@ -66,7 +62,6 @@ public abstract class ConditionEval {
         this.match = match;
         this.dataTimestamp = dataTimestamp;
         this.evalTimestamp = System.currentTimeMillis();
-        this.used = false;
         this.context = context;
     }
 
@@ -92,14 +87,6 @@ public abstract class ConditionEval {
 
     public void setDataTimestamp(long dataTimestamp) {
         this.dataTimestamp = dataTimestamp;
-    }
-
-    public boolean isUsed() {
-        return used;
-    }
-
-    public void setUsed(boolean used) {
-        this.used = used;
     }
 
     public Condition.Type getType() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -344,17 +344,6 @@ public class Dampening {
                 throw new IllegalArgumentException("Unexpected Match type: " + match.name());
         }
 
-        if (Match.ALL == match) {
-        } else {
-            for (ConditionEval ce : currentEvals.values()) {
-
-                if (!ce.isMatch()) {
-                    trueEval = false;
-                    break;
-                }
-            }
-        }
-
         // If we had previously started our time and now have exceeded our time limit then we must start over
         long now = System.currentTimeMillis();
         if (type == Type.RELAXED_TIME && trueEvalsStartTime != 0L) {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -108,10 +108,13 @@ public class Dampening {
      * no time limit for the evaluations.
      * @param triggerId the triggerId
      * @param triggerMode the trigger mode for when this dampening is active
-     * @param numConsecutiveTrueEvals the numConsecutiveTrueEvals
+     * @param numConsecutiveTrueEvals the numConsecutiveTrueEvals, >= 1.
      * @return the configured Dampening
      */
     public static Dampening forStrict(String triggerId, Mode triggerMode, int numConsecutiveTrueEvals) {
+        if (numConsecutiveTrueEvals < 1) {
+            throw new IllegalArgumentException("NumConsecutiveTrueEvals must be >= 1");
+        }
         return new Dampening(triggerId, triggerMode, Type.STRICT, numConsecutiveTrueEvals, numConsecutiveTrueEvals, 0);
     }
 
@@ -120,11 +123,17 @@ public class Dampening {
      * no time limit for the evaluations.
      * @param triggerId the triggerId
      * @param triggerMode the trigger mode for when this dampening is active
-     * @param numTrueEvals the numTrueEvals
-     * @param numTotalEvals the numTotalEvals
+     * @param numTrueEvals the numTrueEvals, >=1
+     * @param numTotalEvals the numTotalEvals, > numTotalEvals
      * @return the configured Dampening
      */
     public static Dampening forRelaxedCount(String triggerId, Mode triggerMode, int numTrueEvals, int numTotalEvals) {
+        if (numTrueEvals < 1) {
+            throw new IllegalArgumentException("NumTrueEvals must be >= 1");
+        }
+        if (numTotalEvals <= numTrueEvals) {
+            throw new IllegalArgumentException("NumTotalEvals must be > NumTrueEvals");
+        }
         return new Dampening(triggerId, triggerMode, Type.RELAXED_COUNT, numTrueEvals, numTotalEvals, 0);
     }
 
@@ -134,12 +143,18 @@ public class Dampening {
      * the requisite data must be supplied in a timely manner.
      * @param triggerId the triggerId
      * @param triggerMode the trigger mode for when this dampening is active
-     * @param numTrueEvals the numTrueEvals
+     * @param numTrueEvals the numTrueEvals, >= 1.
      * @param evalPeriod Elapsed real time, in milliseconds. In other words, this is not measured against
-     * collectionTimes (i.e. the timestamp on the data) but rather the evaluation times.
+     * collectionTimes (i.e. the timestamp on the data) but rather the evaluation times. >=1ms.
      * @return the configured Dampening
      */
     public static Dampening forRelaxedTime(String triggerId, Mode triggerMode, int numTrueEvals, long evalPeriod) {
+        if (numTrueEvals < 1) {
+            throw new IllegalArgumentException("NumTrueEvals must be >= 1");
+        }
+        if (evalPeriod < 1) {
+            throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
+        }
         return new Dampening(triggerId, triggerMode, Type.RELAXED_TIME, numTrueEvals, 0, evalPeriod);
     }
 
@@ -150,10 +165,13 @@ public class Dampening {
      * @param triggerId the triggerId
      * @param triggerMode the trigger mode for when this dampening is active
      * @param evalPeriod Elapsed real time, in milliseconds. In other words, this is not measured against
-     * collectionTimes (i.e. the timestamp on the data) but rather the evaluation times.
+     * collectionTimes (i.e. the timestamp on the data) but rather the evaluation times.  >=1ms.
      * @return the configured Dampening
      */
     public static Dampening forStrictTime(String triggerId, Mode triggerMode, long evalPeriod) {
+        if (evalPeriod < 1) {
+            throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
+        }
         return new Dampening(triggerId, triggerMode, Type.STRICT_TIME, 0, 0, evalPeriod);
     }
 
@@ -164,10 +182,13 @@ public class Dampening {
      * @param triggerId the triggerId
      * @param triggerMode the trigger mode for when this dampening is active
      * @param evalPeriod Elapsed real time, in milliseconds. In other words, this is not measured against
-     * collectionTimes (i.e. the timestamp on the data) but rather the clock starts at true-evaluation-time-1.
+     * collectionTimes (i.e. the timestamp on the data) but rather the clock starts at true-evaluation-time-1. >=1ms.
      * @return the configured Dampening
      */
     public static Dampening forStrictTimeout(String triggerId, Mode triggerMode, long evalPeriod) {
+        if (evalPeriod < 1) {
+            throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
+        }
         return new Dampening(triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
     }
 

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -256,7 +256,7 @@ rule ProvideDefaultDampening
         if (log != null && log.isDebugEnabled()) {
             log.debug("Adding default " + $tmode + " dampening for trigger! " + $t.getId());
         }
-        Dampening d = new Dampening( $tid, $tmode, Dampening.Type.STRICT, 1, 1, 0L );
+        Dampening d = Dampening.forStrict( $tid, $tmode, 1 );
         insert( d );
 end
 

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -207,58 +207,46 @@ end
 // So, there is one Dampening fact for each Trigger fact.  And it is continually updated given each relevant condition
 // set evaluation for the trigger.
 //
-// Note that there are N rules required to cover triggers with varying numbers of conditions, from 1..N, with N being
-// the maximum number of supported conditions.  Current MAX_CONDITIONS = 4.  This applies to ALL-match triggers,
-// ANY-match triggers can have any number of conditions.
-
-// ConditionEval retraction rules
+// The Dampening fact is updated on each condition evaluation and then the ConditionEvaluation fact is retracted
+// from working memory.  For single-condition triggers it is fairly straightforward; each condition evaluation results
+// in a dampening evaluation.
+//
 // Understanding multi-condition Trigger evaluation is important.  ConditionEvals are generated when the relevant Data
-// appears in working memory.  Because Data for specific Ids can appear at different rates, there can be several
+// appears in working memory.  Data for specific DataIds can appear at different rates. There can be several more
 // ConditionEvals for DataId X than for DataId Y, or even before we have a single eval for DataId Y.  Our approach is
 // chosen for two reasons: simplicity of understanding, and the general desire for recency in alerting.  For 
 // *multi-condition* Trigger evaluations we test only tuples containing the most recent evaluation of each condition.
-// For example, consider a Trigger T with two conditions, (X > 100) and (Y > 200).  Now assume Data arrives like this:
-// (t1, X=125), (t2, X=50), (t3, Y=300), (t4, X=110), (t5, Y=150). The t1 evaluation of X=125 will be superseded by the
-// t2 evaluation of X=50. When Y is finally reported at t3, the tuple tested for T is (X=50, Y=300), which will not
-// fire an Alert because the X condition (50 > 100 ) evaluates to false.  At t4 we the tuple (X=110, Y=300) will
-// evaluate to true, firing T.  And at t5 the evaluation of Y=300 will be superseded by Y=150, the tuple (X=110, Y=150)
-// will evaluate to false and T will not fire.
+//
+// For example, consider an ALL-match Trigger T with two conditions, (X > 100) and (Y > 200), and dampening Strict(2).
+// Now assume Data arrives like this:
+//     t1, X=125
+//     t2, X=50
+//     t3, Y=300
+//     t4, X=110
+//     t5, Y=150
+// The t1 condition eval of X=125 will be superseded by the t2 condition eval of X=50. When Y is finally reported at t3,
+// the tuple tested for T is (X=50, Y=300). The dampening eval is false because the X condition (50 > 100) is false.
+// At t4 we test the tuple (X=110, Y=300). The dampening eval is true because both conditions are met.  T does not
+// fire because we need two consecutive true tuples. At t5 the condition eval of Y=300 will be superseded by
+// Y=150, the tuple (X=110, Y=150) will evaluate to false.  T will not fire, the dampening will reset.
+//
+// Now assume T were an ANY-match trigger. For ANY-match we still use a tuple with the most recent evaluation for each
+// condition. But, we don't need an evaluation for every condition, and we only need one condition eval to be true in
+// order to satisfy the T.  The t1 evaluation of (x=125, Y=N/A) is true because the X condition is true. We can ignore
+// the Y condition.  T does not fire because we need two consecutive true tuples.  The t2 evaluation of (x=50, Y=N/A)
+// is false. T does not fire, the dampening is reset.  The t3 evaluation of (x=50, Y=300) is true because the Y
+// condition is true. T does not fire because we need two consecutive true tuples.  The t4 evaluation of (x=110, Y=300)
+// is true in both ways.  T fires and the dampening is reset. The t5 evaluation of (x=110, Y=150) is true because the
+// X condtion is again true, and so on...
 //
 // Given the above approach to matching, we must hold onto the most recent evaluation of each condition used in
-// a multi-condition Trigger.  For a single-condition Trigger we can  immediately retract the ConditionEval after
-// Dampening is updated.  Note that "ANY"-match multi-condition Triggers are equivalent to a single-condition Trigger
-// with respect to retraction, but all others must be retracted only when replaced by a more recent eval.  Additionally,
-// we must prevent updating dampening on the same Tuple multiple times.  To do that we do two things:
-//   - mark the ConditionEvals used in a tested Tuple as "used".
-//   - require at least one unused ConditionEval in a tested Tuple.
-// Note that because Dampening can be updated outside of the rule performing the dampening update, using "no-loop true"
-// is not sufficient.  For example, Dampening is reset when an Trigger is fired.
+// a multi-condition Trigger.  What is important to understand is the most recent evaluation of each condition
+// is held inside the relevant Dampening record and not as a Fact in working memory.  That allows us to have very
+// simple processing here in the rules.  We just take every condition evaluation, have the required dampening
+// Fact process it, and then retract the ConditionEvaluation.
 //
-// The retraction rule executes at a higher-than-default salience (priority) to ensure that only the most recent
-// ConditionEval is applied to Dampening updates.
-//
-// Note that despite being retracted as a fact, the XxxEval pojos are maintained in the Dampening pojo as auditing
-// information for any firing of the Trigger.
-
-rule RetractObsoleteConditionEval
-    salience 10
-    when
-        $ce1 : ConditionEval( $tid : triggerId, ( conditionSetSize > 1 ), $csi : conditionSetIndex, $t1 : evalTimestamp )
-        $ce2 : ConditionEval( $tid == triggerId, $csi == conditionSetIndex, $t1 > evalTimestamp )
-    then
-        retract( $ce2 );
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Retracted obsolete multi-condition eval %s (due to %s)", $ce2, $ce1);
-        }
-end
-
 
 // Dampening update rules
-// Note that single-condition Triggers can retract the ConditionEval immediately because it is not needed to
-// form a future Tuple.  ANY-match Triggers are treated as single-condition because only the single-condition must
-// evaluate to true.
-// For multi-condition Triggers the ConditionEvals can not be retracted and instead must be set to "used". Those
-// ConditionEvals are instead retracted by "RetractObsoleteConditionEval" when a newer Eval comes into WM.
 
 rule ProvideDefaultDampening
     when
@@ -272,122 +260,25 @@ rule ProvideDefaultDampening
         insert( d );
 end
 
-rule DampenTriggerAny
+rule DampenTrigger
     when
-        $t  : Trigger( match == Match.ANY, $tid : id, $tmode : mode )
+        $t  : Trigger( $tid : id, $tmode : mode )
         $d  : Dampening( triggerId == $tid, triggerMode == $tmode, satisfied == false )
         $ce : ConditionEval ( triggerId == $tid )
     then
         retract( $d );
         retract ( $ce );
 
-        $d.perform( $ce );
+        $d.perform( $t.getMatch(), $ce );
 
         insert( $d );
 
         if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Updated (ANY) %s and retracted %s", $d, $ce);
+            log.debugf( "Updated %s using [match=%s] %s", $d, $t.getMatch(), $d.getCurrentEvals().values() );
+            log.debugf( "Retracted %s", $ce );
         }
 end
 
-rule DampenOneConditionTrigger
-    when
-        $t  : Trigger( match == Match.ALL, $tid : id, $tmode : mode )
-        $d  : Dampening( triggerId == $tid, triggerMode == $tmode, satisfied == false )
-        $ce : ConditionEval ( triggerId == $tid, conditionSetSize == 1, conditionSetIndex == 1 )
-    then
-        retract( $d );
-        retract ( $ce );
-
-        $d.perform( $ce );
-
-        insert( $d );
-
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Updated %s and retracted %s", $d, $ce);
-        }
-end
-
-rule DampenTwoConditionTrigger
-    when
-        $t   : Trigger( match == Match.ALL, $tid : id, $tmode : mode )
-        $d   : Dampening( triggerId == $tid, triggerMode == $tmode, satisfied == false )
-        $ce1 : ConditionEval ( triggerId == $tid, conditionSetSize == 2, conditionSetIndex == 1 )
-        $ce2 : ConditionEval ( triggerId == $tid, conditionSetSize == 2, conditionSetIndex == 2 )
-        exists ConditionEval ( triggerId == $tid, used == false )
-    then
-        retract( $d );
-
-        $d.perform( $ce1, $ce2 );
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Updated %s with %s, %s", $d, $ce1, $ce2);
-        }
-
-        insert( $d );
-
-        for( ConditionEval ce : new ConditionEval[] { $ce1, $ce2 } ) {
-            if ( ! ce.isUsed() ) {
-                retract( ce );
-                ce.setUsed( true );
-                insert( ce );
-            }
-        }
-end
-
-rule DampenThreeConditionTrigger
-    when
-        $t   : Trigger( match == Match.ALL, $tid : id, $tmode : mode )
-        $d   : Dampening( triggerId == $tid, triggerMode == $tmode, satisfied == false )
-        $ce1 : ConditionEval ( triggerId == $tid, conditionSetSize == 3, conditionSetIndex == 1 )
-        $ce2 : ConditionEval ( triggerId == $tid, conditionSetSize == 3, conditionSetIndex == 2 )
-        $ce3 : ConditionEval ( triggerId == $tid, conditionSetSize == 3, conditionSetIndex == 3 )
-        exists ConditionEval ( triggerId == $tid, used == false )
-    then
-        retract( $d )
-
-        $d.perform( $ce1, $ce2, $ce3 );
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Updated %s with %s, %s, %s", $d, $ce1, $ce2, $ce3);
-        }
-
-        insert( $d );
-
-        for( ConditionEval ce : new ConditionEval[] { $ce1, $ce2, $ce3 } ) {
-            if ( ! ce.isUsed() ) {
-                retract( ce );
-                ce.setUsed( true );
-                insert( ce );
-            }
-        }
-end
-
-rule DampenFourConditionTrigger
-    when
-        $t   : Trigger( match == Match.ALL, $tid : id, $tmode : mode )
-        $d   : Dampening( triggerId == $tid, triggerMode == $tmode, satisfied == false )
-        $ce1 : ConditionEval ( triggerId == $tid, conditionSetSize == 4, conditionSetIndex == 1 )
-        $ce2 : ConditionEval ( triggerId == $tid, conditionSetSize == 4, conditionSetIndex == 2 )
-        $ce3 : ConditionEval ( triggerId == $tid, conditionSetSize == 4, conditionSetIndex == 3 )
-        $ce4 : ConditionEval ( triggerId == $tid, conditionSetSize == 4, conditionSetIndex == 4 )
-        exists ConditionEval ( triggerId == $tid, used == false )
-    then
-        retract( $d )
-
-        $d.perform( $ce1, $ce2, $ce3, $ce4 );
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf( "Updated %s with %s, %s, %s, %s", $d, $ce1, $ce2, $ce3, $ce4);
-        }
-
-        insert( $d );
-
-        for( ConditionEval ce : new ConditionEval[] { $ce1, $ce2, $ce3, $ce4 } ) {
-            if ( ! ce.isUsed() ) {
-                retract( ce );
-                ce.setUsed( true );
-                insert( ce );
-            }
-        }
-end
 
 // Dampening with STRICT_TIMEOUT
 // Because we are not running the engine in Stream/CEP mode and instead use discrete rulebase executions, we

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
@@ -40,7 +40,7 @@ class DampeningITest extends AbstractITestBase {
         def resp = client.post(path: "triggers", body: testTrigger)
         assertEquals(200, resp.status)
 
-        Dampening d = new Dampening("test-trigger-6", Mode.FIRING, Type.RELAXED_COUNT, 1, 1, 1);
+        Dampening d = Dampening.forRelaxedCount("test-trigger-6", Mode.FIRING, 1, 2);
 
         resp = client.post(path: "triggers/test-trigger-6/dampenings", body: d)
         assertEquals(200, resp.status)

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -113,13 +113,15 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
             if ( resp.status == 200 && resp.data != null && resp.data.size > 0) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -227,13 +229,15 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -271,13 +275,15 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED"] )
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -349,12 +355,14 @@ class LifecycleITest extends AbstractITestBase {
 
         // The alert processing happens async, so give it a little time before failing...
         for ( int i=0; i < 20; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 5
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger"] )
             if ( resp.status == 200 && resp.data.size() == 5 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
         }
@@ -598,13 +606,15 @@ class LifecycleITest extends AbstractITestBase {
         }
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            // println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 5
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger"] )
             if ( resp.status == 200 && resp.data != null && resp.data.size() == 5 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
         }
@@ -730,14 +740,16 @@ class LifecycleITest extends AbstractITestBase {
         /*
              Step 9: Wait until the engine detects the data, matches the conditions and sends an alert
          */
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
             /*
                 We should have only 1 alert
              */
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -800,14 +812,16 @@ class LifecycleITest extends AbstractITestBase {
              Step 15: Wait until the engine detects the data
                       It should retrieve 2 data
          */
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
             /*
                 We should have only 2 alert
              */
             if ( resp.status == 200 && resp.data.size() == 2 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -880,13 +894,15 @@ class LifecycleITest extends AbstractITestBase {
         }
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1 because the trigger should have disabled after firing
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoenable-trigger"] )
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
         }
@@ -994,13 +1010,15 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent alerts for trigger, there should be 1
             resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-autoresolve-trigger"] )
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)
@@ -1044,14 +1062,16 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // The alert processing happens async, so give it a little time before failing...
-        for ( int i=0; i < 10; ++i ) {
-            println "SLEEP!" ;
-            Thread.sleep(1000);
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
 
             // FETCH recent OPEN alerts for trigger, there should be 1
             resp = client.get(path: "",
                 query: [startTime:start,triggerIds:"test-manual-autoresolve-trigger",statuses:"OPEN"] )
             if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    println( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
                 break;
             }
             assertEquals(200, resp.status)


### PR DESCRIPTION
Change approach to support dampening for ANY-Match triggers.  The change moves the current condition eval set from working memory (as facts in the rule engine) to the trigger's Dampening record itself.  This actually ended up having some addition benefits other than allowing ANY-Match dampening:
- It simplified the rules and removed the condition limit for ALL-Match triggers (was 4 conditions).
- After repeated runs of the -Pperf engine unit tests I see engine execution speed reduced by ~37%!

After rebasing on master this PR branch had some work done to resolve issues unrelated to the dampening issue that can also be reviewed:
- The File action plugin needed to be adapted to work on windows
- The CassCluster.getSession() method was made synchronized.