### PR TITLE
[WIP] HWKALERTS-169 Global front-line filtering

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/CacheKey.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/CacheKey.java
@@ -22,13 +22,11 @@ public class CacheKey implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String tenantId;
-    private String dataIdPrefix;
-    private String dataIdSuffix;
+    private String dataId;
 
-    public CacheKey(String tenantId, String dataIdPrefix, String dataIdSuffix) {
+    public CacheKey(String tenantId, String dataId) {
         this.tenantId = tenantId;
-        this.dataIdPrefix = null != dataIdPrefix ? dataIdPrefix : "";
-        this.dataIdSuffix = dataIdSuffix;
+        this.dataId = dataId;
     }
 
     public String getTenantId() {
@@ -39,28 +37,19 @@ public class CacheKey implements Serializable {
         this.tenantId = tenantId;
     }
 
-    public String getDataIdPrefix() {
-        return dataIdPrefix;
+    public String getDataId() {
+        return dataId;
     }
 
-    public void setDataIdPrefix(String dataIdPrefix) {
-        this.dataIdPrefix = dataIdPrefix;
-    }
-
-    public String getDataIdSuffix() {
-        return dataIdSuffix;
-    }
-
-    public void setDataIdSuffix(String dataIdSuffix) {
-        this.dataIdSuffix = dataIdSuffix;
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((dataIdPrefix == null) ? 0 : dataIdPrefix.hashCode());
-        result = prime * result + ((dataIdSuffix == null) ? 0 : dataIdSuffix.hashCode());
+        result = prime * result + ((dataId == null) ? 0 : dataId.hashCode());
         result = prime * result + ((tenantId == null) ? 0 : tenantId.hashCode());
         return result;
     }
@@ -74,15 +63,10 @@ public class CacheKey implements Serializable {
         if (getClass() != obj.getClass())
             return false;
         CacheKey other = (CacheKey) obj;
-        if (dataIdPrefix == null) {
-            if (other.dataIdPrefix != null)
+        if (dataId == null) {
+            if (other.dataId != null)
                 return false;
-        } else if (!dataIdPrefix.equals(other.dataIdPrefix))
-            return false;
-        if (dataIdSuffix == null) {
-            if (other.dataIdSuffix != null)
-                return false;
-        } else if (!dataIdSuffix.equals(other.dataIdSuffix))
+        } else if (!dataId.equals(other.dataId))
             return false;
         if (tenantId == null) {
             if (other.tenantId != null)
@@ -94,8 +78,7 @@ public class CacheKey implements Serializable {
 
     @Override
     public String toString() {
-        return "CacheKey [tenantId=" + tenantId + ", dataIdPrefix=" + dataIdPrefix + ", dataIdSuffix=" + dataIdSuffix
-                + "]";
+        return "CacheKey [tenantId=" + tenantId + ", dataId=" + dataId + "]";
     }
 
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/CacheClient.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/CacheClient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.cache;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.hawkular.alerts.api.model.data.CacheKey;
+import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.event.Event;
+import org.infinispan.Cache;
+
+/**
+ * Provide access to the cache of dataIds in use by the global trigger population (not node specific). It is
+ * used to perform front-line filtering of incoming data and events.  Data with dataIds not found in this cache
+ * can be immediately discarded as it is not needed for trigger evaluation (on this or or other alerting nodes).
+ *
+ * The cache is a shared ISPN cache.
+ *
+ * @author Lucas Ponce
+ * @author Jay Shaughnessy
+ */
+@ApplicationScoped
+public class CacheClient {
+
+    /** key=dataId, value="" */
+    @Resource(lookup = "java:jboss/infinispan/cache/hawkular-alerts/publish")
+    private Cache<CacheKey, String> cache;
+
+    public Set<CacheKey> keySet() {
+        return cache.keySet();
+    }
+
+    public boolean containsKey(CacheKey key) {
+        return cache.containsKey(key);
+    }
+
+    public String get(CacheKey key) {
+        return cache.get(key);
+    }
+
+    public Collection<Data> filterData(Collection<Data> data) {
+        final CacheKey tester = new CacheKey("", "");
+        return data.stream()
+                .filter(d -> cache.containsKey(fillKey(tester, d)))
+                .collect(Collectors.toList());
+    }
+
+    public Collection<Event> filterEvents(Collection<Event> events) {
+        final CacheKey tester = new CacheKey("", "");
+        return events.stream()
+                .filter(e -> cache.containsKey(fillKey(tester, e)))
+                .collect(Collectors.toList());
+    }
+
+    private CacheKey fillKey(CacheKey key, Data data) {
+        key.setTenantId(data.getTenantId());
+        key.setDataId(data.getId());
+        return key;
+    }
+
+    private CacheKey fillKey(CacheKey key, Event event) {
+        key.setTenantId(event.getTenantId());
+        key.setDataId(event.getDataId());
+        return key;
+    }
+
+}

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/web.xml
@@ -70,4 +70,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/data</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/publish</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
+  </resource-env-ref>
+
 </web-app>

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/web.xml
@@ -70,4 +70,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/data</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/publish</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
+  </resource-env-ref>
+
 </web-app>

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/web.xml
@@ -41,4 +41,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/data</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/publish</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
+  </resource-env-ref>
+
 </web-app>


### PR DESCRIPTION
- maintain the publish cache but makes alerting its client (as
  opposed to metrics, for example).
- simplify CacheManager and CacheKey to be based only on tenantId
  and dataId.
- perform global front-line filtering in AlertsService, as Data and
  Events come into the system.
- optimize the engine to use the node-specific AlertsEngineCache
  only in distributed deployment.  With global front-line filtering the
  node-specific filtering is redundant in the single node use case.
* sorry for some formatting changes, eclipse seems to be struggling with
  some of the long stream and lambda stuff.