### PR TITLE
Increase waiting time for C* in itest

### DIFF
--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -449,7 +449,7 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <configuration>
               <tasks>
-                <sleep seconds="5" />
+                <sleep seconds="45" />
               </tasks>
             </configuration>
             <executions>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
@@ -73,6 +73,10 @@ class AbstractITestBase {
 
     @AfterClass
     static void closeSmtpServer() {
+        // Giving some time to process emails before to shutdown the SMTP server
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+        }
         if (smtpServer != null) {
             smtpServer.stop();
         }


### PR DESCRIPTION
Main issue with ITests is that the server needs to initialize Cassandra scheme.
Sometimes (randomly) the first test is executed before the scheme is created.
This also might depends of several factors of the machine where tests are running.
So, I've tested several ways, but all of them are focus on increase the waiting time of the tests until everything is ready on the server.
This PR also increase the SMTP server to avoid some annoying but harmless errors on log.