### PR TITLE
HWKALERTS-120 Add missing keycloak config on hawkular deployments

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/aerogear</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/email</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/file</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/irc</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/pagerduty</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/sms</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,5 @@
 -->
 <jboss-web>
   <context-root>/hawkular/actions/snmp</context-root>
+  <security-domain>keycloak</security-domain>
 </jboss-web>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,32 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
 
 </web-app>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,11 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
       version="3.0">
+
+  <context-param>
+    <param-name>org.keycloak.secretstore.enabled</param-name>
+    <param-value>true</param-value>
+  </context-param>
 
   <security-constraint>
     <web-resource-collection>


### PR DESCRIPTION
This PR is trivial to fix missing keycloak config on plugins .war archives.
In theory, plugins don't expose Web, but to not leave open holes it is good to be consistent.