### PR TITLE
HWKALERTS-119 Move Bus messages to public API

### DIFF
--- a/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/AlertDataMessage.java
+++ b/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/AlertDataMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.bus.messages;
+package org.hawkular.alerts.bus.api;
 
 
 import java.util.Arrays;
@@ -24,6 +24,7 @@ import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.bus.common.AbstractMessage;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * A bus message used to receive data for the alerts subsystem.
  * One message can store a collection of {@link org.hawkular.alerts.bus.messages.AlertData}.

--- a/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/AvailDataMessage.java
+++ b/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/AvailDataMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.bus.messages;
+package org.hawkular.alerts.bus.api;
 
 import java.util.List;
 

--- a/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/MetricDataMessage.java
+++ b/hawkular-alerts-bus-api/src/main/java/org/hawkular/alerts/bus/api/MetricDataMessage.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.bus.messages;
+package org.hawkular.alerts.bus.api;
 
 import java.util.List;
 

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AlertDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AlertDataListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ import javax.ejb.TransactionAttributeType;
 import javax.jms.MessageListener;
 
 import org.hawkular.alerts.api.services.AlertsService;
-import org.hawkular.alerts.bus.messages.AlertDataMessage;
+import org.hawkular.alerts.bus.api.AlertDataMessage;
 import org.hawkular.bus.common.consumer.BasicMessageListener;
 import org.jboss.logging.Logger;
 

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AvailDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/AvailDataListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,10 +30,10 @@ import javax.jms.MessageListener;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.services.AlertsService;
 import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.bus.api.AvailDataMessage;
+import org.hawkular.alerts.bus.api.AvailDataMessage.AvailData;
+import org.hawkular.alerts.bus.api.AvailDataMessage.SingleAvail;
 import org.hawkular.alerts.bus.init.CacheManager;
-import org.hawkular.alerts.bus.messages.AvailDataMessage;
-import org.hawkular.alerts.bus.messages.AvailDataMessage.AvailData;
-import org.hawkular.alerts.bus.messages.AvailDataMessage.SingleAvail;
 import org.hawkular.bus.common.consumer.BasicMessageListener;
 import org.jboss.logging.Logger;
 

--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/MetricDataListener.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/listener/MetricDataListener.java
@@ -29,10 +29,10 @@ import javax.jms.MessageListener;
 
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.bus.api.MetricDataMessage;
+import org.hawkular.alerts.bus.api.MetricDataMessage.MetricData;
+import org.hawkular.alerts.bus.api.MetricDataMessage.SingleMetric;
 import org.hawkular.alerts.bus.init.CacheManager;
-import org.hawkular.alerts.bus.messages.MetricDataMessage;
-import org.hawkular.alerts.bus.messages.MetricDataMessage.MetricData;
-import org.hawkular.alerts.bus.messages.MetricDataMessage.SingleMetric;
 import org.hawkular.bus.common.consumer.BasicMessageListener;
 import org.jboss.logging.Logger;
 


### PR DESCRIPTION
Future messages used by the bus should be placed on the public api for external users.