### PR TITLE
HWKALERTS-129 improve context and tag handling when adding a member trigger

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/GroupMemberInfo.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/GroupMemberInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,20 +35,24 @@ public class GroupMemberInfo {
     private String groupId;
     private String memberId;
     private String memberName;
+    private String memberDescription;
     private Map<String, String> memberContext;
+    private Map<String, String> memberTags;
     private Map<String, String> dataIdMap;
 
     public GroupMemberInfo() {
         // for json construction
     }
 
-    public GroupMemberInfo(String groupId, String memberId, String memberName, Map<String, String> memberContext,
-            Map<String, String> dataIdMap) {
+    public GroupMemberInfo(String groupId, String memberId, String memberName, String memberDescription,
+            Map<String, String> memberContext, Map<String, String> memberTags, Map<String, String> dataIdMap) {
         super();
         this.groupId = groupId;
         this.memberId = memberId;
         this.memberName = memberName;
+        this.memberDescription = memberDescription;
         this.memberContext = memberContext;
+        this.memberTags = memberTags;
         this.dataIdMap = dataIdMap;
     }
 
@@ -74,18 +78,44 @@ public class GroupMemberInfo {
         return memberName;
     }
 
-    /** The member triggerName. Required. */
+    /** The member triggerName. If null defaults to group trigger's name */
     public void setMemberName(String memberName) {
         this.memberName = memberName;
+    }
+
+    public String getMemberDescription() {
+        return memberDescription;
+    }
+
+    /**
+     * @param memberDescription If null defaults to group trigger's description
+     */
+    public void setMemberDescription(String memberDescription) {
+        this.memberDescription = memberDescription;
     }
 
     public Map<String, String> getMemberContext() {
         return memberContext;
     }
 
-    /** The member context. If null will be inherited from the group. */
+    /**
+     * @param memberContext Members inherit the group trigger context. If not null this adds additional, or
+     *                      overrides existing, context entries.
+     */
     public void setMemberContext(Map<String, String> memberContext) {
         this.memberContext = memberContext;
+    }
+
+    public Map<String, String> getMemberTags() {
+        return memberTags;
+    }
+
+    /**
+     * @param memberTags Members inherit the group trigger tags. If not null this adds additional, or
+     *                      overrides existing, tags.
+     */
+    public void setMemberTags(Map<String, String> memberTags) {
+        this.memberTags = memberTags;
     }
 
     public Map<String, String> getDataIdMap() {
@@ -126,6 +156,5 @@ public class GroupMemberInfo {
         return "GroupMemberInfo [groupId=" + groupId + ", memberId=" + memberId + ", memberName=" + memberName
                 + ", memberContext=" + memberContext + ", dataIdMap=" + dataIdMap + "]";
     }
-
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/UnorphanMemberInfo.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/UnorphanMemberInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,15 +32,18 @@ import java.util.Map;
 public class UnorphanMemberInfo {
 
     private Map<String, String> memberContext;
+    private Map<String, String> memberTags;
     private Map<String, String> dataIdMap;
 
     public UnorphanMemberInfo() {
         // for json construction
     }
 
-    public UnorphanMemberInfo(Map<String, String> memberContext, Map<String, String> dataIdMap) {
+    public UnorphanMemberInfo(Map<String, String> memberContext, Map<String, String> memberTags,
+            Map<String, String> dataIdMap) {
         super();
         this.memberContext = memberContext;
+        this.memberTags = memberTags;
         this.dataIdMap = dataIdMap;
     }
 
@@ -48,9 +51,24 @@ public class UnorphanMemberInfo {
         return memberContext;
     }
 
-    /** The member context. If null will be inherited from the group. */
+    /**
+     * @param memberContext Members inherit the group trigger context. If not null this adds additional, or
+     *                      overrides existing, context entries.
+     */
     public void setMemberContext(Map<String, String> memberContext) {
         this.memberContext = memberContext;
+    }
+
+    public Map<String, String> getMemberTags() {
+        return memberTags;
+    }
+
+    /**
+     * @param memberTags Members inherit the group trigger tags. If not null this adds additional, or
+     *                      overrides existing, tags.
+     */
+    public void setMemberTags(Map<String, String> memberTags) {
+        this.memberTags = memberTags;
     }
 
     public Map<String, String> getDataIdMap() {

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
@@ -77,9 +77,13 @@ public interface DefinitionsService {
      * @param tenantId Tenant where trigger is stored
      * @param groupId Group triggerId from which to spawn the member trigger
      * @param memberId The member triggerId, unique id within the tenant, if null an Id will be generated
-     * @param memberName The member triggerName, not null, unique name within the tenant
-     * @param memberContext The member triggerContext. If null the context is inherited from the group trigger
-     * @param dataIdMap Tokens to be replaced in the new trigger
+     * @param memberName The member triggerName, if null defaults to group trigger name
+     * @param memberDescription The member description, if null defaults to group trigger description
+     * @param memberContext Members inherit the group trigger context. If not null this adds additional, or
+     *                      overrides existing, context entries.
+     * @param memberTags Members inherit the group trigger tags. If not null this adds additional, or
+     *                      overrides existing, tags.
+     * @param dataIdMap Tokens to be replaced in the new trigger.
      * @return the member trigger
      * @throws Exception on any problem
      * @see {@link #addTrigger(String, Trigger)} for adding a non-group trigger.
@@ -88,7 +92,9 @@ public interface DefinitionsService {
      * <code>dataIdMap</code> parameter.
      */
     Trigger addMemberTrigger(String tenantId, String groupId, String memberId, String memberName,
-            Map<String, String> memberContext, Map<String, String> dataIdMap) throws Exception;
+            String memberDescription, Map<String, String> memberContext, Map<String, String> memberTags,
+            Map<String, String> dataIdMap)
+            throws Exception;
 
     /**
      * Generate a member trigger for the specified data-driven group trigger.
@@ -221,17 +227,20 @@ public interface DefinitionsService {
 
     /**
      * Un-orphan a member trigger.  The member trigger is again synchronized with the group definition. As an orphan
-     * it may have been altered in various ways. So, as when spawning a new member trigger, the context and dataIdMap
-     * are specified. See {@link org.hawkular.alerts.api.json.MemberTrigger#setDataIdMap(Map)} for an example
+     * it may have been altered in various ways. So, as when spawning a new member trigger, the context, tags and
+     * dataIdMap are specified. See {@link org.hawkular.alerts.api.json.MemberTrigger#setDataIdMap(Map)} for an example
      * of setting the <code>dataIdMap</code>.
      * <p>
      * This is basically a convenience method that first performs a {@link #removeTrigger(String, String)} and
      * then an {@link #addMemberTrigger(String, String, String, String, Map, Map)}. But the member trigger must
-     * already exist for this call to succeed. The trigger will maintain the same group, id, and name.
+     * already exist for this call to succeed. The trigger will maintain the same group, id, name and description.
      * </p>
      * @param tenantId Tenant where trigger is stored
      * @param memberId The member triggerId
-     * @param memberContext The member triggerContext. If null the context is inherited from the member trigger
+     * @param memberContext Context is reset to the group trigger context. If not null this adds additional, or
+     *                      overrides existing, context entries.
+     * @param memberTags Tags are reset to the group trigger tags. If not null this adds additional, or
+     *                      overrides existing, tags.
      * @param dataIdMap Tokens to be replaced in the new trigger
      * @return the member trigger
      * @throws NotFoundException if trigger is not found
@@ -241,7 +250,7 @@ public interface DefinitionsService {
      * of setting the <code>dataIdMap</code>.
      */
     Trigger unorphanMemberTrigger(String tenantId, String memberId, Map<String, String> memberContext,
-            Map<String, String> dataIdMap) throws Exception;
+            Map<String, String> memberTags, Map<String, String> dataIdMap) throws Exception;
 
     /*
         CRUD interface for Dampening
@@ -456,7 +465,7 @@ public interface DefinitionsService {
      * @param groupId Group Trigger adding the condition and whose non-orphan members will also have it added.
      * @param triggerMode Mode where condition is applied
      * @param groupCondition Not null, the condition to add
-     * @param dataIdMemberMap see above for details.
+     * @param dataIdMemberMap see above for details. Null if the group trigger has no members.
      * @return The updated, persisted condition set for the group
      * @throws NotFoundException if trigger is not found
      * @throws Exception on any problem

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
@@ -114,7 +114,7 @@ public class DataDrivenGroupCacheManager {
             }
         } catch (Exception e) {
             log.error("FAILED to updateCache. Unable to generate data-driven member triggers!", e);
-            sourcesMap = null;
+            sourcesMap = new HashMap<>();
         }
 
         if (log.isDebugEnabled()) {

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
@@ -119,12 +119,12 @@ public abstract class PersistenceTest {
         context.put("context", "context-1");
 
         Trigger nt1 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-1-trigger", "member-1",
-                context, dataIdMap);
+                null, null, context, dataIdMap);
         assertNotNull(nt1);
         dataIdMap.put("NumericData-Token", "NumericData-02");
         context.put("context", "context-2");
         Trigger nt2 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-2-trigger", "member-2",
-                context, dataIdMap);
+                null, null, context, dataIdMap);
         assertNotNull(nt2);
 
         Collection<Trigger> memberren = definitionsService.getMemberTriggers(TENANT, "group-trigger", false);
@@ -225,7 +225,7 @@ public abstract class PersistenceTest {
 
         dataIdMap.put("NumericData-Token", "NumericData-01");
         context.put("context", "context-1");
-        nt1 = definitionsService.unorphanMemberTrigger(TENANT, nt1.getId(), context, dataIdMap);
+        nt1 = definitionsService.unorphanMemberTrigger(TENANT, nt1.getId(), context, null, dataIdMap);
         assertNotNull(nt1);
         assertTrue(nt1.toString(), !nt1.isOrphan());
         assertTrue(nt1.toString(), "member-1-trigger".equals(nt1.getId()));
@@ -320,12 +320,12 @@ public abstract class PersistenceTest {
         context.put("context", "context-1");
 
         Trigger nt1 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-1-trigger", "member-1",
-                context, dataIdMap);
+                null, null, context, dataIdMap);
         assertNotNull(nt1);
         dataIdMap.put("NumericData-Token", "NumericData-02");
         context.put("context", "context-2");
         Trigger nt2 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-2-trigger", "member-2",
-                context, dataIdMap);
+                null, null, context, dataIdMap);
         assertNotNull(nt2);
 
         Collection<Trigger> memberren = definitionsService.getMemberTriggers(TENANT, "group-trigger", false);
@@ -415,12 +415,12 @@ public abstract class PersistenceTest {
         Map<String, String> dataIdMap = new HashMap<>(1);
         dataIdMap.put("NumericData-Token", "NumericData-01");
         Trigger nt1 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-1-trigger", "Member-1",
-                null, dataIdMap);
+                null, null, null, dataIdMap);
         assertNotNull(nt1);
 
         dataIdMap.put("NumericData-Token", "NumericData-02");
         Trigger nt2 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-2-trigger", "Member-2",
-                null, dataIdMap);
+                null, null, null, dataIdMap);
         assertNotNull(nt2);
 
         Collection<Condition> groupConditions = definitionsService.getTriggerConditions(TENANT, "group-trigger",
@@ -582,11 +582,11 @@ public abstract class PersistenceTest {
         dataIdMap.put("NumericData-Token", "NumericData-01");
 
         Trigger nt1 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-1-trigger", "Member-1",
-                null, dataIdMap);
+                null, null, null, dataIdMap);
         assertNotNull(nt1);
         dataIdMap.put("NumericData-Token", "NumericData-02");
         Trigger nt2 = definitionsService.addMemberTrigger(TENANT, t.getId(), "member-2-trigger", "Member-2",
-                null, dataIdMap);
+                null, null, null, dataIdMap);
         assertNotNull(nt2);
 
         Dampening groupDampening = Dampening.forStrict(TENANT, "group-trigger", Mode.FIRING, 10);

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
@@ -125,13 +125,14 @@ class TriggersITest extends AbstractITestBase {
         // create member 1
         Map<String,String> dataId1Map = new HashMap<>(2);
         dataId1Map.put("DataId1-Token", "DataId1-Child1");
-        GroupMemberInfo groupMemberInfo = new GroupMemberInfo("group-trigger", "member1", "member1", null, dataId1Map);
+        GroupMemberInfo groupMemberInfo = new GroupMemberInfo("group-trigger", "member1", "member1", null, null, null,
+            dataId1Map);
         resp = client.post(path: "triggers/groups/members", body: groupMemberInfo);
         assertEquals(200, resp.status)
 
         // create member 2
         dataId1Map.put("DataId1-Token", "DataId1-Child2");
-        groupMemberInfo = new GroupMemberInfo("group-trigger", "member2", "member2", null, dataId1Map);
+        groupMemberInfo = new GroupMemberInfo("group-trigger", "member2", "member2", null, null, null, dataId1Map);
         resp = client.post(path: "triggers/groups/members", body: groupMemberInfo);
         assertEquals(200, resp.status)
 
@@ -279,7 +280,7 @@ class TriggersITest extends AbstractITestBase {
         Map<String,String> dataIdMap = new HashMap<>(2);
         dataIdMap.put("DataId1-Token", "DataId1-Child2");
         dataIdMap.put("DataId2-Token", "DataId2-Child2");
-        UnorphanMemberInfo unorphanMemberInfo = new UnorphanMemberInfo(null, dataIdMap);
+        UnorphanMemberInfo unorphanMemberInfo = new UnorphanMemberInfo(null, null, dataIdMap);
         resp = client.post(path: "triggers/groups/members/member2/unorphan", body: unorphanMemberInfo);
         assertEquals(200, resp.status)
 

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
@@ -345,15 +345,14 @@ public class TriggersHandler {
                 return ResponseUtil.badRequest("MemberTrigger is null");
             }
             String groupId = groupMember.getGroupId();
-            String memberName = groupMember.getMemberName();
             if (isEmpty(groupId)) {
                 return ResponseUtil.badRequest("MemberTrigger groupId is null");
             }
-            if (isEmpty(memberName)) {
-                return ResponseUtil.badRequest("MemberTrigger memberName is null");
-            }
-            Trigger child = definitions.addMemberTrigger(tenantId, groupId, groupMember.getMemberId(), memberName,
+            Trigger child = definitions.addMemberTrigger(tenantId, groupId, groupMember.getMemberId(),
+                    groupMember.getMemberName(),
+                    groupMember.getMemberDescription(),
                     groupMember.getMemberContext(),
+                    groupMember.getMemberTags(),
                     groupMember.getDataIdMap());
             if (log.isDebugEnabled()) {
                 log.debug("Child Trigger: " + child.toString());
@@ -543,7 +542,9 @@ public class TriggersHandler {
             if (null == unorphanMemberInfo) {
                 return ResponseUtil.badRequest("MemberTrigger is null");
             }
-            Trigger child = definitions.unorphanMemberTrigger(tenantId, memberId, unorphanMemberInfo.getMemberContext(),
+            Trigger child = definitions.unorphanMemberTrigger(tenantId, memberId,
+                    unorphanMemberInfo.getMemberContext(),
+                    unorphanMemberInfo.getMemberTags(),
                     unorphanMemberInfo.getDataIdMap());
             if (log.isDebugEnabled()) {
                 log.debug("Member Trigger: " + child);


### PR DESCRIPTION
- merge member-supplied context with group-supplied context
- allow members to provide tags at add-time.
  - merge member-supplied tags with group-supplied tags
- allow members to provide member-level description
- allow the trigger name to default to the group name

Also
- fix a bug in adding members with a RateCondition