### PR TITLE
HWKALERTS-157 Process ConditionEval grouped per trigger

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/TriggerConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/TriggerConditionEval.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.model.condition;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.trigger.Mode;
+
+/**
+ * A class to accumulate one or more ConditionEval per Trigger.
+ * This helper class will help to process all ConditionEval in one step inside rules engine.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class TriggerConditionEval {
+
+    private String tenantId;
+
+    private String triggerId;
+
+    private Mode mode;
+
+    private Set<ConditionEval> conditionEvals;
+
+    public TriggerConditionEval(String tenantId, String triggerId, Mode mode) {
+        this.tenantId = tenantId;
+        this.triggerId = triggerId;
+        this.mode = mode;
+        conditionEvals = new HashSet<>();
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getTriggerId() {
+        return triggerId;
+    }
+
+    public void setTriggerId(String triggerId) {
+        this.triggerId = triggerId;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public Set<ConditionEval> getConditionEvals() {
+        return conditionEvals;
+    }
+
+    public void setConditionEvals(Set<ConditionEval> conditionEvals) {
+        this.conditionEvals = conditionEvals;
+    }
+
+    public void addConditionEval(ConditionEval ce) {
+        conditionEvals.add(ce);
+    }
+
+    public void addConditionEval(Collection<ConditionEval> ces) {
+        conditionEvals.addAll(ces);
+    }
+
+    public int getSize() {
+        return conditionEvals.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TriggerConditionEval that = (TriggerConditionEval) o;
+
+        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (triggerId != null ? !triggerId.equals(that.triggerId) : that.triggerId != null) return false;
+        if (mode != that.mode) return false;
+        return conditionEvals != null ? conditionEvals.equals(that.conditionEvals) : that.conditionEvals == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tenantId != null ? tenantId.hashCode() : 0;
+        result = 31 * result + (triggerId != null ? triggerId.hashCode() : 0);
+        result = 31 * result + (mode != null ? mode.hashCode() : 0);
+        result = 31 * result + (conditionEvals != null ? conditionEvals.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TriggerConditionEval{" +
+                "tenantId='" + tenantId + '\'' +
+                ", triggerId='" + triggerId + '\'' +
+                ", mode=" + mode +
+                ", conditionEvals=" + conditionEvals +
+                '}';
+    }
+}

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -32,6 +32,7 @@ import org.hawkular.alerts.api.model.condition.ThresholdCondition;
 import org.hawkular.alerts.api.model.condition.ThresholdConditionEval;
 import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
 import org.hawkular.alerts.api.model.condition.ThresholdRangeConditionEval;
+import org.hawkular.alerts.api.model.condition.TriggerConditionEval;
 import org.hawkular.alerts.api.model.condition.RateCondition;
 import org.hawkular.alerts.api.model.condition.RateConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
@@ -49,10 +50,10 @@ import org.hawkular.alerts.engine.util.RateData;
 
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.List;
-import java.util.Map
-import org.hawkular.alerts.api.model.event.Alert
+import java.util.Map;
 import org.hawkular.alerts.engine.util.ActionsValidator;
 
 global Logger log;
@@ -320,22 +321,37 @@ rule ProvideDefaultDampening
         insert( d );
 end
 
+rule CollectConditionEvals
+    when
+        $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode )
+        $ces : TriggerConditionEval( size > 0 )
+               from accumulate(
+                $ce: ConditionEval ( tenantId == $tenantId,  triggerId == $tid ),
+                init( TriggerConditionEval tce = new TriggerConditionEval($tenantId, $tid, $tmode); ),
+                action ( tce.addConditionEval($ce); ),
+                result( tce )
+               )
+    then
+        $ces.getConditionEvals().stream().forEach(ce -> retract(ce));
+        insert( $ces );
+end
+
 rule DampenTrigger
     when
         $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode )
         $d  : Dampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, satisfied == false )
-        $ce : ConditionEval ( tenantId == $tenantId,  triggerId == $tid )
+        $tce : TriggerConditionEval ( tenantId == $tenantId,  triggerId == $tid )
     then
         retract( $d );
-        retract ( $ce );
+        retract ( $tce );
 
-        $d.perform( $t.getMatch(), $ce );
+        $d.perform( $t.getMatch(), $tce );
 
         insert( $d );
 
         if (log != null && log.isDebugEnabled()) {
             log.debug( "Updated " + $d + " using [match=" + $t.getMatch() + "] " + $d.getCurrentEvals() );
-            log.debug( "Retracted " + $ce );
+            log.debug( "Retracted " + $tce );
         }
 end
 


### PR DESCRIPTION
This PR groups the processing of ConditionEval inside the rules engine.
For multiple conditions triggers there are some corner cases that may lead to false satisfied status.

For example, given the following trigger:

	Trigger1. Matching ANY
		Condition1: HeapUsed < 10 
		Condition2: HeapUsed > 20
		
	Default dampening

Incoming data:

t1.	HeapUsed = 9

	(CE = ConditionEval)
	
	CE: c2. HU (9) > 20 [False]
		** Update Dampening
			CurrentEvals: 1) None
						  2) 9 > 20 [F] 
	CE: c1. HU (9) < 10 [True]
		** Update Dampening
			CurrentEvals: 1) 9 < 10 [T]
						  2) 9 > 20 [F]
--> EVENT

t2. HeapUsed = 11

	CE: c2. HU (11) > 20 [False]
		** Update Dampening
			Current Evals: 1) 9 < 10 [T]
						   2) 11 > 20 [F]
						   
--> EVENT (INCORRECT)

t3. HeapUsed = 21

t4. HeapUsed = 19

Or this other example:

	Trigger1. Matching ALL
		Conditions 
			"myapp.war" text == 'DOWN'
			"datacenter1" text starts 'ERROR'
			"datacenter2" text starts 'WARN'
			
	Default dampening
	
			
Incoming data:

t1. "myapp.war" "DOWN"
t2. "datacenter1" "ERROR [Time] This is a sample as app logging"
t3. "datacenter2" "WARN [Time] This is a sample as app logging"

--> EVENT

t4. "myapp.war" "UP"
t5. "datacenter1" "ERROR [Time] This is a sample as app logging"
t6. "datacenter2" "WARN [Time] This is a sample as app logging"

--> EVENT (INCORRECT)

t7. "myapp.war" "UP"
t8. "datacenter1" "ERROR [Time] This is a sample as app logging"
t9. "datacenter2" "WARN [Time] This is a sample as app logging"

--> EVENT (INCORRECT)

So, this PR introduces a grouping rule in the engine, in a way that ConditionEval are evaluated in a single step, instead to a sequencial way interacting with the working memory.

As a result, the previous behaviour	is maintained (all tests previous tests are ok with this change) but we cover these cornercases with multiple conditions.