### PR TITLE
HWKALERTS-93 Add generic comments at Alert level

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.html.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.html.default_en_US.ftl
@@ -159,13 +159,6 @@
                                                         </td>
                                                     </tr>
                                                 </#if>
-                                                <#if alert.ackNotes?? >
-                                                    <tr>
-                                                        <td align="center" style="color:#999999; font-family:Open sans,sans-serif; font-size:13px; line-height:21px; padding-bottom:7px;">
-                                                            ${alert.ackNotes}
-                                                        </td>
-                                                    </tr>
-                                                </#if>
                                             </#if>
                                             <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
                                                 <tr>
@@ -184,13 +177,16 @@
                                                         </td>
                                                     </tr>
                                                 </#if>
-                                                <#if alert.resolvedNotes?? >
+                                            </#if>
+                                            <#if alert.notes?has_content >
+                                                <#list alert.notes as note>
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open sans,sans-serif; font-size:13px; line-height:21px; padding-bottom:7px;">
-                                                            ${alert.resolvedNotes}
+                                                          ${note.text}
+                                                          <br>(${note.user}, ${note.ctime?number_to_datetime})
                                                         </td>
                                                     </tr>
-                                                </#if>
+                                                </#list>
                                             </#if>
                                         </table>
                                     </td>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.plain.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.plain.default_en_US.ftl
@@ -24,10 +24,6 @@ ${alert.ackTime?number_to_datetime}
 
 by ${alert.ackBy}
 </#if>
-<#if alert.ackNotes?? >
-
-${alert.ackNotes}
-</#if>
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
 
@@ -37,12 +33,16 @@ ${alert.resolvedTime?number_to_datetime}
 
 by ${alert.resolvedBy}
 </#if>
-<#if alert.resolvedNotes?? >
-
-${alert.resolvedNotes}
 </#if>
-</#if>
+<#if alert.notes?has_content>
 
+Notes:
+
+<#list alert.notes as note>
+${note.text} (${note.user}, ${note.ctime?number_to_datetime})
+</#list>
+
+</#if>
 <#if baseUrl??>
 To view metrics of this alert, access your Hawkular account:
 ${baseUrl}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.html.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.html.default_en_US.ftl
@@ -159,13 +159,6 @@
                                                         </td>
                                                     </tr>
                                                 </#if>
-                                                <#if alert.ackNotes?? >
-                                                    <tr>
-                                                        <td align="center" style="color:#999999; font-family:Open sans,sans-serif; font-size:13px; line-height:21px; padding-bottom:7px;">
-                                                            ${alert.ackNotes}
-                                                        </td>
-                                                    </tr>
-                                                </#if>
                                             </#if>
                                             <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
                                                 <tr>
@@ -184,13 +177,16 @@
                                                         </td>
                                                     </tr>
                                                 </#if>
-                                                <#if alert.resolvedNotes?? >
+                                            </#if>
+                                            <#if alert.notes?has_content >
+                                                <#list alert.notes as note>
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open sans,sans-serif; font-size:13px; line-height:21px; padding-bottom:7px;">
-                                                            ${alert.resolvedNotes}
+                                                          ${note.text}
+                                                          <br>(${note.user}, ${note.ctime?number_to_datetime})
                                                         </td>
                                                     </tr>
-                                                </#if>
+                                                </#list>
                                             </#if>
                                         </table>
                                     </td>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.plain.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.plain.default_en_US.ftl
@@ -24,10 +24,6 @@ ${alert.ackTime?number_to_datetime}
 
 by ${alert.ackBy}
 </#if>
-<#if alert.ackNotes?? >
-
-${alert.ackNotes}
-</#if>
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
 
@@ -37,12 +33,16 @@ ${alert.resolvedTime?number_to_datetime}
 
 by ${alert.resolvedBy}
 </#if>
-<#if alert.resolvedNotes?? >
-
-${alert.resolvedNotes}
 </#if>
-</#if>
+<#if alert.notes?has_content>
 
+Notes:
+
+<#list alert.notes as note>
+${note.text} (${note.user}, ${note.ctime?number_to_datetime})
+</#list>
+
+</#if>
 <#if baseUrl??>
 To view metrics of this alert, access your Hawkular account:
 ${baseUrl}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
@@ -135,7 +135,7 @@ public class FilePluginTest {
         rtAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
         rtAlertAck.setAckBy("Test ACK user");
         rtAlertAck.setAckTime(System.currentTimeMillis() + 10000);
-        rtAlertAck.setAckNotes("Test ACK notes");
+        rtAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackThresholdAction = new Action(tenantId, "email", "email-to-test", rtAlertAck);
 
@@ -154,7 +154,7 @@ public class FilePluginTest {
         rtAlertResolved.setStatus(Alert.Status.RESOLVED);
         rtAlertResolved.setResolvedBy("Test RESOLVED user");
         rtAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
-        rtAlertResolved.setResolvedNotes("Test RESOLVED notes");
+        rtAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         rtAlertResolved.setResolvedEvalSets(getEvalList(rtResolveCondition, rtGoodData));
 
         Action resolvedThresholdAction = new Action(tenantId, "email", "email-to-test", rtAlertResolved);
@@ -206,7 +206,7 @@ public class FilePluginTest {
         avAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
         avAlertAck.setAckBy("Test ACK user");
         avAlertAck.setAckTime(System.currentTimeMillis() + 10000);
-        avAlertAck.setAckNotes("Test ACK notes");
+        avAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackAvailabilityAction = new Action(tenantId, "email", "email-to-test", avAlertAck);
 
@@ -226,7 +226,7 @@ public class FilePluginTest {
         avAlertResolved.setStatus(Alert.Status.RESOLVED);
         avAlertResolved.setResolvedBy("Test RESOLVED user");
         avAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
-        avAlertResolved.setResolvedNotes("Test RESOLVED notes");
+        avAlertResolved.addNote("Test RESOLVED", "Test RESOLVED notes");
         avAlertResolved.setResolvedEvalSets(getEvalList(avResolveCondition, avGoodData));
 
         Action resolvedAvailabilityAction = new Action(tenantId, "email", "email-to-test", avAlertResolved);
@@ -288,7 +288,7 @@ public class FilePluginTest {
         mixAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
         mixAlertAck.setAckBy("Test ACK user");
         mixAlertAck.setAckTime(System.currentTimeMillis() + 10000);
-        mixAlertAck.setAckNotes("Test ACK notes");
+        mixAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackTwoCondAction = new Action(tenantId, "email", "email-to-test", mixAlertAck);
 
@@ -316,7 +316,7 @@ public class FilePluginTest {
         mixAlertResolved.setStatus(Alert.Status.RESOLVED);
         mixAlertResolved.setResolvedBy("Test RESOLVED user");
         mixAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
-        mixAlertResolved.setResolvedNotes("Test RESOLVED notes");
+        mixAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         mixAlertResolved.setResolvedEvalSets(getEvalList(mixResolveConditions, mixGoodData));
 
         Action resolvedTwoCondAction = new Action(tenantId, "email", "email-to-test", mixAlertResolved);

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
@@ -226,7 +226,7 @@ public class FilePluginTest {
         avAlertResolved.setStatus(Alert.Status.RESOLVED);
         avAlertResolved.setResolvedBy("Test RESOLVED user");
         avAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
-        avAlertResolved.addNote("Test RESOLVED", "Test RESOLVED notes");
+        avAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         avAlertResolved.setResolvedEvalSets(getEvalList(avResolveCondition, avGoodData));
 
         Action resolvedAvailabilityAction = new Action(tenantId, "email", "email-to-test", avAlertResolved);

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/CommonData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/CommonData.java
@@ -43,7 +43,7 @@ public abstract class CommonData {
         if (null == openAlert) return null;
         openAlert.setStatus(Alert.Status.ACKNOWLEDGED);
         openAlert.setAckBy(ACK_BY);
-        openAlert.setAckNotes(ACK_NOTES);
+        openAlert.addNote(ACK_BY, ACK_NOTES);
         openAlert.setAckTime(System.currentTimeMillis());
         return openAlert;
     }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
@@ -131,7 +131,7 @@ public class JvmGarbageCollectionData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
@@ -137,7 +137,7 @@ public class JvmHeapUsageData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
@@ -137,7 +137,7 @@ public class JvmNonHeapUsageData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
@@ -259,7 +259,7 @@ public class MultipleAllJvmData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
@@ -125,7 +125,7 @@ public class UrlAvailabilityData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
@@ -130,7 +130,7 @@ public class UrlResponseTimeData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
@@ -137,7 +137,7 @@ public class WebActiveSessionsData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
@@ -137,7 +137,7 @@ public class WebContainerCurrentThreadsData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
@@ -137,7 +137,7 @@ public class WebContainerPendingRequestsData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
@@ -131,7 +131,7 @@ public class WebExpiredSessionsData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
@@ -131,7 +131,7 @@ public class WebRejectedSessionsData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
@@ -131,7 +131,7 @@ public class WebRequestsResponseTimeData extends CommonData {
         unresolvedAlert.setResolvedEvalSets(resolvedEvals);
         unresolvedAlert.setStatus(Alert.Status.RESOLVED);
         unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.setResolvedNotes(RESOLVED_NOTES);
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
         unresolvedAlert.setResolvedTime(System.currentTimeMillis());
 
         return unresolvedAlert;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,16 +83,13 @@ public class Alert {
     private String ackBy;
 
     @JsonInclude
-    private String ackNotes;
-
-    @JsonInclude
     private long resolvedTime;
 
     @JsonInclude
     private String resolvedBy;
 
-    @JsonInclude
-    private String resolvedNotes;
+    @JsonInclude(Include.NON_EMPTY)
+    private List<Note> notes;
 
     /*
      * If set this should be the trigger as defined when the alert was fired.  A trigger definition can change
@@ -207,14 +205,6 @@ public class Alert {
         this.ackBy = ackBy;
     }
 
-    public String getAckNotes() {
-        return ackNotes;
-    }
-
-    public void setAckNotes(String ackNotes) {
-        this.ackNotes = ackNotes;
-    }
-
     public long getResolvedTime() {
         return resolvedTime;
     }
@@ -229,14 +219,6 @@ public class Alert {
 
     public void setResolvedBy(String resolvedBy) {
         this.resolvedBy = resolvedBy;
-    }
-
-    public String getResolvedNotes() {
-        return resolvedNotes;
-    }
-
-    public void setResolvedNotes(String resolvedNotes) {
-        this.resolvedNotes = resolvedNotes;
     }
 
     public List<Set<ConditionEval>> getResolvedEvalSets() {
@@ -274,6 +256,17 @@ public class Alert {
         this.context = context;
     }
 
+    public List<Note> getNotes() {
+        if (null == notes) {
+            this.notes = new ArrayList<>();
+        }
+        return notes;
+    }
+
+    public void setNotes(List<Note> notes) {
+        this.notes = notes;
+    }
+
     /**
      * Add context information.
      * @param name context key.
@@ -287,6 +280,19 @@ public class Alert {
             context = new HashMap<>();
         }
         context.put(name, value);
+    }
+
+    /**
+     * Add a note on this alert
+     *
+     * @param user author of the comment
+     * @param text content of the note
+     */
+    public void addNote(String user, String text) {
+        if (user == null || text == null) {
+            throw new IllegalArgumentException("Note mut have non-null user and text");
+        }
+        getNotes().add(new Note(user, text));
     }
 
     @Override
@@ -316,9 +322,103 @@ public class Alert {
 
     @Override
     public String toString() {
-        return "Alert [alertId=" + alertId + ", status=" + status + ", ackTime=" + ackTime
-                + ", ackBy=" + ackBy + ", resolvedTime=" + resolvedTime + ", resolvedBy=" + resolvedBy + ", context="
-                + context + "]";
+        return "Alert{" +
+                "tenantId='" + tenantId + '\'' +
+                ", alertId='" + alertId + '\'' +
+                ", triggerId='" + triggerId + '\'' +
+                ", ctime=" + ctime +
+                ", evalSets=" + evalSets +
+                ", severity=" + severity +
+                ", status=" + status +
+                ", ackTime=" + ackTime +
+                ", ackBy='" + ackBy + '\'' +
+                ", resolvedTime=" + resolvedTime +
+                ", resolvedBy='" + resolvedBy + '\'' +
+                ", notes=" + notes +
+                ", trigger=" + trigger +
+                ", dampening=" + dampening +
+                ", resolvedEvalSets=" + resolvedEvalSets +
+                ", context=" + context +
+                '}';
+    }
+
+    public static class Note {
+        @JsonInclude(Include.NON_EMPTY)
+        private String user;
+
+        @JsonInclude(Include.NON_EMPTY)
+        private long ctime;
+
+        @JsonInclude(Include.NON_EMPTY)
+        private String text;
+
+        public Note() {
+            // for json assembly
+        }
+
+        public Note(String user, String text) {
+            this(user, System.currentTimeMillis(), text);
+        }
+
+        public Note(String user, long ctime, String text) {
+            this.user = user;
+            this.ctime = ctime;
+            this.text = text;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public void setUser(String user) {
+            this.user = user;
+        }
+
+        public long getCtime() {
+            return ctime;
+        }
+
+        public void setCtime(long ctime) {
+            this.ctime = ctime;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Note note = (Note) o;
+
+            if (ctime != note.ctime) return false;
+            if (user != null ? !user.equals(note.user) : note.user != null) return false;
+            return !(text != null ? !text.equals(note.text) : note.text != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = user != null ? user.hashCode() : 0;
+            result = 31 * result + (int) (ctime ^ (ctime >>> 32));
+            result = 31 * result + (text != null ? text.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Note{" +
+                    "user='" + user + '\'' +
+                    ", ctime=" + ctime +
+                    ", text='" + text + '\'' +
+                    '}';
+        }
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Alert.java
@@ -290,7 +290,7 @@ public class Alert {
      */
     public void addNote(String user, String text) {
         if (user == null || text == null) {
-            throw new IllegalArgumentException("Note mut have non-null user and text");
+            throw new IllegalArgumentException("Note must have non-null user and text");
         }
         getNotes().add(new Note(user, text));
     }
@@ -320,14 +320,13 @@ public class Alert {
         return true;
     }
 
-    @Override
-    public String toString() {
-        return "Alert{" +
+    @Override public
+    String toString() {
+        return "Alert" + '[' +
                 "tenantId='" + tenantId + '\'' +
                 ", alertId='" + alertId + '\'' +
                 ", triggerId='" + triggerId + '\'' +
                 ", ctime=" + ctime +
-                ", evalSets=" + evalSets +
                 ", severity=" + severity +
                 ", status=" + status +
                 ", ackTime=" + ackTime +
@@ -337,9 +336,8 @@ public class Alert {
                 ", notes=" + notes +
                 ", trigger=" + trigger +
                 ", dampening=" + dampening +
-                ", resolvedEvalSets=" + resolvedEvalSets +
                 ", context=" + context +
-                '}';
+                ']';
     }
 
     public static class Note {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
@@ -53,6 +53,17 @@ public interface AlertsService {
     void addAlerts(Collection<Alert> alerts) throws Exception;
 
     /**
+     * Add a note on an existing Alert.
+     * If alertId doesn't exist then the note is ignored.
+     * @param tenantId Tenant where alerts are stored
+     * @param alertId Alert to be added a new note
+     * @param user The user adding the note
+     * @param text The content of the note
+     * @throws Exception any problem
+     */
+    void addNote(String tenantId, String alertId, String user, String text) throws Exception;
+
+    /**
      * Delete the requested Alerts, as described by the provided criteria.
      * @param tenantId Tenant where alerts are stored
      * @param criteria specifying the Alerts to be deleted. Not null.

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -169,10 +169,11 @@ public class JsonTest {
                 "\"status\":\"OPEN\"," +
                 "\"ackTime\":0," +
                 "\"ackBy\":null," +
-                "\"ackNotes\":null," +
                 "\"resolvedTime\":0," +
                 "\"resolvedBy\":null," +
-                "\"resolvedNotes\":null," +
+                "\"notes\":[{\"user\":\"user1\",\"ctime\":1,\"text\":\"The comment 1\"}," +
+                "{\"user\":\"user2\",\"ctime\":2,\"text\":\"The comment 2\"}" +
+                "]," +
                 "\"context\":{\"n1\":\"v1\",\"n2\":\"v2\"}}";
 
         ObjectMapper mapper = new ObjectMapper();

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1490,6 +1491,31 @@ public abstract class PersistenceTest {
             System.out.println(action);
             assertNull(action.getAlert());
         }
+    }
+
+    @Test
+    public void test0100BasicNotesOnAlert() throws Exception {
+
+        Alert testAlert = new Alert(TEST_TENANT, "non-existence-trigger", Severity.MEDIUM, null);
+
+        alertsService.addAlerts(Collections.singletonList(testAlert));
+
+        AlertsCriteria criteria = new AlertsCriteria();
+        criteria.setTriggerId("non-existence-trigger");
+
+        List<Alert> alerts = alertsService.getAlerts(TEST_TENANT, criteria, null);
+
+        assertTrue(alerts != null && alerts.size() == 1);
+
+        Alert updatedAlert = alerts.get(0);
+
+        alertsService.addNote(TEST_TENANT, updatedAlert.getAlertId(), "user1", "notes1");
+        alertsService.addNote(TEST_TENANT, updatedAlert.getAlertId(), "user2", "notes2");
+        alertsService.addNote(TEST_TENANT, updatedAlert.getAlertId(), "user3", "notes3");
+
+        Alert updatedAlertWithNotes = alertsService.getAlert(TEST_TENANT, updatedAlert.getAlertId(), false);
+
+        assertTrue(updatedAlertWithNotes != null && updatedAlertWithNotes.getNotes().size() == 3);
     }
 
 }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
@@ -170,6 +170,37 @@ public class AlertsHandler {
     }
 
     @PUT
+    @Path("/note/{alertId}")
+    @Consumes(APPLICATION_JSON)
+    @ApiOperation(value = "Add a note into an existing Alert")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success, Alert Acknowledged invoked successfully"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters") })
+    public Response addAlertNote(@ApiParam(required = true, value = "alertId to add the note")
+                             @PathParam("alertId")
+                             final String alertId,
+                             @ApiParam(required = false, value = "author of the note")
+                             @QueryParam("user")
+                             final String user,
+                             @ApiParam(required = false, value = "text of the note")
+                             @QueryParam("text")
+                             final String text) {
+        try {
+            if (!isEmpty(alertId)) {
+                alertsService.addNote(tenantId, alertId, user, text);
+                log.debugf("AlertId: %s ", alertId);
+                return ResponseUtil.ok();
+            } else {
+                return ResponseUtil.badRequest("AlertId required for adding notes");
+            }
+        } catch (Exception e) {
+            log.debugf(e.getMessage(), e);
+            return ResponseUtil.internalError(e.getMessage());
+        }
+    }
+
+    @PUT
     @Path("/ack")
     @Consumes(APPLICATION_JSON)
     @ApiOperation(value = "Set one or more alerts Acknowledged")


### PR DESCRIPTION
Main goals:
- Moved ackNotes and resolvedNotes into generic notes.
- Add additional API service and endpoint to add notes without state transitions.
- Refactor email plugin templates to support generic notes.

@jshaughn please, could you take a look on it ? Thx.
