### PR TITLE
HWKALERTS-161 Filter alerts by resolved and ack timestamps

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -60,10 +60,10 @@ public class Alert extends Event {
     private String resolvedBy;
 
     @JsonInclude(Include.NON_EMPTY)
-    private List<Note> notes;
+    private List<Note> notes = new ArrayList<>();;
 
     @JsonInclude(Include.NON_EMPTY)
-    private List<LifeCycle> lifecycle;
+    private List<LifeCycle> lifecycle = new ArrayList<>();
 
     @JsonInclude(Include.NON_EMPTY)
     @Thin
@@ -88,6 +88,7 @@ public class Alert extends Event {
         this.status = Status.OPEN;
         this.severity = trigger.getSeverity();
         this.eventType = EventType.ALERT.name();
+        addLifecycle(this.status, "system", this.ctime);
     }
 
     @JsonIgnore
@@ -161,9 +162,6 @@ public class Alert extends Event {
     }
 
     public List<Note> getNotes() {
-        if (null == notes) {
-            this.notes = new ArrayList<>();
-        }
         return notes;
     }
 
@@ -185,9 +183,6 @@ public class Alert extends Event {
     }
 
     public List<LifeCycle> getLifecycle() {
-        if (null == lifecycle) {
-            this.lifecycle = new ArrayList<>();
-        }
         return lifecycle;
     }
 
@@ -202,7 +197,8 @@ public class Alert extends Event {
         getLifecycle().add(new LifeCycle(status, user, stime));
     }
 
-    public LifeCycle lastLifecycle() {
+    @JsonIgnore
+    public LifeCycle getCurrentLifecycle() {
         if (getLifecycle().isEmpty()) {
             return null;
         }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -63,6 +63,9 @@ public class Alert extends Event {
     private List<Note> notes;
 
     @JsonInclude(Include.NON_EMPTY)
+    private List<LifeCycle> lifecycle;
+
+    @JsonInclude(Include.NON_EMPTY)
     @Thin
     private List<Set<ConditionEval>> resolvedEvalSets;
 
@@ -181,6 +184,31 @@ public class Alert extends Event {
         getNotes().add(new Note(user, text));
     }
 
+    public List<LifeCycle> getLifecycle() {
+        if (null == lifecycle) {
+            this.lifecycle = new ArrayList<>();
+        }
+        return lifecycle;
+    }
+
+    public void setLifecycle(List<LifeCycle> lifecycle) {
+        this.lifecycle = lifecycle;
+    }
+
+    public void addLifecycle(Status status, String user, long stime) {
+        if (status == null || user == null) {
+            throw new IllegalArgumentException("Lifecycle must have non-null state and user");
+        }
+        getLifecycle().add(new LifeCycle(status, user, stime));
+    }
+
+    public LifeCycle lastLifecycle() {
+        if (getLifecycle().isEmpty()) {
+            return null;
+        }
+        return getLifecycle().get(getLifecycle().size() - 1);
+    }
+
     @Override
     public String toString() {
         return "Alert [alertId=" + id + ", status=" + status + ", ackTime=" + ackTime
@@ -268,6 +296,81 @@ public class Alert extends Event {
                     "user='" + user + '\'' +
                     ", ctime=" + ctime +
                     ", text='" + text + '\'' +
+                    '}';
+        }
+    }
+
+    public static class LifeCycle {
+        @JsonInclude(Include.NON_EMPTY)
+        private Status status;
+
+        @JsonInclude(Include.NON_EMPTY)
+        private String user;
+
+        @JsonInclude(Include.NON_EMPTY)
+        private long stime;
+
+        public LifeCycle() {
+            // for json assembly
+        }
+
+        public LifeCycle(Status status, String user, long stime) {
+            this.status = status;
+            this.user = user;
+            this.stime = stime;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public void setUser(String user) {
+            this.user = user;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public long getStime() {
+            return stime;
+        }
+
+        public void setStime(long stime) {
+            this.stime = stime;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LifeCycle lifeCycle = (LifeCycle) o;
+
+            if (stime != lifeCycle.stime) return false;
+            if (user != null ? !user.equals(lifeCycle.user) : lifeCycle.user != null) return false;
+            return status == lifeCycle.status;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = user != null ? user.hashCode() : 0;
+            result = 31 * result + (status != null ? status.hashCode() : 0);
+            result = 31 * result + (int) (stime ^ (stime >>> 32));
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "LifeCycle{" +
+                    "user='" + user + '\'' +
+                    ", status=" + status +
+                    ", stime=" + stime +
                     '}';
         }
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,10 @@ import org.hawkular.alerts.api.model.event.Alert;
 public class AlertsCriteria {
     Long startTime = null;
     Long endTime = null;
+    Long startResolvedTime = null;
+    Long endResolvedTime = null;
+    Long startAckTime = null;
+    Long endAckTime = null;
     String alertId = null;
     Collection<String> alertIds = null;
     Alert.Status status = null;
@@ -66,6 +70,50 @@ public class AlertsCriteria {
      */
     public void setEndTime(Long endTime) {
         this.endTime = endTime;
+    }
+
+    public Long getStartResolvedTime() {
+        return startResolvedTime;
+    }
+
+    /**
+     * @param startResolvedTime fetched Alerts must have resolvedTime greater than or equal to startResolvedTime
+     */
+    public void setStartResolvedTime(Long startResolvedTime) {
+        this.startResolvedTime = startResolvedTime;
+    }
+
+    public Long getEndResolvedTime() {
+        return endResolvedTime;
+    }
+
+    /**
+     * @param endResolvedTime fetched Alerts must have resolvedTime less than or equal to endResolvedTime
+     */
+    public void setEndResolvedTime(Long endResolvedTime) {
+        this.endResolvedTime = endResolvedTime;
+    }
+
+    public Long getStartAckTime() {
+        return startAckTime;
+    }
+
+    /**
+     * @param startAckTime fetched Alerts must have ackTime greater than or equal to startAckTime
+     */
+    public void setStartAckTime(Long startAckTime) {
+        this.startAckTime = startAckTime;
+    }
+
+    public Long getEndAckTime() {
+        return endAckTime;
+    }
+
+    /**
+     * @param endAckTime fetched Alerts must have ackTime less than or equal to endAckTime
+     */
+    public void setEndAckTime(Long endAckTime) {
+        this.endAckTime = endAckTime;
     }
 
     public String getAlertId() {
@@ -193,13 +241,23 @@ public class AlertsCriteria {
                 || (null != triggerIds && !triggerIds.isEmpty());
     }
 
+    public boolean hasResolvedTimeCriteria() {
+        return (null != startResolvedTime || null != endResolvedTime);
+    }
+
+    public boolean hasAckTimeCriteria() {
+        return (null != startAckTime || null != endAckTime);
+    }
+
     public boolean hasCriteria() {
         return hasAlertIdCriteria()
                 || hasStatusCriteria()
                 || hasSeverityCriteria()
                 || hasTagCriteria()
                 || hasCTimeCriteria()
-                || hasTriggerIdCriteria();
+                || hasTriggerIdCriteria()
+                || hasResolvedTimeCriteria()
+                || hasAckTimeCriteria();
     }
 
     @Override
@@ -207,6 +265,8 @@ public class AlertsCriteria {
         return "AlertsCriteria [startTime=" + startTime + ", endTime=" + endTime + ", alertId=" + alertId
                 + ", alertIds=" + alertIds + ", status=" + status + ", statusSet=" + statusSet + ", severity="
                 + severity + ", severities=" + severities + ", triggerId=" + triggerId + ", triggerIds=" + triggerIds
-                + ", tags=" + tags + ", thin=" + thin + "]";
+                + ", tags=" + tags + ", startAckTime=" + startAckTime + ", endAckTime=" + endAckTime + ", " +
+                "startResolvedTime=" + startResolvedTime + ", endResolvedTime=" + endResolvedTime + ", " +
+                "thin=" + thin + "]";
     }
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -77,7 +77,10 @@ public class AlertsCriteria {
     }
 
     /**
-     * @param startResolvedTime fetched Alerts must have resolvedTime greater than or equal to startResolvedTime
+     * @param startResolvedTime fetched Alerts must have at least one resolvedTime in the lifecycle greater than or
+     *                          equal to startResolvedTime.
+     *                          Alerts lifecycle might involve several transitions between ACKNOWLEDGE and RESOLVE
+     *                          states.
      */
     public void setStartResolvedTime(Long startResolvedTime) {
         this.startResolvedTime = startResolvedTime;
@@ -88,7 +91,9 @@ public class AlertsCriteria {
     }
 
     /**
-     * @param endResolvedTime fetched Alerts must have resolvedTime less than or equal to endResolvedTime
+     * @param endResolvedTime fetched Alerts must have at least one resolvedTime in the lifecycle less than or equal to
+     *                        endResolvedTime.
+     *                        Alerts lifecycle might involve several transitions between ACKNOWLEDGE and RESOLVE states.
      */
     public void setEndResolvedTime(Long endResolvedTime) {
         this.endResolvedTime = endResolvedTime;
@@ -99,7 +104,9 @@ public class AlertsCriteria {
     }
 
     /**
-     * @param startAckTime fetched Alerts must have ackTime greater than or equal to startAckTime
+     * @param startAckTime fetched Alerts must have at least one ackTime in the lifecycle greater than or equal to
+     *                     startAckTime.
+     *                     Alerts lifecycle might involve several transitions between ACKNOWLEDGE and RESOLVE states.
      */
     public void setStartAckTime(Long startAckTime) {
         this.startAckTime = startAckTime;
@@ -110,7 +117,9 @@ public class AlertsCriteria {
     }
 
     /**
-     * @param endAckTime fetched Alerts must have ackTime less than or equal to endAckTime
+     * @param endAckTime fetched Alerts must have at least one ackTime in the lifecycle less than or equal to
+     *                   endAckTime.
+     *                   Alerts lifecycle might involve several transitions between ACKNOWLEDGE and RESOLVE states.
      */
     public void setEndAckTime(Long endAckTime) {
         this.endAckTime = endAckTime;

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -38,6 +38,7 @@ import org.hawkular.alerts.api.model.Severity;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
+import org.hawkular.alerts.api.model.event.Alert.Status;
 import org.hawkular.alerts.api.model.event.Event;
 import org.hawkular.alerts.api.model.paging.AlertComparator;
 import org.hawkular.alerts.api.model.paging.AlertComparator.Field;
@@ -554,6 +555,38 @@ public class CassAlertsServiceImpl implements AlertsService {
                 }
 
                 /*
+                    Get alertsIds filtered by resolved time clause
+                 */
+                if (criteria.hasResolvedTimeCriteria()) {
+                    Set<String> alertIdsFilteredByResolvedTime = filterByResolvedTime(tenantId, criteria);
+                    if (activeFilter) {
+                        alertIds.retainAll(alertIdsFilteredByResolvedTime);
+                        if (alertIds.isEmpty()) {
+                            return new Page<>(alerts, pager, 0);
+                        }
+                    } else {
+                        alertIds.addAll(alertIdsFilteredByResolvedTime);
+                    }
+                    activeFilter = true;
+                }
+
+                /*
+                    Get alertsIds filtered by ack time clause
+                 */
+                if (criteria.hasAckTimeCriteria()) {
+                    Set<String> alertIdsFilteredByAckTime = filterByAckTime(tenantId, criteria);
+                    if (activeFilter) {
+                        alertIds.retainAll(alertIdsFilteredByAckTime);
+                        if (alertIds.isEmpty()) {
+                            return new Page<>(alerts, pager, 0);
+                        }
+                    } else {
+                        alertIds.addAll(alertIdsFilteredByAckTime);
+                    }
+                    activeFilter = true;
+                }
+
+                /*
                      Get alertsIds filtered by severities clause
                 */
                 if (criteria.hasSeverityCriteria()) {
@@ -755,7 +788,7 @@ public class CassAlertsServiceImpl implements AlertsService {
     private Set<String> filterByStatuses(String tenantId, AlertsCriteria criteria) throws Exception {
         Set<String> result = Collections.emptySet();
 
-        Set<Alert.Status> statuses = new HashSet<>();
+        Set<Status> statuses = new HashSet<>();
         if (isEmpty(criteria.getStatusSet())) {
             if (criteria.getStatus() != null) {
                 statuses.add(criteria.getStatus());
@@ -831,6 +864,72 @@ public class CassAlertsServiceImpl implements AlertsService {
         } else {
             result = new HashSet<>();
             result.addAll(criteria.getEventIds());
+        }
+        return result;
+    }
+
+    private Set<String> filterByResolvedTime(String tenantId, AlertsCriteria criteria) throws Exception {
+        Set<String> result = Collections.emptySet();
+
+        if (criteria.getStartResolvedTime() != null || criteria.getEndResolvedTime() != null) {
+            result = new HashSet<>();
+
+            Session session = CassCluster.getSession();
+            BoundStatement boundLifecycleTime;
+            if (criteria.getStartResolvedTime() != null && criteria.getEndResolvedTime() != null) {
+                PreparedStatement selectAlertLifecycleStartEnd = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_START_END);
+                boundLifecycleTime = selectAlertLifecycleStartEnd.bind(tenantId, Status.RESOLVED.name(),
+                        criteria.getStartResolvedTime(), criteria.getEndResolvedTime());
+            } else if (criteria.getStartResolvedTime() != null) {
+                PreparedStatement selectAlertLifecycleStart = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_START);
+                boundLifecycleTime = selectAlertLifecycleStart.bind(tenantId, Status.RESOLVED.name(),
+                        criteria.getStartResolvedTime());
+            } else {
+                PreparedStatement selectAlertLifecycleEnd = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_END);
+                boundLifecycleTime = selectAlertLifecycleEnd.bind(tenantId, criteria.getEndResolvedTime());
+            }
+
+            ResultSet rsAlertsLifecycleTimes = session.execute(boundLifecycleTime);
+            for (Row row : rsAlertsLifecycleTimes) {
+                String alertId = row.getString("alertId");
+                result.add(alertId);
+            }
+        }
+        return result;
+    }
+
+    private Set<String> filterByAckTime(String tenantId, AlertsCriteria criteria) throws Exception {
+        Set<String> result = Collections.emptySet();
+
+        if (criteria.getStartAckTime() != null || criteria.getEndAckTime() != null) {
+            result = new HashSet<>();
+
+            Session session = CassCluster.getSession();
+            BoundStatement boundLifecycleTime;
+            if (criteria.getStartAckTime() != null && criteria.getEndAckTime() != null) {
+                PreparedStatement selectAlertLifecycleStartEnd = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_START_END);
+                boundLifecycleTime = selectAlertLifecycleStartEnd.bind(tenantId, Status.ACKNOWLEDGED.name(),
+                        criteria.getStartAckTime(), criteria.getEndAckTime());
+            } else if (criteria.getStartAckTime() != null) {
+                PreparedStatement selectAlertLifecycleStart = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_START);
+                boundLifecycleTime = selectAlertLifecycleStart.bind(tenantId, Status.ACKNOWLEDGED.name(),
+                        criteria.getStartAckTime());
+            } else {
+                PreparedStatement selectAlertLifecycleEnd = CassStatement.get(session,
+                        CassStatement.SELECT_ALERT_LIFECYCLE_END);
+                boundLifecycleTime = selectAlertLifecycleEnd.bind(tenantId, criteria.getEndAckTime());
+            }
+
+            ResultSet rsAlertsLifecycleTimes = session.execute(boundLifecycleTime);
+            for (Row row : rsAlertsLifecycleTimes) {
+                String alertId = row.getString("alertId");
+                result.add(alertId);
+            }
         }
         return result;
     }
@@ -1214,10 +1313,11 @@ public class CassAlertsServiceImpl implements AlertsService {
         List<Alert> alertsToAck = getAlerts(tenantId, criteria, null);
 
         for (Alert a : alertsToAck) {
-            a.setStatus(Alert.Status.ACKNOWLEDGED);
+            a.setStatus(Status.ACKNOWLEDGED);
             a.setAckBy(ackBy);
             a.setAckTime(System.currentTimeMillis());
             a.addNote(ackBy, ackNotes);
+            a.addLifecycle(a.getStatus(), a.getAckBy(), a.getAckTime());
             updateAlertStatus(a);
             sendAction(a);
         }
@@ -1245,8 +1345,9 @@ public class CassAlertsServiceImpl implements AlertsService {
         PreparedStatement deleteAlertSeverity = CassStatement.get(session, CassStatement.DELETE_ALERT_SEVERITY);
         PreparedStatement deleteAlertStatus = CassStatement.get(session, CassStatement.DELETE_ALERT_STATUS);
         PreparedStatement deleteAlertTrigger = CassStatement.get(session, CassStatement.DELETE_ALERT_TRIGGER);
+        PreparedStatement deleteAlertLifecycle = CassStatement.get(session, CassStatement.DELETE_ALERT_LIFECYCLE);
         if (deleteAlert == null || deleteAlertCtime == null || deleteAlertSeverity == null
-                || deleteAlertStatus == null || deleteAlertTrigger == null) {
+                || deleteAlertStatus == null || deleteAlertTrigger == null || deleteAlertLifecycle == null) {
             throw new RuntimeException("delete*Alerts PreparedStatement is null");
         }
 
@@ -1258,6 +1359,10 @@ public class CassAlertsServiceImpl implements AlertsService {
             futures.add(session.executeAsync(deleteAlertSeverity.bind(tenantId, a.getSeverity().name(), id)));
             futures.add(session.executeAsync(deleteAlertStatus.bind(tenantId, a.getStatus().name(), id)));
             futures.add(session.executeAsync(deleteAlertTrigger.bind(tenantId, a.getTriggerId(), id)));
+            a.getLifecycle().stream().forEach(l -> {
+                futures.add(session.executeAsync(deleteAlertLifecycle.bind(tenantId, l.getStatus().name(), l.getStime(),
+                        a.getAlertId())));
+            });
             Futures.allAsList(futures).get();
         }
 
@@ -1330,11 +1435,12 @@ public class CassAlertsServiceImpl implements AlertsService {
 
         // resolve the alerts
         for (Alert a : alertsToResolve) {
-            a.setStatus(Alert.Status.RESOLVED);
+            a.setStatus(Status.RESOLVED);
             a.setResolvedBy(resolvedBy);
             a.setResolvedTime(System.currentTimeMillis());
             a.addNote(resolvedBy, resolvedNotes);
             a.setResolvedEvalSets(resolvedEvalSets);
+            a.addLifecycle(a.getStatus(), a.getResolvedBy(), a.getResolvedTime());
             updateAlertStatus(a);
             sendAction(a);
         }
@@ -1366,15 +1472,16 @@ public class CassAlertsServiceImpl implements AlertsService {
 
         AlertsCriteria criteria = new AlertsCriteria();
         criteria.setTriggerId(triggerId);
-        criteria.setStatusSet(EnumSet.complementOf(EnumSet.of(Alert.Status.RESOLVED)));
+        criteria.setStatusSet(EnumSet.complementOf(EnumSet.of(Status.RESOLVED)));
         List<Alert> alertsToResolve = getAlerts(tenantId, criteria, null);
 
         for (Alert a : alertsToResolve) {
-            a.setStatus(Alert.Status.RESOLVED);
+            a.setStatus(Status.RESOLVED);
             a.setResolvedBy(resolvedBy);
             a.setResolvedTime(System.currentTimeMillis());
             a.addNote(resolvedBy, resolvedNotes);
             a.setResolvedEvalSets(resolvedEvalSets);
+            a.addLifecycle(a.getStatus(), a.getResolvedBy(), a.getResolvedTime());
             updateAlertStatus(a);
             sendAction(a);
         }
@@ -1394,16 +1501,23 @@ public class CassAlertsServiceImpl implements AlertsService {
                     CassStatement.DELETE_ALERT_STATUS);
             PreparedStatement insertAlertStatus = CassStatement.get(session,
                     CassStatement.INSERT_ALERT_STATUS);
+            PreparedStatement insertAlertLifecycle = CassStatement.get(session,
+                    CassStatement.INSERT_ALERT_LIFECYCLE);
             PreparedStatement updateAlert = CassStatement.get(session,
                     CassStatement.UPDATE_ALERT);
 
             List<ResultSetFuture> futures = new ArrayList<>();
-            for (Alert.Status statusToDelete : EnumSet.complementOf(EnumSet.of(alert.getStatus()))) {
+            for (Status statusToDelete : EnumSet.complementOf(EnumSet.of(alert.getStatus()))) {
                 futures.add(session.executeAsync(deleteAlertStatus.bind(alert.getTenantId(), statusToDelete.name(),
                         alert.getAlertId())));
             }
             futures.add(session.executeAsync(insertAlertStatus.bind(alert.getTenantId(), alert.getAlertId(), alert
                     .getStatus().name())));
+            Alert.LifeCycle lifecycle = alert.lastLifecycle();
+            if (lifecycle != null) {
+                futures.add(session.executeAsync(insertAlertLifecycle.bind(alert.getTenantId(), alert.getAlertId(),
+                        lifecycle.getStatus().name(), lifecycle.getStime())));
+            }
             futures.add(session.executeAsync(updateAlert.bind(JsonUtil.toJson(alert), alert.getTenantId(),
                     alert.getAlertId())));
 
@@ -1450,7 +1564,7 @@ public class CassAlertsServiceImpl implements AlertsService {
             if (checkIfAllResolved) {
                 AlertsCriteria ac = new AlertsCriteria();
                 ac.setTriggerId(triggerId);
-                ac.setStatusSet(EnumSet.complementOf(EnumSet.of(Alert.Status.RESOLVED)));
+                ac.setStatusSet(EnumSet.complementOf(EnumSet.of(Status.RESOLVED)));
                 Page<Alert> unresolvedAlerts = getAlerts(tenantId, ac, new Pager(0, 1, Order.unspecified()));
                 allResolved = unresolvedAlerts.isEmpty();
             }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -1513,7 +1513,7 @@ public class CassAlertsServiceImpl implements AlertsService {
             }
             futures.add(session.executeAsync(insertAlertStatus.bind(alert.getTenantId(), alert.getAlertId(), alert
                     .getStatus().name())));
-            Alert.LifeCycle lifecycle = alert.lastLifecycle();
+            Alert.LifeCycle lifecycle = alert.getCurrentLifecycle();
             if (lifecycle != null) {
                 futures.add(session.executeAsync(insertAlertLifecycle.bind(alert.getTenantId(), alert.getAlertId(),
                         lifecycle.getStatus().name(), lifecycle.getStime())));

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -45,6 +45,7 @@ public class CassStatement {
     public static final String DELETE_ACTION_PLUGIN;
     public static final String DELETE_ALERT;
     public static final String DELETE_ALERT_CTIME;
+    public static final String DELETE_ALERT_LIFECYCLE;
     public static final String DELETE_ALERT_SEVERITY;
     public static final String DELETE_ALERT_STATUS;
     public static final String DELETE_ALERT_TRIGGER;
@@ -70,6 +71,7 @@ public class CassStatement {
     public static final String INSERT_ACTION_PLUGIN_DEFAULT_PROPERTIES;
     public static final String INSERT_ALERT;
     public static final String INSERT_ALERT_CTIME;
+    public static final String INSERT_ALERT_LIFECYCLE;
     public static final String INSERT_ALERT_SEVERITY;
     public static final String INSERT_ALERT_STATUS;
     public static final String INSERT_ALERT_TRIGGER;
@@ -111,6 +113,9 @@ public class CassStatement {
     public static final String SELECT_ALERT_CTIME_END;
     public static final String SELECT_ALERT_CTIME_START;
     public static final String SELECT_ALERT_CTIME_START_END;
+    public static final String SELECT_ALERT_LIFECYCLE_END;
+    public static final String SELECT_ALERT_LIFECYCLE_START;
+    public static final String SELECT_ALERT_LIFECYCLE_START_END;
     public static final String SELECT_ALERT_STATUS;
     public static final String SELECT_ALERT_SEVERITY;
     public static final String SELECT_ALERT_TRIGGER;
@@ -180,6 +185,9 @@ public class CassStatement {
 
         DELETE_ALERT_CTIME = "DELETE FROM " + keyspace + ".alerts_ctimes "
                 + "WHERE tenantId = ? AND ctime = ? AND alertId = ? ";
+
+        DELETE_ALERT_LIFECYCLE = "DELETE FROM " + keyspace + ".alerts_lifecycle "
+                + "WHERE tenantId = ? AND status = ? AND stime = ? AND alertId = ? ";
 
         DELETE_ALERT_SEVERITY = "DELETE FROM " + keyspace + ".alerts_severities "
                 + "WHERE tenantId = ? AND severity = ? AND alertId = ? ";
@@ -252,6 +260,9 @@ public class CassStatement {
 
         INSERT_ALERT_CTIME = "INSERT INTO " + keyspace + ".alerts_ctimes "
                 + "(tenantId, alertId, ctime) VALUES (?, ?, ?) ";
+
+        INSERT_ALERT_LIFECYCLE = "INSERT INTO " + keyspace + ".alerts_lifecycle "
+                + "(tenantId, alertId, status, stime) VALUES (?, ?, ?, ?) ";
 
         INSERT_ALERT_SEVERITY = "INSERT INTO " + keyspace + ".alerts_severities "
                 + "(tenantId, alertId, severity) VALUES (?, ?, ?) ";
@@ -386,6 +397,15 @@ public class CassStatement {
 
         SELECT_ALERT_CTIME_START_END = "SELECT alertId FROM " + keyspace + ".alerts_ctimes "
                 + "WHERE tenantId = ? AND ctime >= ? AND ctime <= ? ";
+
+        SELECT_ALERT_LIFECYCLE_END = "SELECT alertId FROM " + keyspace + ".alerts_lifecycle "
+                + "WHERE tenantId = ? AND status = ? AND stime <= ? ";
+
+        SELECT_ALERT_LIFECYCLE_START = "SELECT alertId FROM " + keyspace + ".alerts_lifecycle "
+                + "WHERE tenantId = ? AND status = ? AND stime >= ? ";
+
+        SELECT_ALERT_LIFECYCLE_START_END = "SELECT alertId FROM " + keyspace + ".alerts_lifecycle "
+                + "WHERE tenantId = ? AND status = ? AND stime >= ? AND stime <= ? ";
 
         SELECT_ALERT_SEVERITY = "SELECT alertId FROM " + keyspace + ".alerts_severities "
                 + "WHERE tenantId = ? AND severity = ? ";

--- a/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
+++ b/hawkular-alerts-engine/src/main/resources/hawkular-alerts-schema.cql
@@ -248,6 +248,16 @@ CREATE TABLE ${keyspace}.alerts_severities (
 
 -- #
 
+CREATE TABLE ${keyspace}.alerts_lifecycle (
+    tenantId text,
+    alertId text,
+    status text,
+    stime bigint,
+    PRIMARY KEY (tenantId, status, stime, alertId)
+);
+
+-- #
+
 CREATE TABLE ${keyspace}.events (
     tenantId text,
     id text,

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
@@ -48,6 +48,12 @@ class AlertsITest extends AbstractITestBase {
 
         resp = client.get(path: "", query: [tags:"dataId|data-01,dataId|data-02",thin:true] )
         assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endResolvedTime:now, startResolvedTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endAckTime:now, startAckTime:"0"] )
+        assert resp.status == 200 : resp.status
     }
 
     @Test
@@ -70,6 +76,12 @@ class AlertsITest extends AbstractITestBase {
         assert resp.status == 200 : resp.status
 
         resp = client.put(path: "delete", query: [tags:"dataId|data-01,dataId|data-02"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endResolvedTime:now, startResolvedTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endAckTime:now, startAckTime:"0"] )
         assert resp.status == 200 : resp.status
     }
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -490,6 +490,11 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(1, resp.data.size())
 
         resp = client.get(path: "",
+                query: [startResolvedTime:start,triggerIds:"test-manual-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "",
             query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED"] )
         assertEquals(200, resp.status)
         assertEquals(5, resp.data.size())
@@ -699,7 +704,15 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
 
+        resp = client.get(path: "", query: [startAckTime:start,triggerIds:"test-manual2-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
         resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "", query: [startResolvedTime:start,triggerIds:"test-manual2-trigger"] )
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
     }


### PR DESCRIPTION
This PR covers:
- Store lifecycle history on alert.
- Extend alerts criteria to support filtering on resolved and ack timestamps.
- Include new changes on alerts criteria on REST handlers.