### PR TITLE
Add context map at Condition level

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/pom.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/pom.xml
@@ -39,6 +39,13 @@
       <version>${version.org.freemarker}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-actions-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/pom.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-actions-plugins</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-actions-tests</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerts Actions Tests</name>
+
+</project>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/CommonData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/CommonData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+
+/**
+ * Common variables for action tests scenarios
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public abstract class CommonData {
+
+    public static final String TEST_TENANT = "test-tenant";
+    public static final String ACK_BY = "ack-user";
+    public static final String ACK_NOTES = "These ack notes are automatically generated";
+    public static final String RESOLVED_BY = "resolve-user";
+    public static final String RESOLVED_NOTES = "These resolved notes are automatically generated";
+
+    public static Alert ackAlert(Alert openAlert) {
+        if (null == openAlert) return null;
+        openAlert.setStatus(Alert.Status.ACKNOWLEDGED);
+        openAlert.setAckBy(ACK_BY);
+        openAlert.setAckNotes(ACK_NOTES);
+        openAlert.setAckTime(System.currentTimeMillis());
+        return openAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
@@ -61,28 +61,28 @@ public class JvmGarbageCollectionData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdCondition.Operator.GT,
                 1000d);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "GC Duration");
         firingCondition.getContext().put("unit", "ms");
 
-        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 ThresholdCondition.Operator.LTE,
                 1000d);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "GC Duration");
         autoResolveCondition.getContext().put("unit", "ms");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Garbage Collection Alerts on Jvm resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class JvmGarbageCollectionData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdCondition firingCondition;
+    public static ThresholdCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "JVM");
+
+        String triggerId = "thevault~local-jvm-garbage-collection-trigger";
+        String triggerDescription = "JVM Garbage Collection for thevault~Local";
+        String dataId = "thevault~local-jvm-garbage-collection-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdCondition.Operator.GT,
+                1000d);
+        firingCondition.getContext().put("description", "GC Duration");
+        firingCondition.getContext().put("unit", "ms");
+
+        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                ThresholdCondition.Operator.LTE,
+                1000d);
+        autoResolveCondition.getContext().put("description", "GC Duration");
+        autoResolveCondition.getContext().put("unit", "ms");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                1900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                1800d);
+        ThresholdConditionEval eval2 = new ThresholdConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
@@ -61,8 +61,7 @@ public class JvmHeapUsageData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.INCLUSIVE,
@@ -70,11 +69,11 @@ public class JvmHeapUsageData extends CommonData {
                 100d,
                 300d,
                 false);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Heap Usage");
         firingCondition.getContext().put("unit", "Mb");
 
-        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.EXCLUSIVE,
@@ -82,13 +81,14 @@ public class JvmHeapUsageData extends CommonData {
                 100d,
                 300d,
                 true);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Heap Usage");
         autoResolveCondition.getContext().put("unit", "Mb");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Heap Usage Alerts on Jvm resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class JvmHeapUsageData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdRangeCondition firingCondition;
+    public static ThresholdRangeCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "JVM");
+
+        String triggerId = "thevault~local-jvm-heap-usage-trigger";
+        String triggerDescription = "JVM Heap Usage for thevault~Local";
+        String dataId = "thevault~local-jvm-heap-usage-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                100d,
+                300d,
+                false);
+        firingCondition.getContext().put("description", "Heap Usage");
+        firingCondition.getContext().put("unit", "Mb");
+
+        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                100d,
+                300d,
+                true);
+        autoResolveCondition.getContext().put("description", "Heap Usage");
+        autoResolveCondition.getContext().put("unit", "Mb");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                315d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                350d);
+        ThresholdRangeConditionEval eval2 = new ThresholdRangeConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                150d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
@@ -61,8 +61,7 @@ public class JvmNonHeapUsageData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.INCLUSIVE,
@@ -70,11 +69,11 @@ public class JvmNonHeapUsageData extends CommonData {
                 100d,
                 300d,
                 false);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Heap Usage");
         firingCondition.getContext().put("unit", "Mb");
 
-        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.EXCLUSIVE,
@@ -82,13 +81,14 @@ public class JvmNonHeapUsageData extends CommonData {
                 100d,
                 300d,
                 true);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Heap Usage");
         autoResolveCondition.getContext().put("unit", "Mb");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Non Heap Usage Alerts on Jvm resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class JvmNonHeapUsageData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdRangeCondition firingCondition;
+    public static ThresholdRangeCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "JVM");
+
+        String triggerId = "thevault~local-jvm-non-heap-usage-trigger";
+        String triggerDescription = "JVM Non-Heap Usage for thevault~Local";
+        String dataId = "thevault~local-jvm-non-heap-usage-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                100d,
+                300d,
+                false);
+        firingCondition.getContext().put("description", "Heap Usage");
+        firingCondition.getContext().put("unit", "Mb");
+
+        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                100d,
+                300d,
+                true);
+        autoResolveCondition.getContext().put("description", "Heap Usage");
+        autoResolveCondition.getContext().put("unit", "Mb");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                315d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                350d);
+        ThresholdRangeConditionEval eval2 = new ThresholdRangeConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                150d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for multiple conditions alert on Jvm resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class MultipleAllJvmData extends CommonData {
+
+    public static Trigger trigger;
+    public static Condition[] firingConditions;
+    public static Condition[] autoResolveConditions;
+    public static Dampening firingDampening;
+
+    static {
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "JVM");
+
+        String triggerId = "thevault~local-web-multiple-jvm-metrics-trigger";
+        String triggerDescription = "Multiple JVM Metrics for thevault~Local";
+
+    }
+
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
@@ -16,11 +16,24 @@
  */
 package org.hawkular.alerts.actions.tests;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.hawkular.alerts.api.model.condition.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Match;
+import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 
 /**
@@ -42,9 +55,201 @@ public class MultipleAllJvmData extends CommonData {
         context.put("resourceName", "thevault~Local");
         context.put("category", "JVM");
 
+        firingConditions = new Condition[3];
+        autoResolveConditions = new Condition[3];
+        String[] dataId = new String[3];
+
         String triggerId = "thevault~local-web-multiple-jvm-metrics-trigger";
         String triggerDescription = "Multiple JVM Metrics for thevault~Local";
+        dataId[0] = "thevault~local-jvm-garbage-collection-data-id";
+        dataId[1] = "thevault~local-jvm-heap-usage-data-id";
+        dataId[2] = "thevault~local-jvm-non-heap-usage-data-id";
 
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+        trigger.setFiringMatch(Match.ALL);
+        trigger.setAutoResolveMatch(Match.ALL);
+
+        firingConditions[0] = new ThresholdCondition(trigger.getId(),
+                Mode.FIRING,
+                dataId[0],
+                ThresholdCondition.Operator.GT,
+                1000d);
+        firingConditions[0].setTenantId(TEST_TENANT);
+        firingConditions[0].getContext().put("description", "GC Duration");
+        firingConditions[0].getContext().put("unit", "ms");
+
+        autoResolveConditions[0] = new ThresholdCondition(trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId[0],
+                ThresholdCondition.Operator.LTE,
+                1000d);
+        autoResolveConditions[0].setTenantId(TEST_TENANT);
+        autoResolveConditions[0].getContext().put("description", "GC Duration");
+        autoResolveConditions[0].getContext().put("unit", "ms");
+
+
+        firingConditions[1] = new ThresholdRangeCondition(trigger.getId(),
+                Mode.FIRING,
+                dataId[1],
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                100d,
+                300d,
+                false);
+        firingConditions[1].setTenantId(TEST_TENANT);
+        firingConditions[1].getContext().put("description", "Heap Usage");
+        firingConditions[1].getContext().put("unit", "Mb");
+
+        autoResolveConditions[1] = new ThresholdRangeCondition(trigger.getId(),
+                Mode.FIRING,
+                dataId[1],
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                100d,
+                300d,
+                true);
+        autoResolveConditions[1].setTenantId(TEST_TENANT);
+        autoResolveConditions[1].getContext().put("description", "Heap Usage");
+        autoResolveConditions[1].getContext().put("unit", "Mb");
+
+
+        firingConditions[2] = new ThresholdRangeCondition(trigger.getId(),
+                Mode.FIRING,
+                dataId[2],
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                100d,
+                300d,
+                false);
+        firingConditions[2].setTenantId(TEST_TENANT);
+        firingConditions[2].getContext().put("description", "Heap Usage");
+        firingConditions[2].getContext().put("unit", "Mb");
+
+        autoResolveConditions[2] = new ThresholdRangeCondition(trigger.getId(),
+                Mode.FIRING,
+                dataId[2],
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                100d,
+                300d,
+                true);
+        autoResolveConditions[2].setTenantId(TEST_TENANT);
+        autoResolveConditions[2].getContext().put("description", "Heap Usage");
+        autoResolveConditions[2].getContext().put("unit", "Mb");
+
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
+                Mode.FIRING,
+                10000);
+        firingDampening.setTenantId(TEST_TENANT);
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1a = new NumericData(firingConditions[0].getDataId(),
+                System.currentTimeMillis(),
+                1900d);
+        ThresholdConditionEval eval1a = new ThresholdConditionEval((ThresholdCondition) firingConditions[0],
+                rtBadData1a);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+
+        evalSet1.add(eval1a);
+
+        NumericData rtBadData1b = new NumericData(firingConditions[1].getDataId(),
+                System.currentTimeMillis(),
+                315d);
+        ThresholdRangeConditionEval eval1b = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                firingConditions[1], rtBadData1b);
+
+        evalSet1.add(eval1b);
+
+        NumericData rtBadData1c = new NumericData(firingConditions[2].getDataId(),
+                System.currentTimeMillis(),
+                315d);
+        ThresholdRangeConditionEval eval1c = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                firingConditions[2], rtBadData1c);
+
+        evalSet1.add(eval1c);
+
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2a = new NumericData(firingConditions[0].getDataId(),
+                System.currentTimeMillis() + 5000,
+                1800d);
+        ThresholdConditionEval eval2a = new ThresholdConditionEval((ThresholdCondition) firingConditions[0],
+                rtBadData2a);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+
+        evalSet2.add(eval2a);
+
+        NumericData rtBadData2b = new NumericData(firingConditions[1].getDataId(),
+                System.currentTimeMillis() + 5000,
+                350d);
+        ThresholdRangeConditionEval eval2b = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                firingConditions[1], rtBadData2b);
+
+        evalSet2.add(eval2b);
+
+        NumericData rtBadData2c = new NumericData(firingConditions[2].getDataId(),
+                System.currentTimeMillis() + 5000,
+                350d);
+        ThresholdRangeConditionEval eval2c = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                firingConditions[2], rtBadData2c);
+
+        evalSet2.add(eval2c);
+
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodDataA = new NumericData(autoResolveConditions[0].getDataId(),
+                System.currentTimeMillis() + 20000,
+                900d);
+        ThresholdConditionEval eval1A = new ThresholdConditionEval((ThresholdCondition) autoResolveConditions[0],
+                rtGoodDataA);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1A);
+
+        NumericData rtGoodDataB = new NumericData(autoResolveConditions[1].getDataId(),
+                System.currentTimeMillis() + 20000,
+                150d);
+        ThresholdRangeConditionEval eval1B = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                autoResolveConditions[1], rtGoodDataB);
+
+        evalSet1.add(eval1B);
+
+        NumericData rtGoodData = new NumericData(autoResolveConditions[2].getDataId(),
+                System.currentTimeMillis() + 20000,
+                150d);
+        ThresholdRangeConditionEval eval1C = new ThresholdRangeConditionEval((ThresholdRangeCondition)
+                autoResolveConditions[2], rtGoodData);
+
+        evalSet1.add(eval1C);
+
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
     }
 
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/TestPluginMessage.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/TestPluginMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.Map;
+
+import org.hawkular.alerts.actions.api.PluginMessage;
+import org.hawkular.alerts.api.model.action.Action;
+
+/**
+ * Test implementation of PluginMessage interface
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class TestPluginMessage implements PluginMessage {
+    Action action;
+    Map<String, String> properties;
+
+    public TestPluginMessage(Action action, Map<String, String> properties) {
+        this.action = action;
+        this.properties = properties;
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
@@ -60,24 +60,24 @@ public class UrlAvailabilityData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new AvailabilityCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new AvailabilityCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 AvailabilityCondition.Operator.NOT_UP);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Availability");
 
-        autoResolveCondition = new AvailabilityCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new AvailabilityCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 AvailabilityCondition.Operator.UP);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Availability");
 
-        firingDampening = Dampening.forStrictTime(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTime(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition;
+import org.hawkular.alerts.api.model.condition.AvailabilityConditionEval;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.Availability;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Availability Alerts on Url resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class UrlAvailabilityData extends CommonData {
+
+    public static Trigger trigger;
+    public static AvailabilityCondition firingCondition;
+    public static AvailabilityCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "URL");
+        context.put("resourceName", "http://www.jboss.org");
+
+        String triggerId = "jboss-url-availability-trigger";
+        String triggerDescription = "Availability for http://www.jboss.org";
+        String dataId = "jboss-url-availability-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new AvailabilityCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                AvailabilityCondition.Operator.NOT_UP);
+        firingCondition.getContext().put("description", "Availability");
+
+        autoResolveCondition = new AvailabilityCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                AvailabilityCondition.Operator.UP);
+        autoResolveCondition.getContext().put("description", "Availability");
+
+        firingDampening = Dampening.forStrictTime(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        Availability avBadData1 = new Availability(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                Availability.AvailabilityType.DOWN);
+        AvailabilityConditionEval eval1 = new AvailabilityConditionEval(firingCondition, avBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        Availability avBadData2 = new Availability(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                Availability.AvailabilityType.DOWN);
+        AvailabilityConditionEval eval2 = new AvailabilityConditionEval(firingCondition, avBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        Availability avGoodData = new Availability(autoResolveCondition.getDataId(), System.currentTimeMillis() + 20000,
+                Availability.AvailabilityType.UP);
+        AvailabilityConditionEval eval1 = new AvailabilityConditionEval(autoResolveCondition, avGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
@@ -60,28 +60,28 @@ public class UrlResponseTimeData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdCondition.Operator.GT,
                 1000d);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Response Time");
         firingCondition.getContext().put("unit", "ms");
 
-        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 ThresholdCondition.Operator.LTE,
                 1000d);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Response Time");
         autoResolveCondition.getContext().put("unit", "ms");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Response Time Alerts on Url resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class UrlResponseTimeData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdCondition firingCondition;
+    public static ThresholdCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "URL");
+        context.put("resourceName", "http://www.jboss.org");
+
+        String triggerId = "jboss-url-response-time-trigger";
+        String triggerDescription = "Response Time for http://www.jboss.org";
+        String dataId = "jboss-url-response-time-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdCondition.Operator.GT,
+                1000d);
+        firingCondition.getContext().put("description", "Response Time");
+        firingCondition.getContext().put("unit", "ms");
+
+        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                ThresholdCondition.Operator.LTE,
+                1000d);
+        autoResolveCondition.getContext().put("description", "Response Time");
+        autoResolveCondition.getContext().put("unit", "ms");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                1900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                1800d);
+        ThresholdConditionEval eval2 = new ThresholdConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Active Session Alerts on Web resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebActiveSessionsData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdRangeCondition firingCondition;
+    public static ThresholdRangeCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Sessions");
+
+        String triggerId = "thevault~local-web-active-sessions-trigger";
+        String triggerDescription = "Web Active Sessions for thevault~Local";
+        String dataId = "thevault~local-web-active-sessions-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                200d,
+                5000d,
+                false);
+        firingCondition.getContext().put("description", "Active Sessions");
+        firingCondition.getContext().put("unit", "sessions");
+
+        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                200d,
+                5000d,
+                true);
+        autoResolveCondition.getContext().put("description", "Active Sessions");
+        autoResolveCondition.getContext().put("unit", "sessions");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                5010d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                5014d);
+        ThresholdRangeConditionEval eval2 = new ThresholdRangeConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                1000d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
@@ -61,8 +61,7 @@ public class WebActiveSessionsData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.INCLUSIVE,
@@ -70,11 +69,11 @@ public class WebActiveSessionsData extends CommonData {
                 200d,
                 5000d,
                 false);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Active Sessions");
         firingCondition.getContext().put("unit", "sessions");
 
-        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.EXCLUSIVE,
@@ -82,13 +81,14 @@ public class WebActiveSessionsData extends CommonData {
                 200d,
                 5000d,
                 true);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Active Sessions");
         autoResolveCondition.getContext().put("unit", "sessions");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Current Request Threads Alerts on Container resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebContainerCurrentThreadsData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdRangeCondition firingCondition;
+    public static ThresholdRangeCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Container");
+
+        String triggerId = "thevault~local-container-current-threads-trigger";
+        String triggerDescription = "Current Container Threads for thevault~Local";
+        String dataId = "thevault~local-container-current-threads-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                200d,
+                5000d,
+                false);
+        firingCondition.getContext().put("description", "Current Threads");
+        firingCondition.getContext().put("unit", "threads");
+
+        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                200d,
+                5000d,
+                true);
+        autoResolveCondition.getContext().put("description", "Current Threads");
+        autoResolveCondition.getContext().put("unit", "threads");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                5010d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                5014d);
+        ThresholdRangeConditionEval eval2 = new ThresholdRangeConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                1000d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
@@ -61,8 +61,7 @@ public class WebContainerCurrentThreadsData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.INCLUSIVE,
@@ -70,11 +69,11 @@ public class WebContainerCurrentThreadsData extends CommonData {
                 200d,
                 5000d,
                 false);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Current Threads");
         firingCondition.getContext().put("unit", "threads");
 
-        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.EXCLUSIVE,
@@ -82,13 +81,14 @@ public class WebContainerCurrentThreadsData extends CommonData {
                 200d,
                 5000d,
                 true);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Current Threads");
         autoResolveCondition.getContext().put("unit", "threads");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Pending Requests Alerts on Container resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebContainerPendingRequestsData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdRangeCondition firingCondition;
+    public static ThresholdRangeCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Container");
+
+        String triggerId = "thevault~local-container-pending-requests-trigger";
+        String triggerDescription = "Pending Container Requests for thevault~Local";
+        String dataId = "thevault~local-container-pending-requests-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                ThresholdRangeCondition.Operator.INCLUSIVE,
+                200d,
+                5000d,
+                false);
+        firingCondition.getContext().put("description", "Pending Requests");
+        firingCondition.getContext().put("unit", "requests");
+
+        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                ThresholdRangeCondition.Operator.EXCLUSIVE,
+                200d,
+                5000d,
+                true);
+        autoResolveCondition.getContext().put("description", "Pending Requests");
+        autoResolveCondition.getContext().put("unit", "requests");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                5010d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                5014d);
+        ThresholdRangeConditionEval eval2 = new ThresholdRangeConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                1000d);
+        ThresholdRangeConditionEval eval1 = new ThresholdRangeConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
@@ -61,8 +61,7 @@ public class WebContainerPendingRequestsData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.INCLUSIVE,
@@ -70,11 +69,11 @@ public class WebContainerPendingRequestsData extends CommonData {
                 200d,
                 5000d,
                 false);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Pending Requests");
         firingCondition.getContext().put("unit", "requests");
 
-        autoResolveCondition = new ThresholdRangeCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdRangeCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdRangeCondition.Operator.EXCLUSIVE,
@@ -82,13 +81,14 @@ public class WebContainerPendingRequestsData extends CommonData {
                 200d,
                 5000d,
                 true);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Pending Requests");
         autoResolveCondition.getContext().put("unit", "requests");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Expired Session Alerts on Web resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebExpiredSessionsData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdCondition firingCondition;
+    public static ThresholdCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Sessions");
+
+        String triggerId = "thevault~local-web-expired-sessions-trigger";
+        String triggerDescription = "Expired Web Sessions for thevault~Local";
+        String dataId = "thevault~local-web-expired-sessions-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdCondition.Operator.GT,
+                65d);
+        firingCondition.getContext().put("description", "Expired Sessions");
+        firingCondition.getContext().put("unit", "sessions");
+
+        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                ThresholdCondition.Operator.LTE,
+                65d);
+        autoResolveCondition.getContext().put("description", "Expired Sessions");
+        autoResolveCondition.getContext().put("unit", "sessions");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                100d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                101d);
+        ThresholdConditionEval eval2 = new ThresholdConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                30d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
@@ -61,28 +61,28 @@ public class WebExpiredSessionsData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdCondition.Operator.GT,
                 65d);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Expired Sessions");
         firingCondition.getContext().put("unit", "sessions");
 
-        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 ThresholdCondition.Operator.LTE,
                 65d);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Expired Sessions");
         autoResolveCondition.getContext().put("unit", "sessions");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
@@ -61,28 +61,28 @@ public class WebRejectedSessionsData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdCondition.Operator.GT,
                 65d);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Rejected Sessions");
         firingCondition.getContext().put("unit", "sessions");
 
-        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 ThresholdCondition.Operator.LTE,
                 65d);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Rejected Sessions");
         autoResolveCondition.getContext().put("unit", "sessions");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Rejected Session Alerts on Web resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebRejectedSessionsData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdCondition firingCondition;
+    public static ThresholdCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Sessions");
+
+        String triggerId = "thevault~local-web-rejected-sessions-trigger";
+        String triggerDescription = "Rejected Web Sessions for thevault~Local";
+        String dataId = "thevault~local-web-rejected-sessions-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdCondition.Operator.GT,
+                65d);
+        firingCondition.getContext().put("description", "Rejected Sessions");
+        firingCondition.getContext().put("unit", "sessions");
+
+        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                ThresholdCondition.Operator.LTE,
+                65d);
+        autoResolveCondition.getContext().put("description", "Rejected Sessions");
+        autoResolveCondition.getContext().put("unit", "sessions");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                100d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                101d);
+        ThresholdConditionEval eval2 = new ThresholdConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                30d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
@@ -61,28 +61,28 @@ public class WebRequestsResponseTimeData extends CommonData {
                 triggerDescription,
                 context);
 
-        firingCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        firingCondition = new ThresholdCondition(trigger.getId(),
                 Mode.FIRING,
                 dataId,
                 ThresholdCondition.Operator.GT,
                 1000d);
+        firingCondition.setTenantId(TEST_TENANT);
         firingCondition.getContext().put("description", "Response Time");
         firingCondition.getContext().put("unit", "ms");
 
-        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
-                trigger.getId(),
+        autoResolveCondition = new ThresholdCondition(trigger.getId(),
                 Mode.AUTORESOLVE,
                 dataId,
                 ThresholdCondition.Operator.LTE,
                 1000d);
+        autoResolveCondition.setTenantId(TEST_TENANT);
         autoResolveCondition.getContext().put("description", "Response Time");
         autoResolveCondition.getContext().put("unit", "ms");
 
-        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
-                trigger.getId(),
+        firingDampening = Dampening.forStrictTimeout(trigger.getId(),
                 Mode.FIRING,
                 10000);
+        firingDampening.setTenantId(TEST_TENANT);
 
     }
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/test/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.condition.ThresholdCondition;
+import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.data.NumericData;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Provide test data for Response Time Alerts on Url resources
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class WebRequestsResponseTimeData extends CommonData {
+
+    public static Trigger trigger;
+    public static ThresholdCondition firingCondition;
+    public static ThresholdCondition autoResolveCondition;
+    public static Dampening firingDampening;
+
+    static {
+
+        Map<String, String> context = new HashMap<>();
+        context.put("resourceType", "App Server");
+        context.put("resourceName", "thevault~Local");
+        context.put("category", "Web Requests");
+
+        String triggerId = "thevault~local-web-request-response-time-trigger";
+        String triggerDescription = "Web Request Response Time for thevault~Local";
+        String dataId = "thevault~local-web-request-response-time-data-id";
+
+        trigger = new Trigger(TEST_TENANT,
+                triggerId,
+                triggerDescription,
+                context);
+
+        firingCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                dataId,
+                ThresholdCondition.Operator.GT,
+                1000d);
+        firingCondition.getContext().put("description", "Response Time");
+        firingCondition.getContext().put("unit", "ms");
+
+        autoResolveCondition = new ThresholdCondition(TEST_TENANT,
+                trigger.getId(),
+                Mode.AUTORESOLVE,
+                dataId,
+                ThresholdCondition.Operator.LTE,
+                1000d);
+        autoResolveCondition.getContext().put("description", "Response Time");
+        autoResolveCondition.getContext().put("unit", "ms");
+
+        firingDampening = Dampening.forStrictTimeout(TEST_TENANT,
+                trigger.getId(),
+                Mode.FIRING,
+                10000);
+
+    }
+
+    public static Alert getOpenAlert() {
+
+        List<Set<ConditionEval>> satisfyingEvals = new ArrayList<>();
+
+        NumericData rtBadData1 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis(),
+                1900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(firingCondition, rtBadData1);
+
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        satisfyingEvals.add(evalSet1);
+
+        // 5 seconds later
+        NumericData rtBadData2 = new NumericData(firingCondition.getDataId(),
+                System.currentTimeMillis() + 5000,
+                1800d);
+        ThresholdConditionEval eval2 = new ThresholdConditionEval(firingCondition, rtBadData2);
+
+        Set<ConditionEval> evalSet2 = new HashSet<>();
+        evalSet2.add(eval2);
+        satisfyingEvals.add(evalSet2);
+
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger.getId(), trigger.getSeverity(), satisfyingEvals);
+        openAlert.setTrigger(trigger);
+        openAlert.setDampening(firingDampening);
+        openAlert.setContext(trigger.getContext());
+
+        return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert) {
+        List<Set<ConditionEval>> resolvedEvals = new ArrayList<>();
+
+        NumericData rtGoodData = new NumericData(autoResolveCondition.getDataId(),
+                System.currentTimeMillis() + 20000,
+                900d);
+        ThresholdConditionEval eval1 = new ThresholdConditionEval(autoResolveCondition, rtGoodData);
+        Set<ConditionEval> evalSet1 = new HashSet<>();
+        evalSet1.add(eval1);
+        resolvedEvals.add(evalSet1);
+
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
+        unresolvedAlert.setResolvedBy(RESOLVED_BY);
+        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+
+        return unresolvedAlert;
+    }
+
+}

--- a/hawkular-alerts-actions-plugins/pom.xml
+++ b/hawkular-alerts-actions-plugins/pom.xml
@@ -44,6 +44,7 @@
     <module>hawkular-alerts-actions-aerogear</module>
     <module>hawkular-alerts-actions-pagerduty</module>
     <module>hawkular-alerts-actions-file</module>
+    <module>hawkular-alerts-actions-tests</module>
   </modules>
 
   <dependencies>

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
@@ -61,6 +61,11 @@ public class AvailabilityCondition extends Condition {
         this(triggerId, triggerMode, 1, 1, dataId, operator);
     }
 
+    public AvailabilityCondition(String tenantId, String triggerId, Mode triggerMode,
+                                 String dataId, Operator operator) {
+        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operator);
+    }
+
     public AvailabilityCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
         this(triggerId, FIRING, conditionSetSize, conditionSetIndex, dataId, operator);
@@ -68,7 +73,12 @@ public class AvailabilityCondition extends Condition {
 
     public AvailabilityCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.AVAILABILITY);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator);
+    }
+
+    public AvailabilityCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize, int
+            conditionSetIndex, String dataId, Operator operator) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.AVAILABILITY);
         this.dataId = dataId;
         this.operator = operator;
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/AvailabilityCondition.java
@@ -61,24 +61,14 @@ public class AvailabilityCondition extends Condition {
         this(triggerId, triggerMode, 1, 1, dataId, operator);
     }
 
-    public AvailabilityCondition(String tenantId, String triggerId, Mode triggerMode,
-                                 String dataId, Operator operator) {
-        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operator);
-    }
-
     public AvailabilityCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator) {
         this(triggerId, FIRING, conditionSetSize, conditionSetIndex, dataId, operator);
     }
 
-    public AvailabilityCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, Operator operator) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator);
-    }
-
-    public AvailabilityCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize, int
+    public AvailabilityCondition(String triggerId, Mode triggerMode, int conditionSetSize, int
             conditionSetIndex, String dataId, Operator operator) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.AVAILABILITY);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.AVAILABILITY);
         this.dataId = dataId;
         this.operator = operator;
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
@@ -72,16 +72,10 @@ public class CompareCondition extends Condition {
         this(triggerId, FIRING, conditionSetSize, conditionSetIndex, dataId, operator, data2Multiplier, data2Id);
     }
 
-    public CompareCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, Operator operator, Double data2Multiplier, String data2Id) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, data2Multiplier,
-                data2Id);
-    }
-
-    public CompareCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+    public CompareCondition(String triggerId, Mode triggerMode, int conditionSetSize,
                             int conditionSetIndex, String dataId, Operator operator, Double data2Multiplier,
                             String data2Id) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.COMPARE);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.COMPARE);
         this.dataId = dataId;
         this.operator = operator;
         this.data2Id = data2Id;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/CompareCondition.java
@@ -74,7 +74,14 @@ public class CompareCondition extends Condition {
 
     public CompareCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double data2Multiplier, String data2Id) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.COMPARE);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, data2Multiplier,
+                data2Id);
+    }
+
+    public CompareCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+                            int conditionSetIndex, String dataId, Operator operator, Double data2Multiplier,
+                            String data2Id) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.COMPARE);
         this.dataId = dataId;
         this.operator = operator;
         this.data2Id = data2Id;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -16,6 +16,10 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
+
+import java.util.Map;
+
 import org.hawkular.alerts.api.model.trigger.Mode;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -69,6 +73,9 @@ public abstract class Condition {
      */
     @JsonInclude
     protected String conditionId;
+
+    @JsonInclude(Include.NON_NULL)
+    protected Map<String, String> context;
 
     public Condition() {
         // for json assembly
@@ -129,6 +136,14 @@ public abstract class Condition {
 
     public void setTenantId(String tenantId) {
         this.tenantId = tenantId;
+    }
+
+    public Map<String, String> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String, String> context) {
+        this.context = context;
     }
 
     private void updateId() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -82,9 +82,7 @@ public abstract class Condition {
         // for json assembly
     }
 
-    public Condition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-                     Type type) {
-        this.tenantId = tenantId;
+    public Condition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex, Type type) {
         this.triggerId = triggerId;
         this.triggerMode = triggerMode;
         this.conditionSetSize = conditionSetSize;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -18,6 +18,7 @@ package org.hawkular.alerts.api.model.condition;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.hawkular.alerts.api.model.trigger.Mode;
@@ -74,14 +75,16 @@ public abstract class Condition {
     @JsonInclude
     protected String conditionId;
 
-    @JsonInclude(Include.NON_NULL)
+    @JsonInclude(Include.NON_EMPTY)
     protected Map<String, String> context;
 
     public Condition() {
         // for json assembly
     }
 
-    public Condition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex, Type type) {
+    public Condition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
+                     Type type) {
+        this.tenantId = tenantId;
         this.triggerId = triggerId;
         this.triggerMode = triggerMode;
         this.conditionSetSize = conditionSetSize;
@@ -139,6 +142,9 @@ public abstract class Condition {
     }
 
     public Map<String, String> getContext() {
+        if (null == context) {
+            context = new HashMap<>();
+        }
         return context;
     }
 

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
@@ -67,14 +67,9 @@ public class ExternalCondition extends Condition {
         this(triggerId, triggerMode, 1, 1, dataId, systemId, expression);
     }
 
-    public ExternalCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, String systemId, String expression) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, systemId, expression);
-    }
-
-    public ExternalCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+    public ExternalCondition(String triggerId, Mode triggerMode, int conditionSetSize,
                              int conditionSetIndex, String dataId, String systemId, String expression) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.EXTERNAL);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.EXTERNAL);
         this.systemId = systemId;
         this.dataId = dataId;
         this.expression = expression;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
@@ -69,8 +69,12 @@ public class ExternalCondition extends Condition {
 
     public ExternalCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, String systemId, String expression) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.EXTERNAL);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, systemId, expression);
+    }
 
+    public ExternalCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+                             int conditionSetIndex, String dataId, String systemId, String expression) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.EXTERNAL);
         this.systemId = systemId;
         this.dataId = dataId;
         this.expression = expression;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
@@ -71,7 +71,13 @@ public class StringCondition extends Condition {
 
     public StringCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, String pattern, boolean ignoreCase) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.STRING);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
+    }
+
+    public StringCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+                           int conditionSetIndex, String dataId, Operator operator, String pattern,
+                           boolean ignoreCase) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.STRING);
         this.dataId = dataId;
         this.operator = operator;
         this.pattern = pattern;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/StringCondition.java
@@ -69,15 +69,10 @@ public class StringCondition extends Condition {
         this(triggerId, Mode.FIRING, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
     }
 
-    public StringCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, Operator operator, String pattern, boolean ignoreCase) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, pattern, ignoreCase);
-    }
-
-    public StringCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+    public StringCondition(String triggerId, Mode triggerMode, int conditionSetSize,
                            int conditionSetIndex, String dataId, Operator operator, String pattern,
                            boolean ignoreCase) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.STRING);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.STRING);
         this.dataId = dataId;
         this.operator = operator;
         this.pattern = pattern;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
@@ -63,26 +63,15 @@ public class ThresholdCondition extends Condition {
         this(triggerId, triggerMode, 1, 1, dataId, operator, threshold);
     }
 
-    public ThresholdCondition(String tenantId, String triggerId, Mode triggerMode,
-                              String dataId, Operator operator, Double threshold) {
-
-        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operator, threshold);
-    }
-
     public ThresholdCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double threshold) {
 
         this(triggerId, Mode.FIRING, conditionSetSize, conditionSetIndex, dataId, operator, threshold);
     }
 
-    public ThresholdCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, Operator operator, Double threshold) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, threshold);
-    }
-
-    public ThresholdCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+    public ThresholdCondition(String triggerId, Mode triggerMode, int conditionSetSize,
                               int conditionSetIndex, String dataId, Operator operator, Double threshold) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.THRESHOLD);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.THRESHOLD);
         this.dataId = dataId;
         this.operator = operator;
         this.threshold = threshold;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdCondition.java
@@ -63,6 +63,12 @@ public class ThresholdCondition extends Condition {
         this(triggerId, triggerMode, 1, 1, dataId, operator, threshold);
     }
 
+    public ThresholdCondition(String tenantId, String triggerId, Mode triggerMode,
+                              String dataId, Operator operator, Double threshold) {
+
+        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operator, threshold);
+    }
+
     public ThresholdCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double threshold) {
 
@@ -71,7 +77,12 @@ public class ThresholdCondition extends Condition {
 
     public ThresholdCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operator, Double threshold) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.THRESHOLD);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operator, threshold);
+    }
+
+    public ThresholdCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+                              int conditionSetIndex, String dataId, Operator operator, Double threshold) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.THRESHOLD);
         this.dataId = dataId;
         this.operator = operator;
         this.threshold = threshold;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
@@ -90,14 +90,6 @@ public class ThresholdRangeCondition extends Condition {
              thresholdLow, thresholdHigh, inRange);
     }
 
-    public ThresholdRangeCondition(String tenantId, String triggerId, Mode triggerMode,
-                                   String dataId, Operator operatorLow, Operator operatorHigh,
-                                   Double thresholdLow, Double thresholdHigh, boolean inRange) {
-
-        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operatorLow, operatorHigh,
-                thresholdLow, thresholdHigh, inRange);
-    }
-
     public ThresholdRangeCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operatorLow, Operator operatorHigh,
             Double thresholdLow, Double thresholdHigh, boolean inRange) {
@@ -106,17 +98,10 @@ public class ThresholdRangeCondition extends Condition {
                 thresholdLow, thresholdHigh, inRange);
     }
 
-    public ThresholdRangeCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
-            String dataId, Operator operatorLow, Operator operatorHigh,
-            Double thresholdLow, Double thresholdHigh, boolean inRange) {
-        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operatorLow, operatorHigh,
-                thresholdLow, thresholdHigh, inRange);
-    }
-
-    public ThresholdRangeCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+    public ThresholdRangeCondition(String triggerId, Mode triggerMode, int conditionSetSize,
                                    int conditionSetIndex, String dataId, Operator operatorLow, Operator operatorHigh,
                                    Double thresholdLow, Double thresholdHigh, boolean inRange) {
-        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.RANGE);
+        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.RANGE);
         this.dataId = dataId;
         this.operatorLow = operatorLow;
         this.operatorHigh = operatorHigh;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/ThresholdRangeCondition.java
@@ -90,6 +90,14 @@ public class ThresholdRangeCondition extends Condition {
              thresholdLow, thresholdHigh, inRange);
     }
 
+    public ThresholdRangeCondition(String tenantId, String triggerId, Mode triggerMode,
+                                   String dataId, Operator operatorLow, Operator operatorHigh,
+                                   Double thresholdLow, Double thresholdHigh, boolean inRange) {
+
+        this(tenantId, triggerId, triggerMode, 1, 1, dataId, operatorLow, operatorHigh,
+                thresholdLow, thresholdHigh, inRange);
+    }
+
     public ThresholdRangeCondition(String triggerId, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operatorLow, Operator operatorHigh,
             Double thresholdLow, Double thresholdHigh, boolean inRange) {
@@ -101,7 +109,14 @@ public class ThresholdRangeCondition extends Condition {
     public ThresholdRangeCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
             String dataId, Operator operatorLow, Operator operatorHigh,
             Double thresholdLow, Double thresholdHigh, boolean inRange) {
-        super(triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.RANGE);
+        this(null, triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, operatorLow, operatorHigh,
+                thresholdLow, thresholdHigh, inRange);
+    }
+
+    public ThresholdRangeCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+                                   int conditionSetIndex, String dataId, Operator operatorLow, Operator operatorHigh,
+                                   Double thresholdLow, Double thresholdHigh, boolean inRange) {
+        super(tenantId, triggerId, triggerMode, conditionSetSize, conditionSetIndex, Type.RANGE);
         this.dataId = dataId;
         this.operatorLow = operatorLow;
         this.operatorHigh = operatorHigh;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -112,15 +112,10 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrict(String triggerId, Mode triggerMode, int numConsecutiveTrueEvals) {
-        return forStrict(null, triggerId, triggerMode, numConsecutiveTrueEvals);
-    }
-
-    public static Dampening forStrict(String tenantId, String triggerId, Mode triggerMode,
-                                      int numConsecutiveTrueEvals) {
         if (numConsecutiveTrueEvals < 1) {
             throw new IllegalArgumentException("NumConsecutiveTrueEvals must be >= 1");
         }
-        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT, numConsecutiveTrueEvals,
+        return new Dampening(triggerId, triggerMode, Type.STRICT, numConsecutiveTrueEvals,
                 numConsecutiveTrueEvals, 0);
     }
 
@@ -134,18 +129,13 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forRelaxedCount(String triggerId, Mode triggerMode, int numTrueEvals, int numTotalEvals) {
-        return forRelaxedCount(null, triggerId, triggerMode, numTrueEvals, numTotalEvals);
-    }
-
-    public static Dampening forRelaxedCount(String tenantId, String triggerId, Mode triggerMode, int numTrueEvals,
-                                            int numTotalEvals) {
         if (numTrueEvals < 1) {
             throw new IllegalArgumentException("NumTrueEvals must be >= 1");
         }
         if (numTotalEvals <= numTrueEvals) {
             throw new IllegalArgumentException("NumTotalEvals must be > NumTrueEvals");
         }
-        return new Dampening(tenantId, triggerId, triggerMode, Type.RELAXED_COUNT, numTrueEvals, numTotalEvals, 0);
+        return new Dampening(triggerId, triggerMode, Type.RELAXED_COUNT, numTrueEvals, numTotalEvals, 0);
     }
 
     /**
@@ -160,18 +150,13 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forRelaxedTime(String triggerId, Mode triggerMode, int numTrueEvals, long evalPeriod) {
-        return forRelaxedTime(null, triggerId, triggerMode, numTrueEvals, evalPeriod);
-    }
-
-    public static Dampening forRelaxedTime(String tenantId, String triggerId, Mode triggerMode, int numTrueEvals,
-                                           long evalPeriod) {
         if (numTrueEvals < 1) {
             throw new IllegalArgumentException("NumTrueEvals must be >= 1");
         }
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(tenantId, triggerId, triggerMode, Type.RELAXED_TIME, numTrueEvals, 0, evalPeriod);
+        return new Dampening(triggerId, triggerMode, Type.RELAXED_TIME, numTrueEvals, 0, evalPeriod);
     }
 
     /**
@@ -185,14 +170,10 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrictTime(String triggerId, Mode triggerMode, long evalPeriod) {
-        return forStrictTime(null, triggerId, triggerMode, evalPeriod);
-    }
-
-    public static Dampening forStrictTime(String tenantId, String triggerId, Mode triggerMode, long evalPeriod) {
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT_TIME, 0, 0, evalPeriod);
+        return new Dampening(triggerId, triggerMode, Type.STRICT_TIME, 0, 0, evalPeriod);
     }
 
     /**
@@ -206,24 +187,14 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrictTimeout(String triggerId, Mode triggerMode, long evalPeriod) {
-        return forStrictTimeout(null, triggerId, triggerMode, evalPeriod);
-    }
-
-    public static Dampening forStrictTimeout(String tenantId, String triggerId, Mode triggerMode, long evalPeriod) {
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
+        return new Dampening(triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
     }
-
 
     public Dampening(String triggerId, Mode triggerMode, Type type, int evalTrueSetting, int evalTotalSetting,
-            long evalTimeSetting) {
-        this(null, triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting);
-    }
-
-    public Dampening(String tenantId, String triggerId, Mode triggerMode, Type type, int evalTrueSetting,
-                     int evalTotalSetting, long evalTimeSetting) {
+                     long evalTimeSetting) {
         super();
         this.triggerId = triggerId;
         this.type = type;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -44,6 +44,9 @@ public class Dampening {
     };
 
     @JsonInclude
+    private String tenantId;
+
+    @JsonInclude
     private String triggerId;
 
     @JsonInclude
@@ -96,9 +99,6 @@ public class Dampening {
     @JsonIgnore
     private transient List<Set<ConditionEval>> satisfyingEvals = new ArrayList<Set<ConditionEval>>();
 
-    @JsonInclude
-    private String tenantId;
-
     public Dampening() {
         this("Default", Mode.FIRING, Type.STRICT, 1, 1, 0);
     }
@@ -112,10 +112,16 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrict(String triggerId, Mode triggerMode, int numConsecutiveTrueEvals) {
+        return forStrict(null, triggerId, triggerMode, numConsecutiveTrueEvals);
+    }
+
+    public static Dampening forStrict(String tenantId, String triggerId, Mode triggerMode,
+                                      int numConsecutiveTrueEvals) {
         if (numConsecutiveTrueEvals < 1) {
             throw new IllegalArgumentException("NumConsecutiveTrueEvals must be >= 1");
         }
-        return new Dampening(triggerId, triggerMode, Type.STRICT, numConsecutiveTrueEvals, numConsecutiveTrueEvals, 0);
+        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT, numConsecutiveTrueEvals,
+                numConsecutiveTrueEvals, 0);
     }
 
     /**
@@ -128,13 +134,18 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forRelaxedCount(String triggerId, Mode triggerMode, int numTrueEvals, int numTotalEvals) {
+        return forRelaxedCount(null, triggerId, triggerMode, numTrueEvals, numTotalEvals);
+    }
+
+    public static Dampening forRelaxedCount(String tenantId, String triggerId, Mode triggerMode, int numTrueEvals,
+                                            int numTotalEvals) {
         if (numTrueEvals < 1) {
             throw new IllegalArgumentException("NumTrueEvals must be >= 1");
         }
         if (numTotalEvals <= numTrueEvals) {
             throw new IllegalArgumentException("NumTotalEvals must be > NumTrueEvals");
         }
-        return new Dampening(triggerId, triggerMode, Type.RELAXED_COUNT, numTrueEvals, numTotalEvals, 0);
+        return new Dampening(tenantId, triggerId, triggerMode, Type.RELAXED_COUNT, numTrueEvals, numTotalEvals, 0);
     }
 
     /**
@@ -149,13 +160,18 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forRelaxedTime(String triggerId, Mode triggerMode, int numTrueEvals, long evalPeriod) {
+        return forRelaxedTime(null, triggerId, triggerMode, numTrueEvals, evalPeriod);
+    }
+
+    public static Dampening forRelaxedTime(String tenantId, String triggerId, Mode triggerMode, int numTrueEvals,
+                                           long evalPeriod) {
         if (numTrueEvals < 1) {
             throw new IllegalArgumentException("NumTrueEvals must be >= 1");
         }
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(triggerId, triggerMode, Type.RELAXED_TIME, numTrueEvals, 0, evalPeriod);
+        return new Dampening(tenantId, triggerId, triggerMode, Type.RELAXED_TIME, numTrueEvals, 0, evalPeriod);
     }
 
     /**
@@ -169,10 +185,14 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrictTime(String triggerId, Mode triggerMode, long evalPeriod) {
+        return forStrictTime(null, triggerId, triggerMode, evalPeriod);
+    }
+
+    public static Dampening forStrictTime(String tenantId, String triggerId, Mode triggerMode, long evalPeriod) {
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(triggerId, triggerMode, Type.STRICT_TIME, 0, 0, evalPeriod);
+        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT_TIME, 0, 0, evalPeriod);
     }
 
     /**
@@ -186,14 +206,24 @@ public class Dampening {
      * @return the configured Dampening
      */
     public static Dampening forStrictTimeout(String triggerId, Mode triggerMode, long evalPeriod) {
+        return forStrictTimeout(null, triggerId, triggerMode, evalPeriod);
+    }
+
+    public static Dampening forStrictTimeout(String tenantId, String triggerId, Mode triggerMode, long evalPeriod) {
         if (evalPeriod < 1) {
             throw new IllegalArgumentException("EvalPeriod must be >= 1ms");
         }
-        return new Dampening(triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
+        return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
     }
+
 
     public Dampening(String triggerId, Mode triggerMode, Type type, int evalTrueSetting, int evalTotalSetting,
             long evalTimeSetting) {
+        this(null, triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting);
+    }
+
+    public Dampening(String tenantId, String triggerId, Mode triggerMode, Type type, int evalTrueSetting,
+                     int evalTotalSetting, long evalTimeSetting) {
         super();
         this.triggerId = triggerId;
         this.type = type;

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -229,7 +229,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     Mode triggerMode = Mode.valueOf((String) c.get("triggerMode"));
                     int conditionSetSize = (Integer) c.get("conditionSetSize");
                     int conditionSetIndex = (Integer) c.get("conditionSetIndex");
+                    String description = (String) c.get("description");
                     String type = (String) c.get("type");
+                    Map<String, String> context = (Map<String, String>) c.get("context");
                     if (type != null && !type.isEmpty() && type.equals("threshold")) {
                         String dataId = (String) c.get("dataId");
                         String operator = (String) c.get("operator");
@@ -244,6 +246,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         newCondition.setOperator(ThresholdCondition.Operator.valueOf(operator));
                         newCondition.setThreshold(threshold);
                         newCondition.setTenantId(tenantId);
+                        newCondition.setContext(context);
 
                         initCondition(newCondition);
                         log.debugf("Init registration - Inserting [%s]", newCondition);
@@ -268,6 +271,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         newCondition.setThresholdHigh(thresholdHigh);
                         newCondition.setInRange(inRange);
                         newCondition.setTenantId(tenantId);
+                        newCondition.setContext(context);
 
                         initCondition(newCondition);
                         log.debugf("Init registration - Inserting [%s]", newCondition);
@@ -288,6 +292,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         newCondition.setData2Multiplier(data2Multiplier);
                         newCondition.setData2Id(data2Id);
                         newCondition.setTenantId(tenantId);
+                        newCondition.setContext(context);
 
                         initCondition(newCondition);
                         log.debugf("Init registration - Inserting [%s]", newCondition);
@@ -308,6 +313,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         newCondition.setPattern(pattern);
                         newCondition.setIgnoreCase(ignoreCase);
                         newCondition.setTenantId(tenantId);
+                        newCondition.setContext(context);
 
                         initCondition(newCondition);
                         log.debugf("Init registration - Inserting [%s]", newCondition);
@@ -324,6 +330,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         newCondition.setDataId(dataId);
                         newCondition.setOperator(AvailabilityCondition.Operator.valueOf(operator));
                         newCondition.setTenantId(tenantId);
+                        newCondition.setContext(context);
 
                         initCondition(newCondition);
                         log.debugf("Init registration - Inserting [%s]", newCondition);
@@ -1851,9 +1858,9 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                 if (cond instanceof AvailabilityCondition) {
 
                     AvailabilityCondition aCond = (AvailabilityCondition) cond;
-                    futures.add(session.executeAsync(insertConditionAvailability.bind(aCond.getTenantId(), aCond
-                            .getTriggerId(),
-                            aCond.getTriggerMode().name(), aCond.getConditionSetSize(), aCond.getConditionSetIndex(),
+                    futures.add(session.executeAsync(insertConditionAvailability.bind(aCond.getTenantId(),
+                            aCond.getTriggerId(), aCond.getTriggerMode().name(), aCond.getContext(),
+                            aCond.getConditionSetSize(), aCond.getConditionSetIndex(),
                             aCond.getConditionId(), aCond.getDataId(), aCond.getOperator().name())));
 
                 } else if (cond instanceof CompareCondition) {
@@ -1861,41 +1868,43 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     CompareCondition cCond = (CompareCondition) cond;
                     dataIds.add(cCond.getData2Id());
                     futures.add(session.executeAsync(insertConditionCompare.bind(cCond.getTenantId(),
-                            cCond.getTriggerId(), cCond.getTriggerMode().name(), cCond.getConditionSetSize(),
-                            cCond.getConditionSetIndex(), cCond.getConditionId(), cCond.getDataId(),
-                            cCond.getOperator().name(), cCond.getData2Id(), cCond.getData2Multiplier())));
+                            cCond.getTriggerId(), cCond.getTriggerMode().name(), cCond.getContext(),
+                            cCond.getConditionSetSize(), cCond.getConditionSetIndex(),
+                            cCond.getConditionId(), cCond.getDataId(), cCond.getOperator().name(), cCond.getData2Id(),
+                            cCond.getData2Multiplier())));
 
                 } else if (cond instanceof ExternalCondition) {
 
                     ExternalCondition eCond = (ExternalCondition) cond;
-                    futures.add(session.executeAsync(insertConditionExternal.bind(eCond.getTenantId(), eCond
-                            .getTriggerId(), eCond.getTriggerMode().name(), eCond.getConditionSetSize(),
-                            eCond.getConditionSetIndex(), eCond.getConditionId(), eCond.getDataId(),
-                            eCond.getSystemId(), eCond.getExpression())));
+                    futures.add(session.executeAsync(insertConditionExternal.bind(eCond.getTenantId(),
+                            eCond.getTriggerId(), eCond.getTriggerMode().name(), eCond.getContext(),
+                            eCond.getConditionSetSize(), eCond.getConditionSetIndex(), eCond.getConditionId(),
+                            eCond.getDataId(), eCond.getSystemId(), eCond.getExpression())));
 
                 } else if (cond instanceof StringCondition) {
 
                     StringCondition sCond = (StringCondition) cond;
-                    futures.add(session.executeAsync(insertConditionString.bind(sCond.getTenantId(), sCond
-                            .getTriggerId(), sCond.getTriggerMode().name(), sCond.getConditionSetSize(),
-                            sCond.getConditionSetIndex(), sCond.getConditionId(), sCond.getDataId(),
-                            sCond.getOperator().name(), sCond.getPattern(), sCond.isIgnoreCase())));
+                    futures.add(session.executeAsync(insertConditionString.bind(sCond.getTenantId(),
+                            sCond.getTriggerId(), sCond.getTriggerMode().name(), sCond.getContext(),
+                            sCond.getConditionSetSize(), sCond.getConditionSetIndex(), sCond.getConditionId(),
+                            sCond.getDataId(), sCond.getOperator().name(), sCond.getPattern(), sCond.isIgnoreCase())));
 
                 } else if (cond instanceof ThresholdCondition) {
                     ThresholdCondition tCond = (ThresholdCondition) cond;
                     futures.add(session.executeAsync(insertConditionThreshold.bind(tCond.getTenantId(),
-                            tCond.getTriggerId(), tCond.getTriggerMode().name(), tCond.getConditionSetSize(),
-                            tCond.getConditionSetIndex(), tCond.getConditionId(), tCond.getDataId(),
-                            tCond.getOperator().name(), tCond.getThreshold())));
+                            tCond.getTriggerId(), tCond.getTriggerMode().name(), tCond.getContext(),
+                            tCond.getConditionSetSize(), tCond.getConditionSetIndex(),
+                            tCond.getConditionId(), tCond.getDataId(), tCond.getOperator().name(),
+                            tCond.getThreshold())));
 
                 } else if (cond instanceof ThresholdRangeCondition) {
 
                     ThresholdRangeCondition rCond = (ThresholdRangeCondition) cond;
                     futures.add(session.executeAsync(insertConditionThresholdRange.bind(rCond.getTenantId(),
-                            rCond.getTriggerId(), rCond.getTriggerMode().name(), rCond.getConditionSetSize(),
-                            rCond.getConditionSetIndex(), rCond.getConditionId(), rCond.getDataId(),
-                            rCond.getOperatorLow().name(), rCond.getOperatorHigh().name(), rCond.getThresholdLow(),
-                            rCond.getThresholdHigh(), rCond.isInRange())));
+                            rCond.getTriggerId(), rCond.getTriggerMode().name(), rCond.getContext(),
+                            rCond.getConditionSetSize(), rCond.getConditionSetIndex(), rCond.getConditionId(),
+                            rCond.getDataId(), rCond.getOperatorLow().name(), rCond.getOperatorHigh().name(),
+                            rCond.getThresholdLow(), rCond.getThresholdHigh(), rCond.isInRange())));
 
                 } else {
                     throw new IllegalArgumentException("Unexpected ConditionType: " + cond);
@@ -2213,6 +2222,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     aCondition.setConditionSetIndex(row.getInt("conditionSetIndex"));
                     aCondition.setDataId(row.getString("dataId"));
                     aCondition.setOperator(AvailabilityCondition.Operator.valueOf(row.getString("operator")));
+                    aCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = aCondition;
                     break;
                 case COMPARE:
@@ -2226,6 +2236,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     cCondition.setOperator(CompareCondition.Operator.valueOf(row.getString("operator")));
                     cCondition.setData2Id(row.getString("data2Id"));
                     cCondition.setData2Multiplier(row.getDouble("data2Multiplier"));
+                    cCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = cCondition;
                     break;
                 case EXTERNAL:
@@ -2238,6 +2249,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     eCondition.setDataId(row.getString("dataId"));
                     eCondition.setSystemId(row.getString("operator"));
                     eCondition.setExpression(row.getString("pattern"));
+                    eCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = eCondition;
                     break;
                 case RANGE:
@@ -2255,6 +2267,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     rCondition.setThresholdLow(row.getDouble("thresholdLow"));
                     rCondition.setThresholdHigh(row.getDouble("thresholdHigh"));
                     rCondition.setInRange(row.getBool("inRange"));
+                    rCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = rCondition;
                     break;
                 case STRING:
@@ -2268,6 +2281,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     sCondition.setOperator(StringCondition.Operator.valueOf(row.getString("operator")));
                     sCondition.setPattern(row.getString("pattern"));
                     sCondition.setIgnoreCase(row.getBool("ignoreCase"));
+                    sCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = sCondition;
                     break;
                 case THRESHOLD:
@@ -2280,6 +2294,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     tCondition.setDataId(row.getString("dataId"));
                     tCondition.setOperator(ThresholdCondition.Operator.valueOf(row.getString("operator")));
                     tCondition.setThreshold(row.getDouble("threshold"));
+                    tCondition.setContext(row.getMap("context", String.class, String.class));
                     condition = tCondition;
                     break;
                 default:

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -229,7 +229,6 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     Mode triggerMode = Mode.valueOf((String) c.get("triggerMode"));
                     int conditionSetSize = (Integer) c.get("conditionSetSize");
                     int conditionSetIndex = (Integer) c.get("conditionSetIndex");
-                    String description = (String) c.get("description");
                     String type = (String) c.get("type");
                     Map<String, String> context = (Map<String, String>) c.get("context");
                     if (type != null && !type.isEmpty() && type.equals("threshold")) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -185,29 +185,31 @@ public class CassStatement {
                 + "(tenantId, alertId, status) VALUES (?, ?, ?) ";
 
         INSERT_CONDITION_AVAILABILITY = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operator) VALUES (?, ?, ?, 'AVAILABILITY', ?, ?, ?, ?, ?, ?) ";
 
         INSERT_CONDITION_COMPARE = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operator, data2Id, data2Multiplier) VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operator, data2Id, data2Multiplier) " +
+                "VALUES (?, ?, ?, 'COMPARE', ?, ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_CONDITION_EXTERNAL = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operator, pattern) VALUES (?, ?, ?, 'EXTERNAL', ?, ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operator, pattern) VALUES (?, ?, ?, 'EXTERNAL', ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_CONDITION_STRING = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operator, pattern, ignoreCase) VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operator, pattern, ignoreCase) " +
+                "VALUES (?, ?, ?, 'STRING', ?, ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_CONDITION_THRESHOLD = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operator, threshold) VALUES (?, ?, ?, 'THRESHOLD', ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_CONDITION_THRESHOLD_RANGE = "INSERT INTO " + keyspace + ".conditions "
-                + "(tenantId, triggerId, triggerMode, type, conditionSetSize, conditionSetIndex, conditionId, "
-                + "dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) "
-                + "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange) "
+                + "VALUES (?, ?, ?, 'RANGE', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_DAMPENING = "INSERT INTO " + keyspace + ".dampenings "
                 + "(triggerId, triggerMode, type, evalTrueSetting, evalTotalSetting, evalTimeSetting, "
@@ -273,18 +275,21 @@ public class CassStatement {
 
         SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
-                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId, "
+                + "context "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND conditionId = ? ";
 
         SELECT_CONDITIONS_ALL = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
-                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId, "
+                + "context "
                 + "FROM " + keyspace + ".conditions ";
 
         SELECT_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
-                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId, "
+                + "context "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? ";
 
@@ -344,13 +349,15 @@ public class CassStatement {
 
         SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
-                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId, "
+                + "context "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ?";
 
         SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, ignoreCase, "
-                + "threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId "
+                + "threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, tenantId, "
+                + "context "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
 

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
@@ -80,6 +80,7 @@ CREATE TABLE ${keyspace}.conditions (
     thresholdLow double,
     thresholdHigh double,
     inRange boolean,
+    context map<text,text>,
     PRIMARY KEY (tenantId, triggerId, triggerMode, conditionId)
 );
 

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts/conditions-data.json
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts/conditions-data.json
@@ -7,7 +7,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -17,7 +21,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -27,7 +35,11 @@
     "type": "threshold",
     "dataId": "NumericData-02",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-3",
@@ -40,7 +52,11 @@
     "operatorHigh": "INCLUSIVE",
     "thresholdLow": 10.0,
     "thresholdHigh": 15.0,
-    "inRange": true
+    "inRange": true,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-4",
@@ -51,7 +67,11 @@
     "dataId": "NumericData-01",
     "operator": "LT",
     "data2Multiplier": 0.5,
-    "data2Id": "NumericData-02"
+    "data2Id": "NumericData-02",
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-5",
@@ -62,7 +82,10 @@
     "dataId": "StringData-01",
     "operator": "STARTS_WITH",
     "pattern": "Fred",
-    "ignoreCase": false
+    "ignoreCase": false,
+    "context": {
+      "description": "Server Name"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-6",
@@ -71,7 +94,10 @@
     "conditionSetIndex": 1,
     "type": "availability",
     "dataId": "Availability-01",
-    "operator": "NOT_UP"
+    "operator": "NOT_UP",
+    "context": {
+      "description": "Server"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-7",
@@ -81,6 +107,10 @@
     "type": "threshold",
     "dataId": "NumericData-Token",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   }
 ]}

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts/conditions-data.json
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts/conditions-data.json
@@ -7,7 +7,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -17,7 +21,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -27,7 +35,11 @@
     "type": "threshold",
     "dataId": "NumericData-02",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-3",
@@ -40,7 +52,11 @@
     "operatorHigh": "INCLUSIVE",
     "thresholdLow": 10.0,
     "thresholdHigh": 15.0,
-    "inRange": true
+    "inRange": true,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-4",
@@ -51,7 +67,11 @@
     "dataId": "NumericData-01",
     "operator": "LT",
     "data2Multiplier": 0.5,
-    "data2Id": "NumericData-02"
+    "data2Id": "NumericData-02",
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-5",
@@ -62,7 +82,10 @@
     "dataId": "StringData-01",
     "operator": "STARTS_WITH",
     "pattern": "Fred",
-    "ignoreCase": false
+    "ignoreCase": false,
+    "context": {
+      "description": "Server Name"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-6",
@@ -71,7 +94,10 @@
     "conditionSetIndex": 1,
     "type": "availability",
     "dataId": "Availability-01",
-    "operator": "NOT_UP"
+    "operator": "NOT_UP",
+    "context": {
+      "description": "Server"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-7",
@@ -81,6 +107,10 @@
     "type": "threshold",
     "dataId": "NumericData-Token",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   }
 ]}

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/conditions-data.json
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/conditions-data.json
@@ -7,7 +7,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -17,7 +21,11 @@
     "type": "threshold",
     "dataId": "NumericData-01",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-2",
@@ -27,7 +35,11 @@
     "type": "threshold",
     "dataId": "NumericData-02",
     "operator": "GTE",
-    "threshold": 15.0
+    "threshold": 15.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-3",
@@ -40,7 +52,11 @@
     "operatorHigh": "INCLUSIVE",
     "thresholdLow": 10.0,
     "thresholdHigh": 15.0,
-    "inRange": true
+    "inRange": true,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-4",
@@ -51,7 +67,11 @@
     "dataId": "NumericData-01",
     "operator": "LT",
     "data2Multiplier": 0.5,
-    "data2Id": "NumericData-02"
+    "data2Id": "NumericData-02",
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-5",
@@ -62,7 +82,10 @@
     "dataId": "StringData-01",
     "operator": "STARTS_WITH",
     "pattern": "Fred",
-    "ignoreCase": false
+    "ignoreCase": false,
+    "context": {
+      "description": "Server Name"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-6",
@@ -71,7 +94,10 @@
     "conditionSetIndex": 1,
     "type": "availability",
     "dataId": "Availability-01",
-    "operator": "NOT_UP"
+    "operator": "NOT_UP",
+    "context": {
+      "description": "Server"
+    }
   },
   {"tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
     "triggerId": "trigger-7",
@@ -81,6 +107,10 @@
     "type": "threshold",
     "dataId": "NumericData-Token",
     "operator": "LT",
-    "threshold": 10.0
+    "threshold": 10.0,
+    "context": {
+      "description": "Response Time",
+      "unit": "ms"
+    }
   }
 ]}


### PR DESCRIPTION
I'm going to split the HWKALERTS-85 in several commits.
Then we can consolidate changes on master and work on parallel tasks without being blocked for some commit.
This one brings context to Condition level, needed to support multiple types of conditions at actions plugins level.
The context is optional information added from the data and definition and used (optionally) in the actions plugins.