### PR TITLE
HWKALERTS-164 Unify resolved and ack fields with lifecycle

### DIFF
--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
@@ -302,9 +302,9 @@ public class EmailPlugin implements ActionPluginListener {
             if (alert.getStatus().equals(Status.OPEN)) {
                 email.setSentDate(new Date(alert.getCtime()));
             } else if (alert.getStatus().equals(Status.ACKNOWLEDGED)) {
-                email.setSentDate(new Date(alert.getCurrentLifecycle().getStime()));
+                email.setSentDate(new Date(alert.getLastAckTime()));
             } else {
-                email.setSentDate(new Date(alert.getCurrentLifecycle().getStime()));
+                email.setSentDate(new Date(alert.getLastResolvedTime()));
             }
         } else {
             email.setSentDate(new Date());

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
@@ -302,9 +302,9 @@ public class EmailPlugin implements ActionPluginListener {
             if (alert.getStatus().equals(Status.OPEN)) {
                 email.setSentDate(new Date(alert.getCtime()));
             } else if (alert.getStatus().equals(Status.ACKNOWLEDGED)) {
-                email.setSentDate(new Date(alert.getAckTime()));
+                email.setSentDate(new Date(alert.getCurrentLifecycle().getStime()));
             } else {
-                email.setSentDate(new Date(alert.getResolvedTime()));
+                email.setSentDate(new Date(alert.getCurrentLifecycle().getStime()));
             }
         } else {
             email.setSentDate(new Date());

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.html.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.html.default_en_US.ftl
@@ -147,15 +147,15 @@
                                                 <tr>
                                                     <td align="center" style="color:#333333; font-family:Open sans,sans-serif; font-size:13px; line-height:21px;">
                                                         Acknowledge time:
-                                                        <span style="font-size:15px;">${alert.ackTime?number_to_datetime}</span>
+                                                        <span style="font-size:15px;">${alert.currentLifecycle.stime?number_to_datetime}</span>
                                                     </td>
                                                 </tr>
-                                                <#if alert.ackBy?? >
+                                                <#if alert.currentLifecycle.user?? >
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open
                                                         sans,sans-serif; font-size:13px; line-height:21px;
                                                         padding-bottom:2px;">
-                                                            by ${alert.ackBy}
+                                                            by ${alert.currentLifecycle.user}
                                                         </td>
                                                     </tr>
                                                 </#if>
@@ -164,16 +164,15 @@
                                                 <tr>
                                                     <td align="center" style="color:#333333; font-family:Open sans,sans-serif; font-size:13px; line-height:21px;">
                                                         Resolved time:
-                                                        <span style="font-size:15px;">${alert
-                                                        .resolvedTime?number_to_datetime}</span>
+                                                        <span style="font-size:15px;">${alert.currentLifecycle.stime?number_to_datetime}</span>
                                                     </td>
                                                 </tr>
-                                                <#if alert.resolvedBy?? >
+                                                <#if alert.currentLifecycle.user?? >
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open
                                                             sans,sans-serif; font-size:13px; line-height:21px;
                                                             padding-bottom:2px;">
-                                                            by ${alert.resolvedBy}
+                                                            by ${alert.currentLifecycle.user}
                                                         </td>
                                                     </tr>
                                                 </#if>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.plain.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/main/resources/template.plain.default_en_US.ftl
@@ -19,19 +19,19 @@ Conditions:
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'ACKNOWLEDGED'>
 Acknowledge time:
-${alert.ackTime?number_to_datetime}
-<#if alert.ackBy?? >
+${alert.currentLifecycle.stime?number_to_datetime}
+<#if alert.currentLifecycle.user?? >
 
-by ${alert.ackBy}
+by ${alert.currentLifecycle.user}
 </#if>
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
 
 Resolved time:
-${alert.resolvedTime?number_to_datetime}
-<#if alert.resolvedBy?? >
+${alert.currentLifecycle.stime?number_to_datetime}
+<#if alert.currentLifecycle.user?? >
 
-by ${alert.resolvedBy}
+by ${alert.currentLifecycle.user}
 </#if>
 </#if>
 <#if alert.notes?has_content>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.html.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.html.default_en_US.ftl
@@ -147,15 +147,15 @@
                                                 <tr>
                                                     <td align="center" style="color:#333333; font-family:Open sans,sans-serif; font-size:13px; line-height:21px;">
                                                         Acknowledge time:
-                                                        <span style="font-size:15px;">${alert.ackTime?number_to_datetime}</span>
+                                                        <span style="font-size:15px;">${alert.currentLifecycle.stime?number_to_datetime}</span>
                                                     </td>
                                                 </tr>
-                                                <#if alert.ackBy?? >
+                                                <#if alert.currentLifecycle.user?? >
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open
                                                         sans,sans-serif; font-size:13px; line-height:21px;
                                                         padding-bottom:2px;">
-                                                            by ${alert.ackBy}
+                                                            by ${alert.currentLifecycle.user}
                                                         </td>
                                                     </tr>
                                                 </#if>
@@ -164,16 +164,15 @@
                                                 <tr>
                                                     <td align="center" style="color:#333333; font-family:Open sans,sans-serif; font-size:13px; line-height:21px;">
                                                         Resolved time:
-                                                        <span style="font-size:15px;">${alert
-                                                        .resolvedTime?number_to_datetime}</span>
+                                                        <span style="font-size:15px;">${alert.currentLifecycle.stime?number_to_datetime}</span>
                                                     </td>
                                                 </tr>
-                                                <#if alert.resolvedBy?? >
+                                                <#if alert.currentLifecycle.user?? >
                                                     <tr>
                                                         <td align="center" style="color:#999999; font-family:Open
                                                             sans,sans-serif; font-size:13px; line-height:21px;
                                                             padding-bottom:2px;">
-                                                            by ${alert.resolvedBy}
+                                                            by ${alert.currentLifecycle.user}
                                                         </td>
                                                     </tr>
                                                 </#if>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.plain.default_en_US.ftl
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/src/test/resources/template.plain.default_en_US.ftl
@@ -19,19 +19,19 @@ Conditions:
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'ACKNOWLEDGED'>
 Acknowledge time:
-${alert.ackTime?number_to_datetime}
-<#if alert.ackBy?? >
+${alert.currentLifecycle.stime?number_to_datetime}
+<#if alert.currentLifecycle.user?? >
 
-by ${alert.ackBy}
+by ${alert.currentLifecycle.user}
 </#if>
 </#if>
 <#if alert?? && alert.status?? && alert.status == 'RESOLVED'>
 
 Resolved time:
-${alert.resolvedTime?number_to_datetime}
-<#if alert.resolvedBy?? >
+${alert.currentLifecycle.stime?number_to_datetime}
+<#if alert.currentLifecycle.user?? >
 
-by ${alert.resolvedBy}
+by ${alert.currentLifecycle.user}
 </#if>
 </#if>
 <#if alert.notes?has_content>

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,9 +127,7 @@ public class FilePluginTest {
 
         Alert rtAlertAck = new Alert(rtTrigger.getTenantId(), rtTrigger, getEvalList(rtFiringCondition, rtBadData));
         rtAlertAck.setDampening(rtFiringDampening);
-        rtAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
-        rtAlertAck.setAckBy("Test ACK user");
-        rtAlertAck.setAckTime(System.currentTimeMillis() + 10000);
+        rtAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
         rtAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackThresholdAction = new Action(tenantId, "email", "email-to-test", rtAlertAck);
@@ -145,9 +143,7 @@ public class FilePluginTest {
         Alert rtAlertResolved = new Alert(rtTrigger.getTenantId(), rtTrigger,
                 getEvalList(rtFiringCondition, rtBadData));
         rtAlertResolved.setDampening(rtFiringDampening);
-        rtAlertResolved.setStatus(Alert.Status.RESOLVED);
-        rtAlertResolved.setResolvedBy("Test RESOLVED user");
-        rtAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
+        rtAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);
         rtAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         rtAlertResolved.setResolvedEvalSets(getEvalList(rtResolveCondition, rtGoodData));
 
@@ -193,9 +189,7 @@ public class FilePluginTest {
 
         Alert avAlertAck = new Alert(avTrigger.getTenantId(), avTrigger, getEvalList(avFiringCondition, avBadData));
         avAlertAck.setDampening(avFiringDampening);
-        avAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
-        avAlertAck.setAckBy("Test ACK user");
-        avAlertAck.setAckTime(System.currentTimeMillis() + 10000);
+        avAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
         avAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackAvailabilityAction = new Action(tenantId, "email", "email-to-test", avAlertAck);
@@ -212,9 +206,7 @@ public class FilePluginTest {
         Alert avAlertResolved = new Alert(avTrigger.getTenantId(), avTrigger,
                 getEvalList(avFiringCondition, avBadData));
         avAlertResolved.setDampening(avFiringDampening);
-        avAlertResolved.setStatus(Alert.Status.RESOLVED);
-        avAlertResolved.setResolvedBy("Test RESOLVED user");
-        avAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
+        avAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);
         avAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         avAlertResolved.setResolvedEvalSets(getEvalList(avResolveCondition, avGoodData));
 
@@ -273,9 +265,7 @@ public class FilePluginTest {
         Alert mixAlertAck = new Alert(mixTrigger.getTenantId(), mixTrigger,
                 getEvalList(mixConditions, mixBadData));
         mixAlertAck.setDampening(mixFiringDampening);
-        mixAlertAck.setStatus(Alert.Status.ACKNOWLEDGED);
-        mixAlertAck.setAckBy("Test ACK user");
-        mixAlertAck.setAckTime(System.currentTimeMillis() + 10000);
+        mixAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
         mixAlertAck.addNote("Test ACK user", "Test ACK notes");
 
         Action ackTwoCondAction = new Action(tenantId, "email", "email-to-test", mixAlertAck);
@@ -300,10 +290,7 @@ public class FilePluginTest {
         Alert mixAlertResolved = new Alert(mixTrigger.getTenantId(), mixTrigger,
                 getEvalList(mixConditions, mixBadData));
         mixAlertResolved.setDampening(mixFiringDampening);
-        mixAlertResolved.setStatus(Alert.Status.ACKNOWLEDGED);
-        mixAlertResolved.setStatus(Alert.Status.RESOLVED);
-        mixAlertResolved.setResolvedBy("Test RESOLVED user");
-        mixAlertResolved.setResolvedTime(System.currentTimeMillis() + 20000);
+        mixAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);
         mixAlertResolved.addNote("Test RESOLVED user", "Test RESOLVED notes");
         mixAlertResolved.setResolvedEvalSets(getEvalList(mixResolveConditions, mixGoodData));
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/CommonData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/CommonData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,12 @@
  */
 package org.hawkular.alerts.actions.tests;
 
+import java.util.List;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.event.Alert;
+import org.hawkular.alerts.api.model.event.Alert.Status;
 
 /**
  * Common variables for action tests scenarios
@@ -41,11 +46,18 @@ public abstract class CommonData {
      */
     public static Alert ackAlert(Alert openAlert) {
         if (null == openAlert) return null;
-        openAlert.setStatus(Alert.Status.ACKNOWLEDGED);
-        openAlert.setAckBy(ACK_BY);
+        openAlert.addLifecycle(Status.ACKNOWLEDGED, ACK_BY, System.currentTimeMillis());
+        openAlert.setStatus(Status.ACKNOWLEDGED);
         openAlert.addNote(ACK_BY, ACK_NOTES);
-        openAlert.setAckTime(System.currentTimeMillis());
         return openAlert;
+    }
+
+    public static Alert resolveAlert(Alert unresolvedAlert, List<Set<ConditionEval>> resolvedEvals) {
+        if (null == unresolvedAlert) return null;
+        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
+        unresolvedAlert.addLifecycle(Status.RESOLVED, RESOLVED_BY, System.currentTimeMillis());
+        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
+        return unresolvedAlert;
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,13 +121,7 @@ public class JvmGarbageCollectionData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,13 +126,7 @@ public class JvmHeapUsageData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,13 +126,7 @@ public class JvmNonHeapUsageData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -245,13 +245,7 @@ public class MultipleAllJvmData extends CommonData {
 
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -117,13 +117,7 @@ public class UrlAvailabilityData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,13 +120,7 @@ public class UrlResponseTimeData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,13 +127,7 @@ public class WebActiveSessionsData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,13 +127,7 @@ public class WebContainerCurrentThreadsData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,13 +127,7 @@ public class WebContainerPendingRequestsData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,13 +121,7 @@ public class WebExpiredSessionsData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,13 +121,7 @@ public class WebRejectedSessionsData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
+++ b/hawkular-alerts-actions-plugins/hawkular-alerts-actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,13 +121,7 @@ public class WebRequestsResponseTimeData extends CommonData {
         evalSet1.add(eval1);
         resolvedEvals.add(evalSet1);
 
-        unresolvedAlert.setResolvedEvalSets(resolvedEvals);
-        unresolvedAlert.setStatus(Alert.Status.RESOLVED);
-        unresolvedAlert.setResolvedBy(RESOLVED_BY);
-        unresolvedAlert.addNote(RESOLVED_BY, RESOLVED_NOTES);
-        unresolvedAlert.setResolvedTime(System.currentTimeMillis());
-
-        return unresolvedAlert;
+        return resolveAlert(unresolvedAlert, resolvedEvals);
     }
 
 }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -47,18 +47,6 @@ public class Alert extends Event {
     @JsonInclude
     private Status status;
 
-    @JsonInclude
-    private long ackTime;
-
-    @JsonInclude
-    private String ackBy;
-
-    @JsonInclude
-    private long resolvedTime;
-
-    @JsonInclude
-    private String resolvedBy;
-
     @JsonInclude(Include.NON_EMPTY)
     private List<Note> notes = new ArrayList<>();;
 
@@ -121,38 +109,6 @@ public class Alert extends Event {
         this.status = status;
     }
 
-    public long getAckTime() {
-        return ackTime;
-    }
-
-    public void setAckTime(long ackTime) {
-        this.ackTime = ackTime;
-    }
-
-    public String getAckBy() {
-        return ackBy;
-    }
-
-    public void setAckBy(String ackBy) {
-        this.ackBy = ackBy;
-    }
-
-    public long getResolvedTime() {
-        return resolvedTime;
-    }
-
-    public void setResolvedTime(long resolvedTime) {
-        this.resolvedTime = resolvedTime;
-    }
-
-    public String getResolvedBy() {
-        return resolvedBy;
-    }
-
-    public void setResolvedBy(String resolvedBy) {
-        this.resolvedBy = resolvedBy;
-    }
-
     public List<Set<ConditionEval>> getResolvedEvalSets() {
         return resolvedEvalSets;
     }
@@ -194,6 +150,7 @@ public class Alert extends Event {
         if (status == null || user == null) {
             throw new IllegalArgumentException("Lifecycle must have non-null state and user");
         }
+        setStatus(status);
         getLifecycle().add(new LifeCycle(status, user, stime));
     }
 
@@ -207,11 +164,14 @@ public class Alert extends Event {
 
     @Override
     public String toString() {
-        return "Alert [alertId=" + id + ", status=" + status + ", ackTime=" + ackTime
-                + ", ackBy=" + ackBy + ", resolvedTime=" + resolvedTime + ", resolvedBy=" + resolvedBy + ", context="
-                + getContext() + "]";
+        return "Alert{" +
+                "severity=" + severity +
+                ", status=" + status +
+                ", notes=" + notes +
+                ", lifecycle=" + lifecycle +
+                ", resolvedEvalSets=" + resolvedEvalSets +
+                '}';
     }
-
 
     public static class Note {
         @JsonInclude(Include.NON_EMPTY)

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -18,6 +18,7 @@ package org.hawkular.alerts.api.model.event;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 
 import org.hawkular.alerts.api.model.Severity;
@@ -160,6 +161,38 @@ public class Alert extends Event {
             return null;
         }
         return getLifecycle().get(getLifecycle().size() - 1);
+    }
+
+    @JsonIgnore
+    public Long getLastStatusTime(Status status) {
+        if (getLifecycle().isEmpty()) {
+            return null;
+        }
+        Long statusTime = null;
+        ListIterator<LifeCycle> iterator = getLifecycle().listIterator(getLifecycle().size());
+        while (iterator.hasPrevious()) {
+            LifeCycle lifeCycle = iterator.previous();
+            if (lifeCycle.getStatus().equals(status)) {
+                statusTime = lifeCycle.getStime();
+                break;
+            }
+        }
+        return statusTime;
+    }
+
+    @JsonIgnore
+    public Long getLastOpenTime() {
+        return getLastStatusTime(Status.OPEN);
+    }
+
+    @JsonIgnore
+    public Long getLastAckTime() {
+        return getLastStatusTime(Status.ACKNOWLEDGED);
+    }
+
+    @JsonIgnore
+    public Long getLastResolvedTime() {
+        return getLastStatusTime(Status.RESOLVED);
     }
 
     @Override

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -180,10 +180,7 @@ public class JsonTest {
                     "]," +
                 "\"severity\":\"MEDIUM\"," +
                 "\"status\":\"OPEN\"," +
-                "\"ackTime\":0," +
-                "\"ackBy\":null," +
-                "\"resolvedTime\":0," +
-                "\"resolvedBy\":null," +
+                "\"lifecycle\":[{\"status\":\"OPEN\",\"user\":\"system\",\"stime\":1}]," +
                 "\"notes\":[{\"user\":\"user1\",\"ctime\":1,\"text\":\"The comment 1\"}," +
                            "{\"user\":\"user2\",\"ctime\":2,\"text\":\"The comment 2\"}" +
                           "]," +
@@ -195,10 +192,13 @@ public class JsonTest {
         assertNotNull(alert.getEvalSets());
         assertEquals(1, alert.getEvalSets().size());
         assertEquals(2, alert.getEvalSets().get(0).size());
-        assertTrue(alert.getContext() != null);
-        assertTrue(alert.getContext().size() == 2);
-        assertTrue(alert.getContext().get("n1").equals("v1"));
-        assertTrue(alert.getContext().get("n2").equals("v2"));
+        assertNotNull(alert.getContext());
+        assertEquals(2, alert.getContext().size());
+        assertEquals("v1", alert.getContext().get("n1"));
+        assertEquals("v2", alert.getContext().get("n2"));
+        assertEquals(Alert.Status.OPEN, alert.getCurrentLifecycle().getStatus());
+        assertEquals("system", alert.getCurrentLifecycle().getUser());
+        assertEquals(1, alert.getCurrentLifecycle().getStime());
         assertEquals("trigger-test", alert.getText());
 
         /*
@@ -1285,21 +1285,14 @@ public class JsonTest {
                                         "]" + // Close Set
                                     "]," + // Close List
                                     "\"severity\":\"HIGH\"," +
-                                    "\"status\":\"OPEN\"," +
-                                    "\"ackTime\":0," +
-                                    "\"ackBy\":null," +
-                                    "\"resolvedTime\":0," +
-                                    "\"resolvedBy\":null" +
+                                    "\"status\":\"OPEN\"" +
                                 "}" + // End value
                             "}" + // End Condition Eval
                         "]" +   // End Set
                     "]," +  // End List
                     "\"severity\":\"HIGH\"," +
-                    "\"status\":\"OPEN\"," +
-                    "\"ackTime\":0," +
-                    "\"ackBy\":null," +
-                    "\"resolvedTime\":0," +
-                    "\"resolvedBy\":null}," +
+                    "\"status\":\"OPEN\"" +
+                    "}," +
                 "\"properties\":{" +
                     "\"cc\":\"cc-group@hawkular.org\"," +
                     "\"template.html\":\"\"," +

--- a/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/hawkular-alerts-api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -199,6 +199,8 @@ public class JsonTest {
         assertEquals(Alert.Status.OPEN, alert.getCurrentLifecycle().getStatus());
         assertEquals("system", alert.getCurrentLifecycle().getUser());
         assertEquals(1, alert.getCurrentLifecycle().getStime());
+        assertNotNull(alert.getLastOpenTime());
+        assertEquals(1, alert.getLastOpenTime().longValue());
         assertEquals("trigger-test", alert.getText());
 
         /*

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassAlertsServiceImpl.java
@@ -1314,11 +1314,8 @@ public class CassAlertsServiceImpl implements AlertsService {
         List<Alert> alertsToAck = getAlerts(tenantId, criteria, null);
 
         for (Alert a : alertsToAck) {
-            a.setStatus(Status.ACKNOWLEDGED);
-            a.setAckBy(ackBy);
-            a.setAckTime(System.currentTimeMillis());
             a.addNote(ackBy, ackNotes);
-            a.addLifecycle(a.getStatus(), a.getAckBy(), a.getAckTime());
+            a.addLifecycle(Status.ACKNOWLEDGED, ackBy, System.currentTimeMillis());
             updateAlertStatus(a);
             sendAction(a);
         }
@@ -1436,12 +1433,9 @@ public class CassAlertsServiceImpl implements AlertsService {
 
         // resolve the alerts
         for (Alert a : alertsToResolve) {
-            a.setStatus(Status.RESOLVED);
-            a.setResolvedBy(resolvedBy);
-            a.setResolvedTime(System.currentTimeMillis());
             a.addNote(resolvedBy, resolvedNotes);
             a.setResolvedEvalSets(resolvedEvalSets);
-            a.addLifecycle(a.getStatus(), a.getResolvedBy(), a.getResolvedTime());
+            a.addLifecycle(Status.RESOLVED, resolvedBy, System.currentTimeMillis());
             updateAlertStatus(a);
             sendAction(a);
         }
@@ -1477,12 +1471,9 @@ public class CassAlertsServiceImpl implements AlertsService {
         List<Alert> alertsToResolve = getAlerts(tenantId, criteria, null);
 
         for (Alert a : alertsToResolve) {
-            a.setStatus(Status.RESOLVED);
-            a.setResolvedBy(resolvedBy);
-            a.setResolvedTime(System.currentTimeMillis());
             a.addNote(resolvedBy, resolvedNotes);
             a.setResolvedEvalSets(resolvedEvalSets);
-            a.addLifecycle(a.getStatus(), a.getResolvedBy(), a.getResolvedTime());
+            a.addLifecycle(Status.RESOLVED, resolvedBy, System.currentTimeMillis());
             updateAlertStatus(a);
             sendAction(a);
         }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -159,7 +159,8 @@ class LifecycleITest extends AbstractITestBase {
         resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
         assertEquals(200, resp.status)
         assertEquals("RESOLVED", resp.data[0].status)
-        assertEquals("testUser", resp.data[0].resolvedBy)
+        assertEquals(2, resp.data[0].lifecycle.size())
+        assertEquals("testUser", resp.data[0].lifecycle[1].user)
         assertEquals("testNotes", resp.data[0].notes[0].text)
         assertNull(resp.data[0].resolvedEvalSets)
         assertNotNull(resp.data[0].trigger.context);
@@ -275,7 +276,8 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals("ACKNOWLEDGED", resp.data[0].status)
         assertEquals("HIGH", resp.data[0].severity)
-        assertEquals("testUser", resp.data[0].ackBy)
+        assertEquals(2, resp.data[0].lifecycle.size())
+        assertEquals("testUser", resp.data[0].lifecycle[1].user)
         assertEquals("testNotes", resp.data[0].notes[0].text)
 
         // FETCH trigger and make sure it's still enabled (note - we can't check the mode as that is runtime
@@ -310,7 +312,8 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
         assertEquals("RESOLVED", resp.data[0].status)
-        assertEquals("AutoResolve", resp.data[0].resolvedBy)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
     }
 
     @Test
@@ -538,7 +541,8 @@ class LifecycleITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
         assertEquals("RESOLVED", resp.data[0].status)
-        assertEquals("AutoResolve", resp.data[0].resolvedBy)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
         assertNotNull(resp.data[0].evalSets)
         assertNotNull(resp.data[0].resolvedEvalSets)
         assertFalse(resp.data[0].evalSets.isEmpty())
@@ -548,7 +552,8 @@ class LifecycleITest extends AbstractITestBase {
             query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:true] )
         assertEquals(200, resp.status)
         assertEquals("RESOLVED", resp.data[0].status)
-        assertEquals("AutoResolve", resp.data[0].resolvedBy)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
         assertNull(resp.data[0].evalSets)
         assertNull(resp.data[0].resolvedEvalSets)
     }


### PR DESCRIPTION
This PR drops the old resolved* and ack* fields with new lifecycle list on Alert.
This change is propagated into actions architecture and plugins.