### PR TITLE
HWKALERTS-121 Add integration tests for bus scenarios

### DIFF
--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -42,16 +42,42 @@
 
     <dependency>
       <groupId>org.hawkular.alerts</groupId>
-      <artifactId>hawkular-alerts-bus</artifactId>
+      <artifactId>hawkular-alerts-bus-api</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.hawkular.commons</groupId>
-      <artifactId>hawkular-bus-rest-client</artifactId>
+      <artifactId>hawkular-bus-common</artifactId>
       <version>${version.org.hawkular.commons}</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-jms-client-bom</artifactId>
+      <version>${version.org.wildfly}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -301,6 +327,26 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
             <executions>
+              <execution>
+                <id>copy-users-data</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/standalone/configuration</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src/test/resources</directory>
+                      <includes>
+                        <include>application-roles.properties</include>
+                        <include>application-users.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
               <execution>
                 <id>copy-data-dir</id>
                 <phase>pre-integration-test</phase>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ class AbstractITestBase {
 
     static baseURI = System.getProperty('hawkular.base-uri') ?: 'http://127.0.0.1:8080/hawkular/alerts/'
     static RESTClient client
+    static testTenant = "28026b36-8fe4-4332-84c8-524e173a68bf"
 
     @BeforeClass
     static void initClient() {
@@ -50,6 +51,6 @@ class AbstractITestBase {
             This is used for non-bus scenarios.
             In Bus scenarios this property is skipped
          */
-        client.headers.put("Hawkular-Tenant", "28026b36-8fe4-4332-84c8-524e173a68bf")
+        client.headers.put("Hawkular-Tenant", testTenant)
     }
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/BusITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/BusITest.groovy
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest
+
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.junit.Test
+
+import javax.jms.ConnectionFactory
+import javax.jms.JMSContext
+import javax.jms.JMSProducer
+import javax.jms.Topic
+import javax.naming.Context
+import javax.naming.InitialContext
+
+import static org.junit.Assert.assertEquals
+
+/**
+ * Actions REST tests.
+ *
+ * @author Lucas Ponce
+ */
+class BusITest extends AbstractITestBase {
+
+    @Test
+    void availabilityThroughBusTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        Trigger testTrigger = new Trigger("test-bus-email-availability", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-bus-email-availability")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+        /*
+            email-to-admin action is pre-created from demo data
+         */
+        testTrigger.addAction("email", "email-to-admin");
+        testTrigger.addAction("file", "file-to-admin");
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-bus-email-availability",
+                Mode.FIRING, "test-bus-email-availability", AvailabilityCondition.Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-bus-email-availability/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-bus-email-availability", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-bus-email-availability");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-bus-email-availability"] )
+        assertEquals(200, resp.status)
+
+        // Send in DOWN avail data to fire the trigger
+
+        Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory")
+        env.put(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8080")
+        env.put(Context.SECURITY_PRINCIPAL, 'hawkular')
+        env.put(Context.SECURITY_CREDENTIALS, 'hawkular')
+
+        InitialContext namingContext = new InitialContext(env)
+        ConnectionFactory connectionFactory = (ConnectionFactory) namingContext.lookup('jms/RemoteConnectionFactory')
+        JMSContext context = connectionFactory.createContext('hawkular', 'hawkular')
+        Topic topic = (Topic) namingContext.lookup('java:/topic/HawkularAvailData')
+        JMSProducer producer = context.createProducer()
+
+        for (int i=0; i<5; i++) {
+            String strAvailData = "{\"availData\":{\"data\":[{\"tenantId\":\"$testTenant\"," +
+                    "\"id\":\"test-bus-email-availability\"," +
+                    "\"timestamp\":" + System.currentTimeMillis() + "," +
+                    "\"avail\":\"DOWN\"}]}}"
+            producer.send(topic, strAvailData)
+        }
+
+        context.close()
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            // println "SLEEP!" ;
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-bus-email-availability"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+    }
+
+    @Test
+    void thresholdThroughBusTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        Trigger testTrigger = new Trigger("test-bus-email-threshold", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-bus-email-threshold")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+        /*
+            email-to-admin action is pre-created from demo data
+         */
+        testTrigger.addAction("email", "email-to-admin");
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        ThresholdCondition firingCond = new ThresholdCondition("test-bus-email-threshold",
+                Mode.FIRING, "test-bus-email-threshold", ThresholdCondition.Operator.GT, 300);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-bus-email-threshold/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-bus-email-threshold", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-bus-email-threshold");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-bus-email-threshold"] )
+        assertEquals(200, resp.status)
+
+        // Send in data to fire the trigger
+
+        Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory")
+        env.put(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8080")
+        env.put(Context.SECURITY_PRINCIPAL, 'hawkular')
+        env.put(Context.SECURITY_CREDENTIALS, 'hawkular')
+
+        InitialContext namingContext = new InitialContext(env)
+        ConnectionFactory connectionFactory = (ConnectionFactory) namingContext.lookup('jms/RemoteConnectionFactory')
+        JMSContext context = connectionFactory.createContext('hawkular', 'hawkular')
+        Topic topic = (Topic) namingContext.lookup('java:/topic/HawkularMetricData')
+        JMSProducer producer = context.createProducer()
+
+        for (int i=0; i<5; i++) {
+            String strMetricData = "{\"metricData\":{\"tenantId\":\"$testTenant\"," +
+                    "\"data\":[{\"source\":\"test-bus-email-threshold\"," +
+                    "\"timestamp\":" + System.currentTimeMillis() + "," +
+                    "\"value\":" + String.valueOf(305.5 + i) + "}]}}"
+            producer.send(topic, strMetricData)
+        }
+
+        context.close()
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            // println "SLEEP!" ;
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-bus-email-threshold"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+    }
+
+
+}

--- a/hawkular-alerts-rest-tests/src/test/resources/application-roles.properties
+++ b/hawkular-alerts-rest-tests/src/test/resources/application-roles.properties
@@ -1,0 +1,41 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Properties declaration of users roles for the realm 'ApplicationRealm' which is the default realm
+# for application services on new installations.
+#
+# This includes the following protocols: remote ejb, remote jndi, web, remote jms
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# The format of this file is as follows: -
+# username=role1,role2,role3
+#
+# A utility script is provided which can be executed from the bin folder to add the users: -
+# - Linux
+#  bin/add-user.sh
+#
+# - Windows
+#  bin\add-user.bat
+#
+# The following illustrates how an admin user could be defined.
+#
+#admin=PowerUser,BillingAdmin,
+#guest=guest
+hawkular=guest

--- a/hawkular-alerts-rest-tests/src/test/resources/application-users.properties
+++ b/hawkular-alerts-rest-tests/src/test/resources/application-users.properties
@@ -1,0 +1,42 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Properties declaration of users for the realm 'ApplicationRealm' which is the default realm
+# for application services on new installations.
+#
+# This includes the following protocols: remote ejb, remote jndi, web, remote jms
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# The format of this realm is as follows: -
+# username=HEX( MD5( username ':' realm ':' password))
+#
+# A utility script is provided which can be executed from the bin folder to add the users: -
+# - Linux
+#  bin/add-user.sh
+#
+# - Windows
+#  bin\add-user.bat
+#
+#$REALM_NAME=ApplicationRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#
+# The following illustrates how an admin user could be defined, this
+# is for illustration only and does not correspond to a usable password.
+#
+hawkular=2e1e5cc53887b6592e92423688b5ff7d

--- a/hawkular-alerts-rest-tests/src/test/resources/standalone-hawkular.xsl
+++ b/hawkular-alerts-rest-tests/src/test/resources/standalone-hawkular.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,10 +75,10 @@
     <xsl:copy>
       <xsl:apply-templates select="@*|node()" />
       <jms-topic name="HawkularAlertData" entries="java:/topic/HawkularAlertData"/>
-      <jms-topic name="HawkularMetricData" entries="java:/topic/HawkularMetricData"/>
+      <jms-topic name="HawkularMetricData" entries="java:/topic/HawkularMetricData java:jboss/exported/topic/HawkularMetricData"/>
       <jms-queue name="HawkularAlertsPluginsQueue" entries="java:/queue/HawkularAlertsPluginsQueue"/>
       <jms-queue name="HawkularAlertsActionsResponseQueue" entries="java:/queue/HawkularAlertsActionsResponseQueue"/>
-      <jms-topic name="HawkularAvailData" entries="java:/topic/HawkularAvailData"/>
+      <jms-topic name="HawkularAvailData" entries="java:/topic/HawkularAvailData java:jboss/exported/topic/HawkularAvailData"/>
       <jms-topic name="HawkularCommandEvent" entries="java:/topic/HawkularCommandEvent"/>
       <jms-topic name="HawkularAlertsActionsTopic" entries="java:/topic/HawkularAlertsActionsTopic"/>
     </xsl:copy>


### PR DESCRIPTION
Minor PR to cover bus scenarios.
Repeating some tests but sending data directly through the bus instead using /data endpoint.
This will give better testing support for hawkular scenarios.
Noted that with new changes on bus, using javax.jms packages are needed to connect remotely to bus destinations instead to use the old abstract hawkular-bus api.