### PR TITLE
HWKALERTS-98 Fix collision on fast alerts

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
@@ -167,7 +168,7 @@ public class Event implements Comparable<Event>, Serializable {
 
         this.ctime = System.currentTimeMillis();
 
-        this.id = trigger.getId() + "-" + this.ctime;
+        this.id = trigger.getId() + "-" + this.ctime + "-" + UUID.randomUUID();
         this.dataId = trigger.getId();
         this.context = trigger.getContext();
         if (!isEmpty(trigger.getEventCategory())) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -101,6 +101,9 @@ public class CassAlertsServiceImpl implements AlertsService {
         if (alerts.isEmpty()) {
             return;
         }
+        if (log.isDebugEnabled()) {
+            log.debug("Adding " + alerts.size() + " alerts");
+        }
         session = CassCluster.getSession();
         PreparedStatement insertAlert = CassStatement.get(session, CassStatement.INSERT_ALERT);
         PreparedStatement insertAlertTrigger = CassStatement.get(session, CassStatement.INSERT_ALERT_TRIGGER);
@@ -153,11 +156,12 @@ public class CassAlertsServiceImpl implements AlertsService {
         if (events == null) {
             throw new IllegalArgumentException("Events must be not null");
         }
-
         if (events.isEmpty()) {
             return;
         }
-
+        if (log.isDebugEnabled()) {
+            log.debug("Adding " + events.size() + " events");
+        }
         session = CassCluster.getSession();
         PreparedStatement insertEvent = CassStatement.get(session, CassStatement.INSERT_EVENT);
         PreparedStatement insertEventCategory = CassStatement.get(session, CassStatement.INSERT_EVENT_CATEGORY);


### PR DESCRIPTION
DEBUG on/off was important.
Generated alerts with automatic id can come into collision when testing same trigger.
This is rare but possible.