### PR TITLE
HWKALERTS-154 Do not thrown Exception on BusActionPluginListener#close

### DIFF
--- a/hawkular-alerts-actions-bus/src/main/java/org/hawkular/alerts/actions/bus/BusActionPluginListener.java
+++ b/hawkular-alerts-actions-bus/src/main/java/org/hawkular/alerts/actions/bus/BusActionPluginListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,11 +92,15 @@ public class BusActionPluginListener extends BasicMessageListener<BusActionMessa
     }
 
     @PreDestroy
-    public void close() throws Exception {
+    public void close() {
         Collection<ActionPluginSender> senders = ActionPlugins.getSenders().values();
         for (ActionPluginSender sender: senders) {
             if (sender instanceof BusActionPluginSender) {
-                ((BusActionPluginSender)sender).close();
+                try {
+                    ((BusActionPluginSender)sender).close();
+                } catch (Exception e) {
+                    msgLog.error("Error closing sender [" + sender.toString() + "]", e);
+                }
             }
         }
     }

--- a/hawkular-alerts-actions-bus/src/main/java/org/hawkular/alerts/actions/bus/BusActionPluginSender.java
+++ b/hawkular-alerts-actions-bus/src/main/java/org/hawkular/alerts/actions/bus/BusActionPluginSender.java
@@ -145,4 +145,11 @@ public class BusActionPluginSender implements ActionPluginSender {
             msgLog.errorCannotSendMessage(e.getMessage());
         }
     }
+
+    @Override
+    public String toString() {
+        return "BusActionPluginSender[" +
+                "actionPlugin='" + actionPlugin + '\'' +
+                ']';
+    }
 }


### PR DESCRIPTION
@PreDestroy methods can not throw custom Exception or a WARN will be filled on the log.
This is a minor refactor to clean some harmless warnings at startup.

Please @objectiser could you take a quick look ? 
Jay is on PTO for some days.
If you can mark it as review it I can merge it on the upstream.

Thanks a lot for your help :-)