### PR TITLE
HWKALERTS-140 Validate actions definitions against plugins deployed

### DIFF
--- a/examples/autoresolve-process/src/test/resources/autoresolve-process-definitions.json
+++ b/examples/autoresolve-process/src/test/resources/autoresolve-process-definitions.json
@@ -38,8 +38,7 @@
       "actionId": "notify-to-admins",
       "properties": {
         "to": "admins@hawkular.org",
-        "cc": "developers@hawkular.org",
-        "description": "Notify by email to Admins with cc to Developers"
+        "cc": "developers@hawkular.org"
       }
     }
   ]

--- a/examples/events/src/test/resources/events-tutorial-03.json
+++ b/examples/events/src/test/resources/events-tutorial-03.json
@@ -30,8 +30,7 @@
       "actionId": "notify-to-admins",
       "properties": {
         "to": "admins@hawkular.org",
-        "cc": "developers@hawkular.org",
-        "description": "Notify by email to Admins with cc to Developers"
+        "cc": "developers@hawkular.org"
       }
     }
   ]

--- a/examples/events/src/test/resources/events-tutorial-04.json
+++ b/examples/events/src/test/resources/events-tutorial-04.json
@@ -52,8 +52,7 @@
       "actionId": "notify-to-admins",
       "properties": {
         "to": "admins@hawkular.org",
-        "cc": "developers@hawkular.org",
-        "description": "Notify by email to Admins with cc to Developers"
+        "cc": "developers@hawkular.org"
       }
     }
   ]

--- a/examples/events/src/test/resources/events-tutorial-05.json
+++ b/examples/events/src/test/resources/events-tutorial-05.json
@@ -53,8 +53,7 @@
       "actionId": "notify-to-admins",
       "properties": {
         "to": "admins@hawkular.org",
-        "cc": "developers@hawkular.org",
-        "description": "Notify by email to Admins with cc to Developers"
+        "cc": "developers@hawkular.org"
       }
     }
   ]

--- a/examples/hello-world/src/test/resources/hello-world-definitions.json
+++ b/examples/hello-world/src/test/resources/hello-world-definitions.json
@@ -38,8 +38,7 @@
       "actionId": "notify-to-admins",
       "properties": {
         "to": "admins@hawkular.org",
-        "cc": "developers@hawkular.org",
-        "description": "Notify by email to Admins with cc to Developers"
+        "cc": "developers@hawkular.org"
       }
     }
   ]

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/StandaloneAlerts.java
@@ -69,7 +69,6 @@ public class StandaloneAlerts {
 
         definitions.setAlertsEngine(engine);
         definitions.setAlertsContext(alertsContext);
-        definitions.setExecutor(new StandaloneExecutorService());
 
         actions.setAlertsContext(alertsContext);
         actions.setDefinitions(definitions);
@@ -78,8 +77,6 @@ public class StandaloneAlerts {
         engine.setDefinitions(definitions);
         engine.setActions(actions);
         engine.setRules(rules);
-
-        definitions.init();
 
         log.debug("Waiting for initialization...");
         try {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsContext.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsContext.java
@@ -43,21 +43,9 @@ import org.jboss.logging.Logger;
 public class AlertsContext {
     private final Logger log = Logger.getLogger(AlertsContext.class);
 
-    private boolean initialized = false;
-
     private Map<DefinitionsListener, Set<Type>> definitionListeners = new HashMap<>();
 
     List<ActionListener> actionsListeners = new CopyOnWriteArrayList<>();
-
-    public boolean isInitialized() {
-        return initialized;
-    }
-
-    public void setInitialized(boolean initialized) {
-        synchronized (this) {
-            this.initialized = initialized;
-        }
-    }
 
     public void registerDefinitionListener(DefinitionsListener listener, Type eventType, Type... eventTypes) {
         EnumSet<Type> types = EnumSet.of(eventType, eventTypes);

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -366,25 +366,6 @@
                   </resources>
                 </configuration>
               </execution>
-              <execution>
-                <id>copy-data-dir</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/${project.build.finalName}/standalone/data</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/src/test/wildfly-data</directory>
-                      <includes>
-                        <include>**/*</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
 
@@ -633,31 +614,6 @@
                       <destFileName>hawkular-alerts-actions-webhook.war</destFileName>
                     </artifactItem>
                   </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-data-dir-on-standalone</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${hawkular.data}</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/src/test/wildfly-data</directory>
-                      <includes>
-                        <include>**/*</include>
-                      </includes>
-                    </resource>
-                  </resources>
                 </configuration>
               </execution>
             </executions>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/BusITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/BusITest.groovy
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.rest
 
+import org.hawkular.alerts.api.model.action.ActionDefinition
 import org.hawkular.alerts.api.model.condition.AvailabilityCondition
 import org.hawkular.alerts.api.model.condition.Condition
 import org.hawkular.alerts.api.model.condition.ThresholdCondition
@@ -44,8 +45,22 @@ class BusITest extends AbstractITestBase {
     void availabilityThroughBusTest() {
         String start = String.valueOf(System.currentTimeMillis());
 
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
         // CREATE the trigger
-        def resp = client.get(path: "")
+        resp = client.get(path: "")
         assert resp.status == 200 : resp.status
 
         Trigger testTrigger = new Trigger("test-bus-email-availability", "http://www.mydemourl.com");
@@ -61,7 +76,6 @@ class BusITest extends AbstractITestBase {
             email-to-admin action is pre-created from demo data
          */
         testTrigger.addAction(new TriggerAction("email", "email-to-admin"));
-        testTrigger.addAction(new TriggerAction("file", "file-to-admin"));
 
         resp = client.post(path: "triggers", body: testTrigger)
         assertEquals(200, resp.status)
@@ -135,14 +149,31 @@ class BusITest extends AbstractITestBase {
 
         resp = client.delete(path: "triggers/test-bus-email-availability");
         assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
     }
 
     @Test
     void thresholdThroughBusTest() {
         String start = String.valueOf(System.currentTimeMillis());
 
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
         // CREATE the trigger
-        def resp = client.get(path: "")
+        resp = client.get(path: "")
         assert resp.status == 200 : resp.status
 
         Trigger testTrigger = new Trigger("test-bus-email-threshold", "http://www.mydemourl.com");
@@ -231,7 +262,8 @@ class BusITest extends AbstractITestBase {
 
         resp = client.delete(path: "triggers/test-bus-email-threshold");
         assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
     }
-
-
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ImportExportITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ImportExportITest.groovy
@@ -32,30 +32,11 @@ class ImportExportITest extends AbstractITestBase {
     static Logger logger = LoggerFactory.getLogger(ImportExportITest.class)
 
     @Test
-    void exportTest() {
-        def resp = client.get(path: "export")
-        assertEquals(200, resp.status)
+    void importExportTest() {
+        String basePath = new File(".").canonicalPath
+        String toImport = new File(basePath + "/src/test/wildfly-data/hawkular-alerts/alerts-data.json").text
 
-        for (int i = 0; i < resp.data.triggers.size(); i++) {
-            logger.info("Exported trigger: " + resp.data.triggers[i])
-        }
-        for (int i = 0; i < resp.data.actions.size(); i++) {
-            logger.info("Exported action: " + resp.data.actions[i])
-        }
-
-        // Original definitions from alerts-data.json should be in the backend
-        assertEquals(9, resp.data.triggers.size())
-        assertEquals(6, resp.data.actions.size())
-    }
-
-    @Test
-    void exportImportTest() {
-        def resp = client.get(path: "export")
-        assertEquals(200, resp.status)
-
-        def exported = resp.data
-
-        resp = client.post(path: "import/delete", body: exported)
+        def resp = client.post(path: "import/delete", body: toImport)
         assertEquals(200, resp.status)
 
         resp = client.get(path: "export")
@@ -63,7 +44,7 @@ class ImportExportITest extends AbstractITestBase {
 
         // Original definitions from alerts-data.json should be in the backend
         assertEquals(9, resp.data.triggers.size())
-        assertEquals(6, resp.data.actions.size())
+        assertEquals(1, resp.data.actions.size())
     }
 
 

--- a/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/alerts-data.json
+++ b/hawkular-alerts-rest-tests/src/test/wildfly-data/hawkular-alerts/alerts-data.json
@@ -9,11 +9,7 @@
         "description": "description 1",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ],
         "context": {
           "name1":"value1"
@@ -54,11 +50,7 @@
         "description": "description 2",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ]
       },
       "dampenings":[],
@@ -96,11 +88,7 @@
         "description": "description 3",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ]
       },
       "dampenings":[],
@@ -130,11 +118,7 @@
         "description": "description 4",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ]
       },
       "dampenings":[],
@@ -162,11 +146,7 @@
         "description": "description 5",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ]
       },
       "dampenings":[],
@@ -193,11 +173,7 @@
         "description": "description 6",
         "severity": "HIGH",
         "actions": [
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-1"},
-          {"actionPlugin":"snmp", "actionId":"SNMP-Trap-2"},
-          {"actionPlugin":"sms", "actionId":"sms-to-cio"},
-          {"actionPlugin":"email", "actionId":"email-to-admin"},
-          {"actionPlugin":"aerogear", "actionId":"agpush-to-admin"}
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
         ]
       },
       "dampenings":[],
@@ -315,60 +291,11 @@
   "actions":[
     {
       "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
-      "actionPlugin": "snmp",
-      "actionId": "SNMP-Trap-1",
-      "properties": {
-        "host": "snmp-host",
-        "port": "1234",
-        "oid": "1.2.3.4.5",
-        "description": "This is an example of SNMP Action Plugin"
-      }
-    },
-    {
-      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
-      "actionPlugin": "snmp",
-      "actionId": "SNMP-Trap-2",
-      "properties": {
-        "host": "snmp-host",
-        "port": "1234",
-        "oid": "1.2.3.4.5",
-        "description": "This is an example of SNMP Action Plugin"
-      }
-    },
-    {
-      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
       "actionPlugin": "email",
       "actionId": "email-to-admin",
       "properties": {
         "to": "admin@hawkular.org",
-        "cc": "bigboss@hawkular.org",
-        "description": "This is an example of Email Action Plugin"
-      }
-    },
-    {
-      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
-      "actionPlugin": "sms",
-      "actionId": "sms-to-cio",
-      "properties": {
-        "phone": "+15005550006",
-        "description": "This is an example of SMS Action Plugin"
-      }
-    },
-    {
-      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
-      "actionPlugin": "aerogear",
-      "actionId": "agpush-to-admin",
-      "properties": {
-        "alias": "GeorgeAbitbol",
-        "description": "This is an example of Aerogear Action Plugin"
-      }
-    },
-    {
-      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
-      "actionPlugin": "file",
-      "actionId": "file-to-admin",
-      "properties": {
-        "description": "This is an example of File Plugin"
+        "cc": "bigboss@hawkular.org"
       }
     }
   ]

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/ActionsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/ActionsHandler.java
@@ -202,6 +202,9 @@ public class ActionsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/ActionsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/ActionsHandler.java
@@ -218,6 +218,7 @@ public class ActionsHandler {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, ActionDefinition Updated."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 404, message = "ActionDefinition not found for update.", response = ApiError.class)
     })
     public Response updateActionDefinition(@ApiParam(value = "ActionDefinition to be updated.",
@@ -247,6 +248,9 @@ public class ActionsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -290,6 +294,7 @@ public class ActionsHandler {
             responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched list of actions."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response findActionsHistory(
@@ -334,6 +339,9 @@ public class ActionsHandler {
             return ResponseUtil.paginatedOk(actionPage, uri);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -346,6 +354,7 @@ public class ActionsHandler {
             responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Actions deleted."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response deleteActionsHistory(
@@ -381,6 +390,9 @@ public class ActionsHandler {
             return ResponseUtil.ok(numDeleted);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/AlertsHandler.java
@@ -90,6 +90,7 @@ public class AlertsHandler {
             response = Alert.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched list of alerts."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters"),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response findAlerts(
@@ -138,6 +139,9 @@ public class AlertsHandler {
             return ResponseUtil.paginatedOk(alertPage, uri);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -172,6 +176,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -206,6 +213,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -241,6 +251,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -275,6 +288,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -310,6 +326,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -320,6 +339,7 @@ public class AlertsHandler {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Alert deleted."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 404, message = "Alert not found.", response = ApiError.class)
     })
     public Response deleteAlert(
@@ -340,6 +360,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -352,6 +375,7 @@ public class AlertsHandler {
             response = Integer.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Alerts deleted."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters"),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response deleteAlerts(
@@ -392,6 +416,9 @@ public class AlertsHandler {
             return ResponseUtil.ok(numDeleted);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -508,6 +535,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -544,6 +574,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -575,6 +608,9 @@ public class AlertsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/EventsHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/EventsHandler.java
@@ -119,6 +119,9 @@ public class EventsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -154,6 +157,9 @@ public class EventsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -188,6 +194,9 @@ public class EventsHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -199,6 +208,7 @@ public class EventsHandler {
             response = Event.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched list of events."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response findEvents(
@@ -241,6 +251,9 @@ public class EventsHandler {
             return ResponseUtil.paginatedOk(eventPage, uri);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -284,6 +297,7 @@ public class EventsHandler {
             response = Integer.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response deleteEvents(
@@ -317,6 +331,9 @@ public class EventsHandler {
             return ResponseUtil.ok(numDeleted);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
@@ -94,6 +94,7 @@ public class TriggersHandler {
             response = Trigger.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched list of triggers."),
+            @ApiResponse(code = 400, message = "Bad request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response findTriggers(
@@ -122,6 +123,9 @@ public class TriggersHandler {
             return ResponseUtil.paginatedOk(triggerPage, uri);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -317,6 +321,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -361,6 +368,9 @@ public class TriggersHandler {
             return ResponseUtil.notFound(e.getMessage());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -434,7 +444,8 @@ public class TriggersHandler {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Trigger updated."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class),
-            @ApiResponse(code = 404, message = "Trigger doesn't exist/Invalid Parameters.", response = ApiError.class)
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
+            @ApiResponse(code = 404, message = "Trigger doesn't exist.", response = ApiError.class)
     })
     public Response updateTrigger(
             @ApiParam(value = "Trigger definition id to be updated.", required = true)
@@ -471,7 +482,8 @@ public class TriggersHandler {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Group Trigger updated."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class),
-            @ApiResponse(code = 404, message = "Trigger doesn't exist/Invalid Parameters.", response = ApiError.class)
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
+            @ApiResponse(code = 404, message = "Trigger doesn't exist.", response = ApiError.class)
     })
     public Response updateGroupTrigger(
             @ApiParam(value = "Group Trigger id to be updated.", required = true)
@@ -494,6 +506,9 @@ public class TriggersHandler {
 
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -534,7 +549,8 @@ public class TriggersHandler {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Trigger updated."),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class),
-            @ApiResponse(code = 404, message = "Trigger doesn't exist/Invalid Parameters.", response = ApiError.class)
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
+            @ApiResponse(code = 404, message = "Trigger doesn't exist.", response = ApiError.class)
     })
     public Response unorphanMemberTrigger(
             @ApiParam(value = "Member Trigger id to be made an orphan.", required = true)
@@ -561,6 +577,9 @@ public class TriggersHandler {
 
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -659,6 +678,7 @@ public class TriggersHandler {
             response = Dampening.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Successfully fetched list of dampenings."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Internal server error.", response = ApiError.class)
     })
     public Response getTriggerModeDampenings(
@@ -677,6 +697,9 @@ public class TriggersHandler {
             return ResponseUtil.ok(dampenings);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -747,6 +770,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -785,6 +811,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -828,6 +857,7 @@ public class TriggersHandler {
             response = Dampening.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Dampening Updated."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 404, message = "No Dampening Found.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)
     })
@@ -855,6 +885,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -867,6 +900,7 @@ public class TriggersHandler {
             response = Dampening.class)
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Success, Dampening Updated."),
+            @ApiResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
             @ApiResponse(code = 404, message = "No Dampening Found.", response = ApiError.class),
             @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)
     })
@@ -894,6 +928,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -1061,6 +1098,9 @@ public class TriggersHandler {
             return ResponseUtil.notFound(e.getMessage());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -1114,6 +1154,9 @@ public class TriggersHandler {
             return ResponseUtil.notFound(e.getMessage());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -1159,6 +1202,9 @@ public class TriggersHandler {
             return ResponseUtil.notFound(e.getMessage());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -1209,6 +1255,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
@@ -213,6 +213,9 @@ public class TriggersHandler {
             }
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -277,6 +280,9 @@ public class TriggersHandler {
             return ResponseUtil.ok(fullTrigger);
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -451,6 +457,9 @@ public class TriggersHandler {
 
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                return ResponseUtil.badRequest("Bad arguments: " + e.getMessage());
+            }
             return ResponseUtil.internalError(e);
         }
     }
@@ -1048,8 +1057,6 @@ public class TriggersHandler {
             }
             return ResponseUtil.ok(updatedConditions);
 
-        } catch (IllegalArgumentException e) {
-            return ResponseUtil.badRequest("Bad argument: " + e.getMessage());
         } catch (NotFoundException e) {
             return ResponseUtil.notFound(e.getMessage());
         } catch (Exception e) {


### PR DESCRIPTION
Highlights of this PR:
* Actions are validated against plugins:
 - An action should have a plugins deployed in the system.
 - An action should follow the properties defined in a plugin.
* Initialization files logic has been removed:
 - As we have import/export logic, initialize the definitions via files was only used for some tests and had some caveats in clustering logic too, so I think that with the import/export we are covered for the same functionality and more consistency.
- Also it was problematic as plugins deployment needs the Engine fully deployed, so it should be moved in another place.
* The use case of what to do when a plugin is undeployed is not covered, now it maintains the action definitions but it will fail at the moment of execution of the action. Perhaps a nice to have is to mark some state, but then we need to add a way to detect "undeployments" of .war, so for the moment I think that could be a cornercase and it is good as it is working today.