### PR TITLE
Email properties

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/pom.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail</artifactId>
+      <version>${version.com.icegreen}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.hawkular.alerts</groupId>
       <artifactId>hawkular-alerts-actions-tests</artifactId>
       <version>${project.version}</version>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailSessionProperties.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailSessionProperties.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.email;
+
+/**
+ * A helper class to load properties used for email Session creation.
+ *
+ * Properties can be defined via file from
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class EmailSessionProperties {
+
+
+
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmGarbageCollectionEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmGarbageCollectionEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class JvmGarbageCollectionEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class JvmGarbageCollectionEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class JvmGarbageCollectionEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class JvmGarbageCollectionEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmHeapUsageEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmHeapUsageEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class JvmHeapUsageEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class JvmHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class JvmHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class JvmHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmNonHeapUsageEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/JvmNonHeapUsageEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class JvmNonHeapUsageEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class JvmNonHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class JvmNonHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class JvmNonHeapUsageEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/MultipleAllJvmEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/MultipleAllJvmEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class MultipleAllJvmEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class MultipleAllJvmEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class MultipleAllJvmEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class MultipleAllJvmEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/SmtpServerTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/SmtpServerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.email;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetup;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class SmtpServerTest {
+
+    private static final String TEST_SMTP_HOST = "localhost";
+    private static int TEST_SMTP_PORT = 2525;
+
+    private GreenMail server;
+
+    @Before
+    public void startSmtpServer() {
+        server = new GreenMail(new ServerSetup(TEST_SMTP_PORT, TEST_SMTP_HOST, "smtp"));
+        server.start();
+    }
+
+    @After
+    public void stopSmtpServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void checkSmtpServer() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("mail.smtp.host", TEST_SMTP_HOST);
+        props.setProperty("mail.smtp.port", String.valueOf(TEST_SMTP_PORT));
+
+        Session session = Session.getInstance(props);
+
+        Message message = new MimeMessage(session);
+        message.setFrom(new InternetAddress("alerts-test-sender@hawkular.org"));
+        message.setRecipients(Message.RecipientType.TO,
+                InternetAddress.parse("alerts-test-receiver@hawkular.org"));
+        message.setSubject("Check SMTP Server");
+        message.setText("This is the text of the message");
+        Transport.send(message);
+
+        assertEquals(1, server.getReceivedMessages().length);
+    }
+}

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/UrlAvailabilityEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/UrlAvailabilityEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class UrlAvailabilityEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class UrlAvailabilityEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class UrlAvailabilityEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class UrlAvailabilityEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/UrlResponseTimeEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/UrlResponseTimeEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class UrlResponseTimeEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class UrlResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class UrlResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class UrlResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebActiveSessionsEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebActiveSessionsEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebActiveSessionsEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebActiveSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebActiveSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebActiveSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebContainerCurrentThreadsEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebContainerCurrentThreadsEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebContainerCurrentThreadsEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebContainerCurrentThreadsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebContainerCurrentThreadsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebContainerCurrentThreadsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebContainerPendingRequestsEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebContainerPendingRequestsEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebContainerPendingRequestsEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebContainerPendingRequestsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebContainerPendingRequestsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebContainerPendingRequestsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebExpiredSessionsEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebExpiredSessionsEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebExpiredSessionsEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebExpiredSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebExpiredSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebExpiredSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebRejectedSessionsEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebRejectedSessionsEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebRejectedSessionsEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebRejectedSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebRejectedSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebRejectedSessionsEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebRequestsResponseTimeEmailTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/java/org/hawkular/alerts/actions/email/WebRequestsResponseTimeEmailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class WebRequestsResponseTimeEmailTest extends CommonTest {
     @BeforeClass
     public static void prepareMessages() {
         plugin = new EmailPlugin();
+        plugin.setSender(new TestActionPluginSender());
 
         properties= new HashMap<>();
         properties.put("to", "admin@hawkular.org");
@@ -64,6 +66,10 @@ public class WebRequestsResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(openMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-1-open.eml");
+
+        plugin.process(openMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -79,6 +85,10 @@ public class WebRequestsResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(ackMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-2-ack.eml");
+
+        plugin.process(ackMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
     @Test
@@ -95,6 +105,10 @@ public class WebRequestsResponseTimeEmailTest extends CommonTest {
         Message email = plugin.createMimeMessage(resolvedMessage);
         assertNotNull(email);
         writeEmailFile(email, this.getClass().getSimpleName() + "-3-resolved.eml");
+
+        plugin.process(resolvedMessage);
+        // Test generates 2 messages on the mail server
+        assertEquals(2, server.getReceivedMessages().length);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
   </issueManagement>
 
   <properties>
+    <version.com.icegreen>1.4.1</version.com.icegreen>
     <version.javaee.spec>7.0</version.javaee.spec>
     <version.maven-patch-plugin>1.2</version.maven-patch-plugin>
     <version.org.codehaus.jsr166-mirror>1.7.0</version.org.codehaus.jsr166-mirror>


### PR DESCRIPTION
This PR moves the java.mail.Session to be managed via system properties.
This helps to configure from several points.
In alerts, it can be configured from hawkular-alerts.properties file, and in hawkular it can be configured in several places where system properties will be defined.
Also, it supports several definitions by tenant.

Other minor enhancements are to introduce an embedded smtp server for testing.