### PR TITLE
Add global tenant validation on REST endpoints

### DIFF
--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -443,26 +443,6 @@
             </executions>
           </plugin>
 
-          <!-- Adding a delay to let the server to process initial data -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <configuration>
-              <tasks>
-                <sleep seconds="45" />
-              </tasks>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sleep-for-a-while</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
           <!-- Configure integration tests -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -482,7 +482,7 @@
                 </goals>
                 <configuration>
                   <includes>
-                    <include>**/*ITest*</include>
+                    <include>org/hawkular/alerts/rest/IntegrationSuite.class</include>
                   </includes>
                   <excludes>
                     <excludeFile>org/hawkular/alerts/rest/ClusterITest.class</excludeFile>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
@@ -37,10 +37,6 @@ class AbstractITestBase {
     static RESTClient client
     static testTenant = "28026b36-8fe4-4332-84c8-524e173a68bf"
 
-    static TEST_SMTP_HOST = "localhost";
-    static TEST_SMTP_PORT = 2525;
-    static GreenMail smtpServer;
-
     @BeforeClass
     static void initClient() {
 
@@ -63,22 +59,5 @@ class AbstractITestBase {
          */
         client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
         client.headers.put("Hawkular-Tenant", testTenant)
-    }
-
-    @BeforeClass
-    static void initSmtpServer() {
-        smtpServer = new GreenMail(new ServerSetup(TEST_SMTP_PORT, TEST_SMTP_HOST, "smtp"));
-        smtpServer.start();
-    }
-
-    @AfterClass
-    static void closeSmtpServer() {
-        // Giving some time to process emails before to shutdown the SMTP server
-        for ( int i=0; i < 10; ++i ) {
-            Thread.sleep(500);
-        }
-        if (smtpServer != null) {
-            smtpServer.stop();
-        }
     }
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AbstractITestBase.groovy
@@ -16,11 +16,6 @@
  */
 package org.hawkular.alerts.rest
 
-import com.icegreen.greenmail.util.GreenMail
-import com.icegreen.greenmail.util.ServerSetup
-import groovyx.net.http.HttpResponseDecorator
-import groovyx.net.http.HttpResponseException
-import org.junit.AfterClass
 import org.junit.BeforeClass
 
 import groovyx.net.http.ContentType
@@ -59,5 +54,13 @@ class AbstractITestBase {
          */
         client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
         client.headers.put("Hawkular-Tenant", testTenant)
+
+        def resp = client.get(path: "status")
+        def tries = 100
+        while (tries > 0 && resp.data.status != "STARTED") {
+            Thread.sleep(500);
+            resp = client.get(path: "status")
+            tries--
+        }
     }
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/IntegrationSuite.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/IntegrationSuite.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest
+
+import com.icegreen.greenmail.util.GreenMail
+import com.icegreen.greenmail.util.ServerSetup
+
+import org.hawkular.alerts.rest.ActionsITest
+import org.hawkular.alerts.rest.AlertsITest
+import org.hawkular.alerts.rest.BusITest
+import org.hawkular.alerts.rest.ConditionsITest
+import org.hawkular.alerts.rest.DampeningITest
+import org.hawkular.alerts.rest.EventsITest
+import org.hawkular.alerts.rest.EventsLifecycleITest
+import org.hawkular.alerts.rest.GroupITest
+import org.hawkular.alerts.rest.ImportExportITest
+import org.hawkular.alerts.rest.LifecycleITest
+import org.hawkular.alerts.rest.TenantITest
+import org.hawkular.alerts.rest.TriggersITest
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.runner.RunWith
+import org.junit.runners.Suite;
+
+/**
+ * Group ITest on a suite to have better control of execution
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses([
+        ActionsITest.class,
+        AlertsITest.class,
+        BusITest.class,
+        ConditionsITest.class,
+        DampeningITest.class,
+        EventsITest.class,
+        EventsLifecycleITest.class,
+        GroupITest.class,
+        ImportExportITest.class,
+        LifecycleITest.class,
+        TenantITest.class,
+        TriggersITest.class
+])
+class IntegrationSuite {
+
+    static TEST_SMTP_HOST = "localhost";
+    static TEST_SMTP_PORT = 2525;
+    static GreenMail smtpServer;
+
+    @BeforeClass
+    static void initSmtpServer() {
+        smtpServer = new GreenMail(new ServerSetup(TEST_SMTP_PORT, TEST_SMTP_HOST, "smtp"));
+        smtpServer.start();
+    }
+
+    @AfterClass
+    static void closeSmtpServer() {
+        // Give some time to the server to process last emails before to shutdown the SMTP server
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(1000);
+        }
+        if (smtpServer != null) {
+            smtpServer.stop();
+        }
+    }
+}

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TenantITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TenantITest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest
+
+import org.hawkular.alerts.api.model.action.ActionDefinition
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.data.Data
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.api.model.trigger.TriggerAction
+import org.hawkular.alerts.rest.AbstractITestBase
+import org.junit.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import static org.hawkular.alerts.api.model.event.Alert.Status
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+/**
+ * Tenant header validation in REST calls.
+ *
+ * @author Lucas Ponce
+ */
+class TenantITest extends AbstractITestBase {
+
+    static Logger logger = LoggerFactory.getLogger(TenantITest.class)
+
+    @Test
+    void findPlugins() {
+        client.headers.put("Hawkular-Tenant", null)
+        def resp = client.get(path: "plugins")
+        assertEquals(400, resp.status)
+
+        client.headers.put("Hawkular-Tenant", "")
+        resp = client.get(path: "plugins")
+        assertEquals(400, resp.status)
+    }
+
+}

--- a/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TenantFilter.java
+++ b/hawkular-alerts-rest/src/main/java/org/hawkular/alerts/rest/TenantFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest;
+
+import static org.hawkular.alerts.rest.HawkularAlertsApp.TENANT_HEADER_NAME;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Global tenant that validates if tenant is correctly supplied
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Provider
+public class TenantFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (isEmpty(requestContext.getHeaderString(TENANT_HEADER_NAME))) {
+            requestContext.abortWith(ResponseUtil.badRequest(TENANT_HEADER_NAME + " " +
+                    "should be provided."));
+        }
+    }
+
+    private boolean isEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+}


### PR DESCRIPTION
Improve common SMTP used on itests

SMTP server for itest can be improved if started shared for all tests in a suite.
This helps to reduce the waiting time.
Also, using a suite will help in future itest improvements, as at the beginning of the suite the waiting of cassandra scheme can be done.
Using a suite is compatible to exucute separate tests when needed.
