### PR TITLE
HWKALERTS-142 Minimal changes to upgrade to C* 3.4

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-aerogear/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus"/>
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-irc/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-pagerduty/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-sms/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-snmp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -21,7 +21,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
     </dependencies>
   </deployment>

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -1399,7 +1399,7 @@ public class CassAlertsServiceImpl implements AlertsService {
 
             List<ResultSetFuture> futures = new ArrayList<>();
             for (Alert.Status statusToDelete : EnumSet.complementOf(EnumSet.of(alert.getStatus()))) {
-                futures.add(session.executeAsync(deleteAlertStatus.bind(alert.getTenantId(), statusToDelete,
+                futures.add(session.executeAsync(deleteAlertStatus.bind(alert.getTenantId(), statusToDelete.name(),
                         alert.getAlertId())));
             }
             futures.add(session.executeAsync(insertAlertStatus.bind(alert.getTenantId(), alert.getAlertId(), alert

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
@@ -26,8 +26,8 @@ import org.hawkular.alerts.engine.util.TokenReplacingReader;
 import org.jboss.logging.Logger;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
@@ -67,9 +67,8 @@ public class CassCluster {
             log.debug("Checking Schema existence for keyspace: " + keyspace);
         }
 
-        ResultSet resultSet = session.execute("SELECT * FROM system.schema_keyspaces WHERE keyspace_name = '" +
-                keyspace + "'");
-        if (!resultSet.isExhausted()) {
+        KeyspaceMetadata keyspaceMetadata = cluster.getMetadata().getKeyspace(keyspace);
+        if (keyspaceMetadata != null) {
             if (overwrite) {
                 session.execute("DROP KEYSPACE " + keyspace);
             } else {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -284,7 +284,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                     trigger.isAutoEnable(), trigger.isAutoResolve(), trigger.isAutoResolveAlerts(),
                     trigger.getAutoResolveMatch().name(), trigger.getContext(), trigger.getDataIdMap(),
                     trigger.getDescription(), trigger.isEnabled(), trigger.getEventCategory(), trigger.getEventText(),
-                    trigger.getEventType(), trigger.getFiringMatch().name(), trigger.getMemberOf(), trigger.getName(),
+                    trigger.getEventType().name(), trigger.getFiringMatch().name(), trigger.getMemberOf(), trigger.getName(),
                     trigger.getSeverity().name(), trigger.getSource(), trigger.getTags(), trigger.getType().name()));
 
             insertTriggerActions(trigger);
@@ -2107,8 +2107,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
                         futures.add(session.executeAsync(insertConditionRate.bind(rateCond.getTenantId(),
                                 rateCond.getTriggerId(), rateCond.getTriggerMode().name(), rateCond.getContext(),
                                 rateCond.getConditionSetSize(), rateCond.getConditionSetIndex(),
-                                rateCond.getConditionId(), rateCond.getDataId(), rateCond.getDirection(),
-                                rateCond.getPeriod(), rateCond.getOperator().name(), rateCond.getThreshold())));
+                                rateCond.getConditionId(), rateCond.getDataId(), rateCond.getDirection().name(),
+                                rateCond.getPeriod().name(), rateCond.getOperator().name(), rateCond.getThreshold())));
                         break;
                     case STRING:
                         StringCondition sCond = (StringCondition) cond;

--- a/hawkular-alerts-rest/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/hawkular-alerts-rest/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@
   <deployment>
     <dependencies>
       <module name="org.hawkular.commons.cassandra-driver" export="true" />
-      <module name="org.hawkular.commons.guava" export="true" />
+      <module name="com.google.guava" export="true" />
       <module name="org.hawkular.bus" />
       <module name="org.infinispan" export="true" />
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>36</version>
+    <version>40</version>
   </parent>
 
   <groupId>org.hawkular.alerts</groupId>
@@ -91,8 +91,8 @@
     <version.org.codehaus.groovy.maven>1.0</version.org.codehaus.groovy.maven>
     <version.org.drools>6.3.0.Final</version.org.drools>
     <version.org.freemarker>2.3.17</version.org.freemarker>
-    <version.org.hawkular.accounts>2.0.22.Final</version.org.hawkular.accounts>
-    <version.org.hawkular.commons>0.4.0.Final</version.org.hawkular.commons>
+    <version.org.hawkular.accounts>2.0.23.Final</version.org.hawkular.accounts>
+    <version.org.hawkular.commons>0.5.0.Final</version.org.hawkular.commons>
     <version.org.hawkular.metrics>0.13.0.Final</version.org.hawkular.metrics>
     <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
     <version.org.infinispan.eap64>5.2.9.Final</version.org.infinispan.eap64>


### PR DESCRIPTION
I have upgraded to parent 40 where it is defined the C* 3.4 dependency.
I fixed minimal changes to have itest running on C*.
Please @jshaughn, can you take a look ?
Some time without pushing so another pair of eyes are always welcome :-).