### PR TITLE
HWKALERTS-131 Re-use member dataIdMappings when updating group trigger conditions

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -103,6 +103,12 @@ public class Trigger implements Serializable {
     @JsonInclude
     private Match autoResolveMatch;
 
+    // Only set for MEMBER triggers, the dataIdMap used when adding the member. Is re-used
+    // for group condition updates unless a new dataIdMap is provided.
+    @JsonInclude(Include.NON_EMPTY)
+    protected Map<String, String> dataIdMap;
+
+    // Only set for MEMBER triggers, the group trigger for which this is a member.
     @JsonInclude(Include.NON_EMPTY)
     private String memberOf;
 
@@ -173,6 +179,7 @@ public class Trigger implements Serializable {
         this.autoResolve = false;
         this.autoResolveAlerts = true;
         this.autoResolveMatch = Match.ALL;
+        this.dataIdMap = null;
         this.eventCategory = null;
         this.eventText = null;
         this.eventType = EventType.ALERT; // Is this an OK default, or should it be a constructor parameter?
@@ -346,6 +353,14 @@ public class Trigger implements Serializable {
         this.actions = actions;
     }
 
+    public Map<String, String> getDataIdMap() {
+        return dataIdMap;
+    }
+
+    public void setDataIdMap(Map<String, String> dataIdMap) {
+        this.dataIdMap = dataIdMap;
+    }
+
     public void addAction(TriggerAction triggerAction) {
         getActions().add(triggerAction);
     }
@@ -488,7 +503,8 @@ public class Trigger implements Serializable {
                 + ", context=" + context + ", actions=" + actions + ", autoDisable=" + autoDisable
                 + ", autoEnable=" + autoEnable + ", autoResolve=" + autoResolve + ", autoResolveAlerts="
                 + autoResolveAlerts + ", autoResolveMatch=" + autoResolveMatch + ", memberOf=" + memberOf
-                + ", enabled=" + enabled + ", firingMatch=" + firingMatch + ", mode=" + mode + ", tags=" + tags + "]";
+                + ", dataIdMap=" + dataIdMap + ", enabled=" + enabled + ", firingMatch=" + firingMatch
+                + ", mode=" + mode + ", tags=" + tags + "]";
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
@@ -448,13 +448,27 @@ public interface DefinitionsService {
             Collection<Condition> conditions) throws Exception;
 
     /**
-     * The condition set for the specified Group Trigger and trigger mode.  The set conditions are ordered
-     * using the Collection ordering as the conditionSet ordering (assuming an ordered Collection implementation
-     * is supplied).  Any existing conditions are replaced. The non-orphan member triggers will have the new condition
-     * set applied, using the provided dataIdMemberMap.
-     * See {@link org.hawkular.alerts.api.json.GroupConditions#setDataIdMemberMap(Map)} for
-     * an example of the <code>dataIdMemberMap</code> parameter.  The following Condition fields are ignored for
-     * the incoming conditions, and set in the returned collection set:
+     * The condition set for the specified Group Trigger and trigger mode.  The conditionSet is ordered
+     * using the Collection ordering (assuming an ordered Collection implementation is supplied).  Any existing
+     * conditions are replaced. The non-orphan member triggers will have the new condition set applied, using the
+     * provided dataIdMemberMap. See {@link org.hawkular.alerts.api.json.GroupConditionsInfo#setDataIdMemberMap(Map)}
+     * for an example of the <code>dataIdMemberMap</code> parameter.
+     * <p>
+     * The <code>dataIdMemberMap</code> should be null if the group has no members.
+     * </p>
+     * <p>
+     * The <code>dataIdMemberMap</code> should be null if this is a DataDriven group trigger.  In this
+     * case the member triggers are removed and will be re-populated as incoming data demands.
+     * </p>
+     * <p>
+     * For [non-data-driven] group triggers with existing members the <code>dataIdMemberMap</code> is handled
+     * as follows. For members not included in the <code>dataIdMemberMap</code> their most recently supplied
+     * dataIdMap will be used. This means that it is not necessary to supply mappings if the new condition set
+     * uses only dataIds found in the old condition set. If the new conditions introduce new dataIds a full
+     * <code>dataIdMemberMap</code> must be supplied.
+     * </p>
+     * <p>
+     * The following Condition fields are ignored for the incoming conditions, and set in the returned collection set:
      * <pre>
      *   conditionId
      *   triggerId
@@ -462,6 +476,7 @@ public interface DefinitionsService {
      *   conditionSetSize
      *   conditionSetIndex
      * </pre>
+     * </p>
      * @param tenantId Tenant where trigger is stored
      * @param groupId Group Trigger adding the condition and whose non-orphan members will also have it added.
      * @param triggerMode Mode where condition is applied

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -149,6 +149,7 @@ public class CassStatement {
     public static final String UPDATE_DAMPENING_ID;
     public static final String UPDATE_EVENT;
     public static final String UPDATE_TRIGGER;
+    public static final String UPDATE_TRIGGER_DATA_ID_MAP;
     public static final String UPDATE_TRIGGER_ENABLED;
 
     static {
@@ -317,9 +318,9 @@ public class CassStatement {
 
         INSERT_TRIGGER = "INSERT INTO " + keyspace + ".triggers " +
                 "(tenantId, id, autoDisable, autoEnable, autoResolve, autoResolveAlerts, autoResolveMatch, "
-                + "context, description, enabled, eventCategory, eventText, eventType, firingMatch, memberOf, name, "
-                + "severity, source, tags, type) "
-                + "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+                + "context, dataIdMap, description, enabled, eventCategory, eventText, eventType, firingMatch, "
+                + "memberOf, name, severity, source, tags, type) "
+                + "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
 
         INSERT_TRIGGER_ACTIONS = "INSERT INTO " + keyspace + ".triggers_actions "
                 + "(tenantId, triggerId, actionPlugin, actionId, payload) VALUES (?, ?, ?, ?, ?) ";
@@ -467,7 +468,7 @@ public class CassStatement {
                 + "WHERE tenantId = ? AND type = ? and name = ? AND value = ? ";
 
         SELECT_TRIGGER = "SELECT tenantId, id, autoDisable, autoEnable, autoResolve, autoResolveAlerts, "
-                + "autoResolveMatch, context, description, enabled, eventCategory, eventText, eventType, "
+                + "autoResolveMatch, context, dataIdMap, description, enabled, eventCategory, eventText, eventType, "
                 + "firingMatch, memberOf, name, severity, source, tags, type "
                 + "FROM " + keyspace + ".triggers "
                 + "WHERE tenantId = ? AND id = ? ";
@@ -501,12 +502,12 @@ public class CassStatement {
                 + "WHERE tenantId = ? AND triggerId = ? and triggerMode = ? ";
 
         SELECT_TRIGGERS_ALL = "SELECT tenantId, id, autoDisable, autoEnable, autoResolve, autoResolveAlerts, "
-                + "autoResolveMatch, context, description, enabled, eventCategory, eventText, eventType, "
+                + "autoResolveMatch, context, dataIdMap, description, enabled, eventCategory, eventText, eventType, "
                 + "firingMatch, memberOf, name, severity, source, tags, type "
                 + "FROM " + keyspace + ".triggers ";
 
         SELECT_TRIGGERS_TENANT = "SELECT tenantId, id, autoDisable, autoEnable, autoResolve, autoResolveAlerts, "
-                + "autoResolveMatch, context, description, enabled, eventCategory, eventText, eventType, "
+                + "autoResolveMatch, context, dataIdMap, description, enabled, eventCategory, eventText, eventType, "
                 + "firingMatch, memberOf, name, severity, source, tags, type "
                 + "FROM " + keyspace + ".triggers WHERE tenantId = ? ";
 
@@ -532,9 +533,12 @@ public class CassStatement {
 
         UPDATE_TRIGGER = "UPDATE " + keyspace + ".triggers "
                 + "SET autoDisable = ?, autoEnable = ?, autoResolve = ?, autoResolveAlerts = ?, autoResolveMatch = ?, "
-                + "context = ?, description = ?,  enabled = ?, eventCategory = ?, eventText = ?, firingMatch = ?, "
-                + "memberOf = ?, name = ?, severity = ?, source = ?, tags = ?, type = ? "
+                + "context = ?, dataIdMap = ?, description = ?,  enabled = ?, eventCategory = ?, eventText = ?, "
+                + "firingMatch = ?, memberOf = ?, name = ?, severity = ?, source = ?, tags = ?, type = ? "
                 + "WHERE tenantId = ? AND id = ? ";
+
+        UPDATE_TRIGGER_DATA_ID_MAP = "UPDATE " + keyspace + ".triggers "
+                + "SET dataIdMap = ? WHERE tenantId = ? AND id = ? ";
 
         UPDATE_TRIGGER_ENABLED = "UPDATE " + keyspace + ".triggers "
                 + "SET enabled = ? WHERE tenantId = ? AND id = ? ";

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
@@ -37,6 +37,7 @@ CREATE TABLE ${keyspace}.triggers (
     autoResolveAlerts boolean,
     autoResolveMatch text,
     context map<text,text>,
+    dataIdMap map<text,text>,
     description text,
     enabled boolean,
     eventCategory text,


### PR DESCRIPTION

- persist the historical dataIdMappings used on member triggers
- use them when updating group conditions, supplementing any provided mappings