### PR TITLE
HWKALERTS-173

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/CacheManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/CacheManager.java
@@ -33,7 +33,6 @@ import javax.ejb.TransactionAttributeType;
 
 import org.hawkular.alerts.api.model.condition.CompareCondition;
 import org.hawkular.alerts.api.model.condition.Condition;
-import org.hawkular.alerts.api.model.condition.ExternalCondition;
 import org.hawkular.alerts.api.model.data.CacheKey;
 import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.api.services.PropertiesService;
@@ -106,12 +105,6 @@ public class CacheManager {
             Collection<Condition> conditions = definitions.getAllConditions();
             final Set<CacheKey> activeKeys = new HashSet<>();
             for (Condition c : conditions) {
-                // external conditions are evaluated by the relevant external alerter. Data is not metrics-based
-                // so don't waste energy adding it to the publishing cache.
-                if (c instanceof ExternalCondition) {
-                    continue;
-                }
-
                 CacheKey cacheKey = new CacheKey(c.getTenantId(), c.getDataId());
                 if (!activeKeys.contains(cacheKey)) {
                     activeKeys.add(cacheKey);


### PR DESCRIPTION
The filtering of ExternalCondition dataIds was valid when we were filtering inside Hmetrics, because the ids were not metrics-based, but it is not valid to filter out all ExternalCondition dataIds now that
we're doing front-line filtering.

@lucasponce Please review and merge.