### PR TITLE
HWKALERTS-152 Update examples to work with hawkular-services

### DIFF
--- a/examples/autoresolve-process/README.adoc
+++ b/examples/autoresolve-process/README.adoc
@@ -50,8 +50,6 @@ TIP: By default, Hawkular Alerting will send email notifications using a SMTP se
  a test smtp server can be used to validate the reception of the emails. Hawkular Alerting has been tested using
  https://nilhcem.github.io/FakeSMTP/[FakeSMTP].
 
-TIP: To run the example against the Hawkular distribution, use the command `mvn validate -Dhawkular`.
-
 == create_definitions.groovy
 
 Create a trigger to two conditions to fire an alert when a process is down and update when the process is up:
@@ -67,3 +65,11 @@ Create an action definition to notify by email to admins group with cc to develo
 
 Invoke a shell command (Linux) to detect if the process is present and send a data for "process-status" over the REST
  API.
+
+The detection of the process is OS dependent, this example is tested under Linux platforms.
+For other platform this command should be changed for an equivalent expression:
+
+[source,shell,subs="+attributes"]
+----
+    def proc = ["sh", "-c", "ps -e | grep ${processName} | wc -l"].execute()
+----

--- a/examples/autoresolve-process/src/test/groovy/create_definitions.groovy
+++ b/examples/autoresolve-process/src/test/groovy/create_definitions.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/autoresolve-process/src/test/groovy/send_data.groovy
+++ b/examples/autoresolve-process/src/test/groovy/send_data.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def processName = "firefox"
 

--- a/examples/events/README.adoc
+++ b/examples/events/README.adoc
@@ -37,8 +37,6 @@ TIP: By default, Hawkular Alerting will send email notifications using a SMTP se
  a test smtp server can be used to validate the reception of the emails. Hawkular Alerting has been tested using
  https://nilhcem.github.io/FakeSMTP/[FakeSMTP].
 
-TIP: To run the example against the Hawkular distribution, use the command `mvn validate -Dhawkular`.
-
 == tutorial1
 
 Minimalist example to send and event.

--- a/examples/events/src/test/groovy/clean_events.groovy
+++ b/examples/events/src/test/groovy/clean_events.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.put(path: "events/delete")
 

--- a/examples/events/src/test/groovy/create_definitions_events_tutorial_03.groovy
+++ b/examples/events/src/test/groovy/create_definitions_events_tutorial_03.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/events/src/test/groovy/create_definitions_events_tutorial_04.groovy
+++ b/examples/events/src/test/groovy/create_definitions_events_tutorial_04.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/events/src/test/groovy/create_definitions_events_tutorial_05.groovy
+++ b/examples/events/src/test/groovy/create_definitions_events_tutorial_05.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/events/src/test/groovy/send_events_tutorial_01.groovy
+++ b/examples/events/src/test/groovy/send_events_tutorial_01.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 // Send some random events
 

--- a/examples/events/src/test/groovy/send_events_tutorial_02.groovy
+++ b/examples/events/src/test/groovy/send_events_tutorial_02.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 // Send some random events
 

--- a/examples/events/src/test/groovy/send_events_tutorial_03.groovy
+++ b/examples/events/src/test/groovy/send_events_tutorial_03.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 // Send some random events
 

--- a/examples/events/src/test/groovy/send_events_tutorial_04.groovy
+++ b/examples/events/src/test/groovy/send_events_tutorial_04.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 // Send some random events
 

--- a/examples/events/src/test/groovy/send_events_tutorial_05.groovy
+++ b/examples/events/src/test/groovy/send_events_tutorial_05.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 // Send some random events
 

--- a/examples/hello-world/README.adoc
+++ b/examples/hello-world/README.adoc
@@ -35,8 +35,6 @@ TIP: By default, Hawkular Alerting will send email notifications using a SMTP se
  a test smtp server can be used to validate the reception of the emails. Hawkular Alerting has been tested using
  https://nilhcem.github.io/FakeSMTP/[FakeSMTP].
 
-TIP: To run the example against the Hawkular distribution, use the command `mvn validate -Dhawkular`.
-
 == create_definitions.groovy
 
 Create a hello world trigger to two conditions to fire an alert everytime that:

--- a/examples/hello-world/src/test/groovy/create_definitions.groovy
+++ b/examples/hello-world/src/test/groovy/create_definitions.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/hello-world/src/test/groovy/send_data.groovy
+++ b/examples/hello-world/src/test/groovy/send_data.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 while (true) {
 

--- a/examples/webhook/README.adoc
+++ b/examples/webhook/README.adoc
@@ -31,7 +31,16 @@ Open a new shell to run the webhook example
     mvn validate
 ----
 
-TIP: To run the example against the Hawkular distribution, use the command `mvn validate -Dhawkular`.
+TIP: To run the example against the Hawkular Services distribution, you must install the webhook plugin manually.
+
+[source,shell,subs="+attributes"]
+----
+    # Build the Hawkular Alerting without any flag to prepare the plugin for hawkular services distribution
+    mvn clean install
+    # Copy the plugin into hawkular-services distribution
+    cp hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/target/hawkular-alerts-actions-webhook.war \
+    $HAWKULAR_SERVICES/modules/system/layers/hawkular/org/hawkular/nest/main/deployments/
+----
 
 == create_definitions.groovy
 

--- a/examples/webhook/src/test/groovy/create_definitions.groovy
+++ b/examples/webhook/src/test/groovy/create_definitions.groovy
@@ -32,17 +32,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 def resp = client.post(path: "import/all", body: definitions)
 

--- a/examples/webhook/src/test/groovy/send_data.groovy
+++ b/examples/webhook/src/test/groovy/send_data.groovy
@@ -30,17 +30,17 @@ client.handler.failure = { resp ->
     return resp
 }
 
-if (System.getProperties().containsKey("hawkular")) {
-    /*
-        User: jdoe
-        Password: password
-        String encodedCredentials = Base64.getMimeEncoder()
-        .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-     */
-    client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
-} else {
-    client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
-}
+/*
+    Basic header is used only for hawkular-services distribution.
+    This header is ignored on standalone scenarios.
+
+    User: jdoe
+    Password: password
+    String encodedCredentials = Base64.getMimeEncoder()
+    .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+ */
+client.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+client.defaultRequestHeaders.put("Hawkular-Tenant", tenant)
 
 while (true) {
 


### PR DESCRIPTION
Minor PR to make compatible Hawkular Alerting examples with hawkular-services distribution.
Standalone scenario remains as it was but now examples can be easy executed against hawkular-services backend (helping to test the component).

Please @jshaughn, could you take a look ?
Thanks.