### PR TITLE
clean up bus/activemq related deps

### DIFF
--- a/hawkular-alerts-actions-bus/pom.xml
+++ b/hawkular-alerts-actions-bus/pom.xml
@@ -49,22 +49,8 @@
     <!-- Hawkular Nest dependencies -->
     <dependency>
       <groupId>org.hawkular.bus</groupId>
-      <artifactId>hawkular-bus-mdb</artifactId>
+      <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.bus}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-all</artifactId>
-      <version>${version.org.apache.activemq}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-jaas</artifactId>
-      <version>${version.org.apache.activemq}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/hawkular-alerts-actions-plugins/pom.xml
+++ b/hawkular-alerts-actions-plugins/pom.xml
@@ -59,7 +59,7 @@
     <!-- Hawkular Nest dependencies -->
     <dependency>
       <groupId>org.hawkular.bus</groupId>
-      <artifactId>hawkular-bus-mdb</artifactId>
+      <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.bus}</version>
       <scope>provided</scope>
     </dependency>
@@ -68,20 +68,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.com.google.guava}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-all</artifactId>
-      <version>${version.org.apache.activemq}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-jaas</artifactId>
-      <version>${version.org.apache.activemq}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/hawkular-alerts-bus/pom.xml
+++ b/hawkular-alerts-bus/pom.xml
@@ -55,7 +55,7 @@
     <!-- Hawkular Nest dependencies -->
     <dependency>
       <groupId>org.hawkular.bus</groupId>
-      <artifactId>hawkular-bus-mdb</artifactId>
+      <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.bus}</version>
       <scope>provided</scope>
     </dependency>
@@ -64,20 +64,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.com.google.guava}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-all</artifactId>
-      <version>${version.org.apache.activemq}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-jaas</artifactId>
-      <version>${version.org.apache.activemq}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
There are modules that depend on hawkular-bus-mdb but they only use classes in
hawkular-bus-common. This clean up helps with ongoing work for HAWKULAR-732.