### PR TITLE
Force English locale in mail decimal formatting

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
@@ -148,7 +148,7 @@ public class EmailTemplate {
 
         /*
             Invoke freemarker template with PluginMessageDescription as root object for dynamic data.
-            PluginMessageDescription fields are accesible within .ftl templates.
+            PluginMessageDescription fields are accessible within .ftl templates.
          */
         StringWriter writerPlain = new StringWriter();
         StringWriter writerHtml = new StringWriter();

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
@@ -17,10 +17,12 @@
 package org.hawkular.alerts.actions.email;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -116,7 +118,7 @@ public class PluginMessageDescription {
     /** Base URL to be used on templates to build links into main UI */
     private String baseUrl;
 
-    private DecimalFormat decimalFormat = new DecimalFormat("####0.0");
+    private DecimalFormat decimalFormat = new DecimalFormat("####0.0", new DecimalFormatSymbols(Locale.ENGLISH));
 
     /**
      * Helper inner class to store a Condition with a calculated description.


### PR DESCRIPTION
Locale should be forced to English (rather that system default) since the whole mail is written in English.
Without it, we could end up with mixed languages/formatting such as "GC Duration greater than 1000,0 ms" with wrong decimal separator.

Note that the issue was seen from JUnit EmailTemplateTest:

Expected :Tiny template: Alert [open] message: GC Duration greater than 1000,0 ms for App Server thevault~Local
Actual   :Tiny template: Alert [open] message: GC Duration greater than 1000.0 ms for App Server thevault~Local