### PR TITLE
Upgrade MetricsId serialized class for ISPN uses

### DIFF
--- a/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/init/CacheManager.java
+++ b/hawkular-alerts-bus/src/main/java/org/hawkular/alerts/bus/init/CacheManager.java
@@ -176,7 +176,7 @@ public class CacheManager {
                 This logic assumes that alerting is the only writer for the shared publishCache
              */
             log.debugf("Publishing metricId %s ", metricId);
-            publishCache.put(metricId, dataIdKey.getDataId());
+            publishCache.put(convert(metricId), dataIdKey.getDataId());
             /*
                 This alternative logic assumes that more writers can add/remove entries into the shared publishCache.
 
@@ -204,7 +204,7 @@ public class CacheManager {
                 This logic assumes that alerting is the only writer for the shared publishCache
              */
             log.debugf("Unpublishing metricId %s ", metricId);
-            publishCache.remove(metricId);
+            publishCache.remove(convert(metricId));
             /*
                 This alternative logic assumes that more writers can add/remove entries into the shared publishCache.
 
@@ -255,6 +255,12 @@ public class CacheManager {
             return null;
         }
         return new MetricId(tenantId, type, metricId);
+    }
+
+    private String convert(MetricId id) {
+        return new StringBuilder(id.getTenantId() == null ? "" : id.getTenantId()).append("-")
+                .append((id.getType() == null ? "" : id.getType().getText())).append("-")
+                .append((id.getName() == null ? "" : id.getName())).toString();
     }
 
     public static class DataIdKey {

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <version.org.drools>6.4.0.Final</version.org.drools>
     <version.org.freemarker>2.3.17</version.org.freemarker>
     <version.org.hawkular.commons>0.7.4.Final</version.org.hawkular.commons>
-    <version.org.hawkular.metrics>0.18.0.Final</version.org.hawkular.metrics>
+    <version.org.hawkular.metrics>0.19.0.Final</version.org.hawkular.metrics>
     <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
     <version.org.infinispan.eap64>5.2.9.Final</version.org.infinispan.eap64>
     <version.org.jboss.jboss-vfs>3.2.10.Final</version.org.jboss.jboss-vfs>


### PR DESCRIPTION
It seems that ISPN can handle non-serialized objects.
This has created some problems when using MetricId as a key on ISPN between Metrics and Alerting.
A preliminar workaround was to use a string type as a key, but a better approach is to use a MetricId which implements Serialized.
This PR is on hold until we can test that a serialized MetricId class is working fine in metrics.
Then we will use that for key on published cache.