### PR TITLE
HWKALERTS-176 Add support for MissingConditions

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/JacksonDeserializer.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/json/JacksonDeserializer.java
@@ -35,6 +35,8 @@ import org.hawkular.alerts.api.model.condition.EventCondition;
 import org.hawkular.alerts.api.model.condition.EventConditionEval;
 import org.hawkular.alerts.api.model.condition.ExternalCondition;
 import org.hawkular.alerts.api.model.condition.ExternalConditionEval;
+import org.hawkular.alerts.api.model.condition.MissingCondition;
+import org.hawkular.alerts.api.model.condition.MissingConditionEval;
 import org.hawkular.alerts.api.model.condition.RateCondition;
 import org.hawkular.alerts.api.model.condition.RateConditionEval;
 import org.hawkular.alerts.api.model.condition.StringCondition;
@@ -152,6 +154,22 @@ public class JacksonDeserializer {
                         eConditionEval.setCondition((ExternalCondition) condition);
                         if (node.get("value") != null) {
                             eConditionEval.setValue(node.get("value").textValue());
+                        }
+                    } catch (Exception e) {
+                        throw new ConditionEvalException(e);
+                    }
+                    break;
+                }
+                case MISSING: {
+                    try {
+                        conditionEval = new MissingConditionEval();
+                        MissingConditionEval mConditionEval = (MissingConditionEval) conditionEval;
+                        mConditionEval.setCondition((MissingCondition) condition);
+                        if (node.get("previousTime") != null) {
+                            mConditionEval.setPreviousTime(node.get("previousTime").longValue());
+                        }
+                        if (node.get("time") != null) {
+                            mConditionEval.setTime(node.get("time").longValue());
                         }
                     } catch (Exception e) {
                         throw new ConditionEvalException(e);
@@ -397,6 +415,21 @@ public class JacksonDeserializer {
                     }
                     if (node.get("expression") != null) {
                         evCondition.setExpression(node.get("expression").textValue());
+                    }
+                } catch (Exception e) {
+                    throw new ConditionException(e);
+                }
+                break;
+            }
+            case MISSING: {
+                try {
+                    condition = new MissingCondition();
+                    MissingCondition mCondition = (MissingCondition) condition;
+                    if (node.get("dataId") != null) {
+                        mCondition.setDataId(node.get("dataId").textValue());
+                    }
+                    if (node.get("interval") != null) {
+                        mCondition.setInterval(node.get("interval").longValue());
                     }
                 } catch (Exception e) {
                     throw new ConditionException(e);

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -39,7 +39,7 @@ public abstract class Condition implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public enum Type {
-        AVAILABILITY, COMPARE, STRING, THRESHOLD, RANGE, EXTERNAL, EVENT, RATE
+        AVAILABILITY, COMPARE, STRING, THRESHOLD, RANGE, EXTERNAL, EVENT, RATE, MISSING
     }
 
     @JsonInclude

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/MissingCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/MissingCondition.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.model.condition;
+
+import org.hawkular.alerts.api.model.trigger.Mode;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * A <code>MissingCondition</code> is used to evaluate when a data or an event has not been received on time interval.
+ *
+ * A MissingCondition will be evaluated to true when a data/event has not been received in the last interval time
+ * starting to count from trigger was enabled or last received data/event.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class MissingCondition extends Condition {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonInclude
+    private String dataId;
+
+    @JsonInclude(Include.NON_NULL)
+    private long interval;
+
+    public MissingCondition() {
+        this("", "", Mode.FIRING, 1, 1, null, 0L);
+    }
+
+    public MissingCondition(String tenantId, String triggerId, String dataId, long interval) {
+        this(tenantId, triggerId, Mode.FIRING, 1, 1, dataId, interval);
+    }
+
+    public MissingCondition(String tenantId, String triggerId, Mode triggerMode, String dataId, long interval) {
+        this(tenantId, triggerId, triggerMode, 1, 1, dataId, interval);
+    }
+
+    /**
+     * This constructor requires the tenantId be assigned prior to persistence. It can be used when
+     * creating triggers via Rest, as the tenant will be assigned automatically.
+     */
+    public MissingCondition(String triggerId, Mode triggerMode, String dataId, long interval) {
+        this("", triggerId, triggerMode, 1, 1, dataId, interval);
+    }
+
+    public MissingCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+            int conditionSetIndex, String dataId, long interval) {
+        super(tenantId, triggerId, (null == triggerMode ? Mode.FIRING : triggerMode), conditionSetSize,
+                conditionSetIndex, Type.MISSING);
+        this.dataId = dataId;
+        this.interval = interval;
+    }
+
+    @Override
+    public String getDataId() {
+        return dataId;
+    }
+
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public boolean match(long previousTime, long time) {
+        return (previousTime + interval) < time;
+    }
+
+    public String getLog(long previousTime, long time) {
+        return triggerId + " : " +  dataId + " at " + time + ". Previous time: " + previousTime + " . Interval: "
+                + interval;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        MissingCondition that = (MissingCondition) o;
+
+        if (interval != that.interval) return false;
+        return dataId != null ? dataId.equals(that.dataId) : that.dataId == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (dataId != null ? dataId.hashCode() : 0);
+        result = 31 * result + (int) (interval ^ (interval >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MissingCondition{" +
+                "dataId='" + dataId + '\'' +
+                ", interval=" + interval +
+                '}';
+    }
+}

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/MissingConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/MissingConditionEval.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.model.condition;
+
+import java.util.HashMap;
+
+import org.hawkular.alerts.api.model.condition.Condition.Type;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * An evaluation state for MissingCondition
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class MissingConditionEval extends ConditionEval {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonInclude(Include.NON_NULL)
+    private MissingCondition condition;
+
+    @JsonInclude
+    private long previousTime;
+
+    @JsonInclude
+    private long time;
+
+    /**
+     * Used for JSON deserialization, not for general use.
+     */
+    public MissingConditionEval() {
+        super(Type.MISSING, false, 0, null);
+        this.previousTime = 0L;
+        this.time = 0L;
+    }
+
+    public MissingConditionEval(MissingCondition condition, long previousTime, long time) {
+        super(Type.MISSING, condition.match(previousTime, time), time, new HashMap<>());
+        this.condition = condition;
+        this.previousTime = previousTime;
+        this.time = time;
+    }
+
+    @Override
+    public String getTenantId() {
+        return condition.getTenantId();
+    }
+
+    @Override
+    public String getTriggerId() {
+        return condition.getTriggerId();
+    }
+
+    @Override
+    public int getConditionSetSize() {
+        return condition.getConditionSetSize();
+    }
+
+    @Override
+    public int getConditionSetIndex() {
+        return condition.getConditionSetIndex();
+    }
+
+    @Override
+    public String getLog() {
+        return condition.getLog(previousTime, time);
+    }
+
+    public MissingCondition getCondition() {
+        return condition;
+    }
+
+    public void setCondition(MissingCondition condition) {
+        this.condition = condition;
+    }
+
+    public long getPreviousTime() {
+        return previousTime;
+    }
+
+    public void setPreviousTime(long previousTime) {
+        this.previousTime = previousTime;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        MissingConditionEval that = (MissingConditionEval) o;
+
+        if (previousTime != that.previousTime) return false;
+        if (time != that.time) return false;
+        return condition != null ? condition.equals(that.condition) : that.condition == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (condition != null ? condition.hashCode() : 0);
+        result = 31 * result + (int) (previousTime ^ (previousTime >>> 32));
+        result = 31 * result + (int) (time ^ (time >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MissingConditionEval{" +
+                "condition=" + condition +
+                ", previousTime=" + previousTime +
+                ", time=" + time +
+                '}';
+    }
+}

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -375,7 +375,8 @@ public class Event implements Comparable<Event>, Serializable {
     @Override
     public String toString() {
         return "Event [tenantId=" + tenantId + ", id=" + id + ", ctime=" + ctime + ", category=" + category
-                + ", text=" + text + ", context=" + context + ", tags=" + tags + ", trigger=" + trigger + "]";
+                + ", dataId=" + dataId + ", dataSource=" + dataSource + ", text=" + text + ", context=" + context + ", " +
+                "tags=" + tags + ", trigger=" + trigger + "]";
     }
 
     /* (non-Javadoc)

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -704,8 +704,8 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                 missingState.setPreviousTime(System.currentTimeMillis());
                 missingState.setTime(System.currentTimeMillis());
                 rules.addFact(missingState);
-                rules.addFact(eval);
             }
+            rules.addFact(eval);
         });
     }
 

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -453,7 +453,8 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
             Iterator<MissingState> it = missingStates.iterator();
             while (it.hasNext()) {
                 MissingState missingState = it.next();
-                if (missingState.getTriggerId().equals(triggerId)) {
+                if (missingState.getTenantId().equals(trigger.getTenantId()) &&
+                        missingState.getTriggerId().equals(triggerId)) {
                     it.remove();
                 }
             }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -79,6 +79,7 @@ public class CassStatement {
     public static final String INSERT_CONDITION_COMPARE;
     public static final String INSERT_CONDITION_EVENT;
     public static final String INSERT_CONDITION_EXTERNAL;
+    public static final String INSERT_CONDITION_MISSING;
     public static final String INSERT_CONDITION_RATE;
     public static final String INSERT_CONDITION_STRING;
     public static final String INSERT_CONDITION_THRESHOLD;
@@ -290,6 +291,10 @@ public class CassStatement {
                 + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
                 "conditionId, dataId, operator, pattern) VALUES (?, ?, ?, 'EXTERNAL', ?, ?, ?, ?, ?, ?, ?) ";
 
+        INSERT_CONDITION_MISSING = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, interval) VALUES (?, ?, ?, 'MISSING', ?, ?, ?, ?, ?, ?) ";
+
         INSERT_CONDITION_RATE = "INSERT INTO " + keyspace + ".conditions "
                 + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, "
                 + "conditionId, dataId, direction, period, operator, threshold) "
@@ -421,20 +426,20 @@ public class CassStatement {
         SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context "
+                + "direction, period, tenantId, context, interval "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND conditionId = ? ";
 
         SELECT_CONDITIONS_ALL = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context "
+                + "direction, period, tenantId, context, interval "
                 + "FROM " + keyspace + ".conditions ";
 
         SELECT_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context "
+                + "direction, period, tenantId, context, interval "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? ";
 
@@ -504,14 +509,14 @@ public class CassStatement {
         SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context "
+                + "direction, period, tenantId, context, interval "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ?";
 
         SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, ignoreCase, "
                 + "threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context "
+                + "direction, period, tenantId, context, interval "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
 

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
@@ -43,20 +43,20 @@ public class MissingState {
 
     private long time;
 
-    public MissingState(Trigger trigger, MissingCondition condition) {
-        this(trigger.getTenantId(), trigger.getId(), condition.getTriggerMode(), trigger.getSource(),
-                condition.getDataId(), System.currentTimeMillis(), System.currentTimeMillis());
-    }
+    private String conditionId;
 
-    public MissingState(String tenantId, String triggerId, Mode triggerMode, String source, String dataId,
-        long previousTime, long time) {
-        this.tenantId = tenantId;
-        this.triggerId = triggerId;
-        this.triggerMode = triggerMode;
-        this.source = source;
-        this.dataId = dataId;
-        this.previousTime = previousTime;
-        this.time = time;
+    private MissingCondition condition;
+
+    public MissingState(Trigger trigger, MissingCondition condition) {
+        this.tenantId = trigger.getTenantId();
+        this.triggerId = trigger.getId();
+        this.triggerMode = condition.getTriggerMode();
+        this.source = trigger.getSource();
+        this.dataId = condition.getDataId();
+        this.previousTime = System.currentTimeMillis();
+        this.time = System.currentTimeMillis();
+        this.conditionId = condition.getConditionId();
+        this.condition = condition;
     }
 
     public String getTenantId() {
@@ -115,6 +115,25 @@ public class MissingState {
         this.time = time;
     }
 
+    public String getConditionId() {
+        return conditionId;
+    }
+
+    public void setConditionId(String conditionId) {
+        this.conditionId = conditionId;
+    }
+
+    public MissingCondition getCondition() {
+        return condition;
+    }
+
+    public void setCondition(MissingCondition condition) {
+        this.condition = condition;
+    }
+
+    /*
+            Due performance reasons, conditionId will be used for equals()/hashCode() instead of condition
+         */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -128,7 +147,8 @@ public class MissingState {
         if (triggerId != null ? !triggerId.equals(that.triggerId) : that.triggerId != null) return false;
         if (triggerMode != that.triggerMode) return false;
         if (source != null ? !source.equals(that.source) : that.source != null) return false;
-        return dataId != null ? dataId.equals(that.dataId) : that.dataId == null;
+        if (dataId != null ? !dataId.equals(that.dataId) : that.dataId != null) return false;
+        return conditionId != null ? conditionId.equals(that.conditionId) : that.conditionId == null;
 
     }
 
@@ -141,6 +161,7 @@ public class MissingState {
         result = 31 * result + (dataId != null ? dataId.hashCode() : 0);
         result = 31 * result + (int) (previousTime ^ (previousTime >>> 32));
         result = 31 * result + (int) (time ^ (time >>> 32));
+        result = 31 * result + (conditionId != null ? conditionId.hashCode() : 0);
         return result;
     }
 
@@ -154,6 +175,8 @@ public class MissingState {
                 ", dataId='" + dataId + '\'' +
                 ", previousTime=" + previousTime +
                 ", time=" + time +
+                ", conditionId='" + conditionId + '\'' +
+                ", condition=" + condition +
                 '}';
     }
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.util;
+
+import org.hawkular.alerts.api.model.condition.MissingCondition;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * MissingConditions detects when there is a missing data or event within a defined time interval.
+ * This class stores a last evaluation time of a missing data.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class MissingState {
+
+    private String tenantId;
+
+    private String triggerId;
+
+    private Mode triggerMode;
+
+    private String source;
+
+    private String dataId;
+
+    private long previousTime;
+
+    private long time;
+
+    public MissingState(Trigger trigger, MissingCondition condition) {
+        this(trigger.getTenantId(), trigger.getId(), condition.getTriggerMode(), trigger.getSource(),
+                condition.getDataId(), System.currentTimeMillis(), System.currentTimeMillis());
+    }
+
+    public MissingState(String tenantId, String triggerId, Mode triggerMode, String source, String dataId,
+        long previousTime, long time) {
+        this.tenantId = tenantId;
+        this.triggerId = triggerId;
+        this.triggerMode = triggerMode;
+        this.source = source;
+        this.dataId = dataId;
+        this.previousTime = previousTime;
+        this.time = time;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getTriggerId() {
+        return triggerId;
+    }
+
+    public void setTriggerId(String triggerId) {
+        this.triggerId = triggerId;
+    }
+
+    public Mode getTriggerMode() {
+        return triggerMode;
+    }
+
+    public void setTriggerMode(Mode triggerMode) {
+        this.triggerMode = triggerMode;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getDataId() {
+        return dataId;
+    }
+
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
+    }
+
+    public long getPreviousTime() {
+        return previousTime;
+    }
+
+    public void setPreviousTime(long previousTime) {
+        this.previousTime = previousTime;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MissingState that = (MissingState) o;
+
+        if (previousTime != that.previousTime) return false;
+        if (time != that.time) return false;
+        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (triggerId != null ? !triggerId.equals(that.triggerId) : that.triggerId != null) return false;
+        if (triggerMode != that.triggerMode) return false;
+        if (source != null ? !source.equals(that.source) : that.source != null) return false;
+        return dataId != null ? dataId.equals(that.dataId) : that.dataId == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tenantId != null ? tenantId.hashCode() : 0;
+        result = 31 * result + (triggerId != null ? triggerId.hashCode() : 0);
+        result = 31 * result + (triggerMode != null ? triggerMode.hashCode() : 0);
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        result = 31 * result + (dataId != null ? dataId.hashCode() : 0);
+        result = 31 * result + (int) (previousTime ^ (previousTime >>> 32));
+        result = 31 * result + (int) (time ^ (time >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MissingState{" +
+                "tenantId='" + tenantId + '\'' +
+                ", triggerId='" + triggerId + '\'' +
+                ", triggerMode=" + triggerMode +
+                ", source='" + source + '\'' +
+                ", dataId='" + dataId + '\'' +
+                ", previousTime=" + previousTime +
+                ", time=" + time +
+                '}';
+    }
+}

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -264,47 +264,32 @@ rule Rate
         insert( ce );
 end
 
-// Use a higher salience here to ensure that MissingState is always updated before Missing performs the evaluation
 rule UpdateMissingStateFromData
-    salience 100
     when
-        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, $time : time )
+        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
         $d  : Data( tenantId == $tenantId, source == $tsource, id == $did)
    then
-        $md.setPreviousTime($d.getTimestamp());
-        $md.setTime($d.getTimestamp());
         if (log != null && log.isDebugEnabled()) {
             log.debugf("UpdateMissingStateFromData: %s ", $md);
         }
-        retract( $md )
+        modify( $md ) {
+            setPreviousTime($d.getTimestamp()),
+            setTime($d.getTimestamp())
+        }
 end
 
 rule UpdateMissingStateFromEvent
-    salience 100
     when
-        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, $time : time )
+        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
         $e  : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did)
     then
-        $md.setPreviousTime($e.getCtime());
-        $md.setTime($e.getCtime());
         if (log != null && log.isDebugEnabled()) {
             log.debugf("UpdateMissingStateFromEvent: %s ", $md);
         }
-        retract( $md )
-end
-
-rule Missing
-    when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
-        $c  : MissingCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
-        $md : MissingState( tenantId == $tenantId, source == $tsource, dataId == $did, previousTime < time )
-    then
-        MissingConditionEval ce = new MissingConditionEval($c, $md.getPreviousTime(), $md.getTime());
-        if (log != null && log.isDebugEnabled()) {
-            log.debugf("Missing Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getLog());
-        }
-        retract( $md )
-        insert( ce );
+        modify( $md ) {
+            setPreviousTime($e.getCtime()),
+            setTime($e.getCtime())
+        };
 end
 
 // Data retraction rules
@@ -318,13 +303,14 @@ rule RetractProcessedRateData
         $rd : RateData( $tenantId : data.tenantId, $dsource : data.source, $did : data.id )
         $d  : Data( tenantId == $tenantId, source == $dsource, id == $did )
     then
-        $rd.setData( $d );
         if (log != null && log.isDebugEnabled()) {
             log.debugf("Retracting %s", $d);
             log.debugf("Updating %s", $rd);
         }
         retract ( $d );
-        update ( $rd );
+        modify ( $rd ) {
+            setData( $d )
+        }
 end
 
 rule RetractProcessedData

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -26,6 +26,8 @@ import org.hawkular.alerts.api.model.condition.ExternalCondition;
 import org.hawkular.alerts.api.model.condition.ExternalConditionEval;
 import org.hawkular.alerts.api.model.condition.EventCondition;
 import org.hawkular.alerts.api.model.condition.EventConditionEval;
+import org.hawkular.alerts.api.model.condition.MissingCondition;
+import org.hawkular.alerts.api.model.condition.MissingConditionEval;
 import org.hawkular.alerts.api.model.condition.StringCondition;
 import org.hawkular.alerts.api.model.condition.StringConditionEval;
 import org.hawkular.alerts.api.model.condition.ThresholdCondition;
@@ -46,6 +48,7 @@ import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.alerts.api.model.trigger.TriggerAction;
 import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.engine.util.CompareData;
+import org.hawkular.alerts.engine.util.MissingState;
 import org.hawkular.alerts.engine.util.RateData;
 
 import org.jboss.logging.Logger;
@@ -54,7 +57,8 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.List;
 import java.util.Map;
-import org.hawkular.alerts.engine.util.ActionsValidator;
+import org.hawkular.alerts.engine.util.ActionsValidator
+import org.hawkular.alerts.engine.util.MissingState;
 
 global Logger log;
 global ActionsService actions;
@@ -63,7 +67,7 @@ global List events;
 global Set pendingTimeouts;
 global Map autoResolvedTriggers;
 global Set disabledTriggers;
-
+global Set missingStates
 
 ////// CONDITION MATCHING
 //
@@ -260,6 +264,48 @@ rule Rate
         insert( ce );
 end
 
+// Use a higher salience here to ensure that MissingState is always updated before Missing performs the evaluation
+rule UpdateMissingStateFromData
+    salience 100
+    when
+        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, $time : time )
+        $d  : Data( tenantId == $tenantId, source == $tsource, id == $did)
+   then
+        $md.setPreviousTime($d.getTimestamp());
+        $md.setTime($d.getTimestamp());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("UpdateMissingStateFromData: %s ", $md);
+        }
+        retract( $md )
+end
+
+rule UpdateMissingStateFromEvent
+    salience 100
+    when
+        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, $time : time )
+        $e  : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did)
+    then
+        $md.setPreviousTime($e.getCtime());
+        $md.setTime($e.getCtime());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("UpdateMissingStateFromEvent: %s ", $md);
+        }
+        retract( $md )
+end
+
+rule Missing
+    when
+        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $c  : MissingCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
+        $md : MissingState( tenantId == $tenantId, source == $tsource, dataId == $did, previousTime < time )
+    then
+        MissingConditionEval ce = new MissingConditionEval($c, $md.getPreviousTime(), $md.getTime());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Missing Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getLog());
+        }
+        retract( $md )
+        insert( ce );
+end
 
 // Data retraction rules
 // These rules are expected to fire after any Eval rules, due to their simplicity.  Note that Data is not retracted

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -67,7 +67,6 @@ global List events;
 global Set pendingTimeouts;
 global Map autoResolvedTriggers;
 global Set disabledTriggers;
-global Set missingStates
 
 ////// CONDITION MATCHING
 //
@@ -266,18 +265,19 @@ end
 
 rule UpdateMissingStateFromData
     when
-        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
+        $ms : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
         $d  : Data( tenantId == $tenantId, source == $tsource, id == $did)
    then
         if (log != null && log.isDebugEnabled()) {
-            log.debugf("UpdateMissingStateFromData: %s ", $md);
+            log.debugf("UpdateMissingStateFromData: %s ", $ms);
         }
-        modify( $md ) {
+        // MissingState object is referenced in the AlertsEngineImpl.missingStates set
+        modify( $ms ) {
             setPreviousTime($d.getTimestamp()),
             setTime($d.getTimestamp())
         }
         // We now is a non matching eval but needed for Dampening
-        MissingConditionEval mce = new MissingConditionEval( $md.getCondition(), $md.getPreviousTime(), $md.getTime());
+        MissingConditionEval mce = new MissingConditionEval( $ms.getCondition(), $ms.getPreviousTime(), $ms.getTime());
         if (log != null && log.isDebugEnabled()) {
             log.debugf("MissingConditionEval : %s %s", (mce.isMatch() ? "Match!" : "no match"), mce.getLog());
         }
@@ -286,18 +286,19 @@ end
 
 rule UpdateMissingStateFromEvent
     when
-        $md : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
+        $ms : MissingState( $tenantId : tenantId, $tsource : source, $did : dataId, previousTime < time )
         $e  : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did)
     then
         if (log != null && log.isDebugEnabled()) {
-            log.debugf("UpdateMissingStateFromEvent: %s ", $md);
+            log.debugf("UpdateMissingStateFromEvent: %s ", $ms);
         }
-        modify( $md ) {
+        // MissingState object is referenced in the AlertsEngineImpl.missingStates set
+        modify( $ms ) {
             setPreviousTime($e.getCtime()),
             setTime($e.getCtime())
         };
         // We now is a non matching eval but needed for Dampening
-        MissingConditionEval mce = new MissingConditionEval( $md.getCondition(), $md.getPreviousTime(), $md.getTime());
+        MissingConditionEval mce = new MissingConditionEval( $ms.getCondition(), $ms.getPreviousTime(), $ms.getTime());
         if (log != null && log.isDebugEnabled()) {
             log.debugf("MissingConditionEval : %s %s", (mce.isMatch() ? "Match!" : "no match"), mce.getLog());
         }

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -276,6 +276,12 @@ rule UpdateMissingStateFromData
             setPreviousTime($d.getTimestamp()),
             setTime($d.getTimestamp())
         }
+        // We now is a non matching eval but needed for Dampening
+        MissingConditionEval mce = new MissingConditionEval( $md.getCondition(), $md.getPreviousTime(), $md.getTime());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("MissingConditionEval : %s %s", (mce.isMatch() ? "Match!" : "no match"), mce.getLog());
+        }
+        insert( mce );
 end
 
 rule UpdateMissingStateFromEvent
@@ -290,6 +296,12 @@ rule UpdateMissingStateFromEvent
             setPreviousTime($e.getCtime()),
             setTime($e.getCtime())
         };
+        // We now is a non matching eval but needed for Dampening
+        MissingConditionEval mce = new MissingConditionEval( $md.getCondition(), $md.getPreviousTime(), $md.getTime());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("MissingConditionEval : %s %s", (mce.isMatch() ? "Match!" : "no match"), mce.getLog());
+        }
+        insert( mce );
 end
 
 // Data retraction rules

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/checker.cql
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/checker.cql
@@ -46,6 +46,11 @@ WHERE keyspace_name='${keyspace}' AND table_name = 'conditions';
 
 -- #
 
+SELECT column_name FROM system_schema.columns
+WHERE keyspace_name='${keyspace}' AND table_name = 'conditions' AND column_name = 'interval';
+
+-- #
+
 SELECT table_name FROM system_schema.tables
 WHERE keyspace_name='${keyspace}' AND table_name = 'dampenings';
 

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.2.3.groovy
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.2.3.groovy
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.schema
-
-include '/org/hawkular/alerts/schema/bootstrap.groovy'
 
 setKeyspace keyspace
 
-// Upgrade scripts are defined here:
-include '/org/hawkular/alerts/schema/updates/schema-1.2.1.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.2.3.groovy'
+schemaChange {
+  version '2.0'
+  author 'lponce'
+  tags '1.2.x'
+  cql "ALTER TABLE conditions ADD interval bigint"
+}

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
@@ -40,6 +40,7 @@ import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.condition.EventCondition;
 import org.hawkular.alerts.api.model.condition.ExternalCondition;
 import org.hawkular.alerts.api.model.condition.ExternalConditionEval;
+import org.hawkular.alerts.api.model.condition.MissingCondition;
 import org.hawkular.alerts.api.model.condition.RateCondition;
 import org.hawkular.alerts.api.model.condition.RateConditionEval;
 import org.hawkular.alerts.api.model.condition.StringCondition;
@@ -60,6 +61,7 @@ import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.alerts.engine.impl.DroolsRulesEngineImpl;
 import org.hawkular.alerts.engine.service.RulesEngine;
+import org.hawkular.alerts.engine.util.MissingState;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -82,6 +84,7 @@ public class RulesEngineTest {
     Set<Data> datums = new HashSet<Data>();
     Set<Event> inputEvents = new HashSet<>();
     List<Event> outputEvents = new ArrayList<>();
+    Set<MissingState> missingStates = new HashSet<>();
 
     @Before
     public void before() {
@@ -91,6 +94,7 @@ public class RulesEngineTest {
         rulesEngine.addGlobal("pendingTimeouts", pendingTimeouts);
         rulesEngine.addGlobal("autoResolvedTriggers", autoResolvedTriggers);
         rulesEngine.addGlobal("disabledTriggers", disabledTriggers);
+        rulesEngine.addGlobal("missingStates", missingStates);
     }
 
     @After
@@ -101,6 +105,7 @@ public class RulesEngineTest {
         datums.clear();
         inputEvents.clear();
         outputEvents.clear();
+        missingStates.clear();
     }
 
     @Test
@@ -1887,5 +1892,85 @@ public class RulesEngineTest {
         assertTrue(rulesEngine.getFact(jsonfmt1d) != null);
         assertTrue(rulesEngine.getFact(jsonfmt1c2) != null);
         assertTrue(rulesEngine.getFact(jsonfmt1c2eval) != null);
+    }
+
+    @Test
+    public void missingDataTestNoData() throws Exception {
+        //Initial trigger and condition
+        Trigger t1 = new Trigger("tenant", "trigger-m", "Missing test Trigger");
+        MissingCondition fmt1 = new MissingCondition("tenant", "trigger-m", "data-id", 3000L);
+
+        t1.setEnabled(true);
+
+        // Missing state is generated on reloadTrigger()
+        missingStates.add(new MissingState(t1, fmt1));
+
+        rulesEngine.addFact(t1);
+        rulesEngine.addFact(fmt1);
+
+        // Rules Invoker thread updates missing states periodically
+        MissingState missingState = missingStates.iterator().next();
+
+        rulesEngine.removeFact(missingState);
+
+        // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
+        missingState.setPreviousTime(missingState.getTime());
+        missingState.setTime(missingState.getTime() + 4000);
+
+        rulesEngine.addFact(missingState);
+
+        // If missing states but not data rules engine should fire
+        rulesEngine.fireNoData();
+
+        assertEquals(1, alerts.size());
+
+
+        // Rules Invoker thread updates missing states periodically
+        missingState = missingStates.iterator().next();
+
+        rulesEngine.removeFact(missingState);
+
+        // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
+        missingState.setPreviousTime(missingState.getTime());
+        missingState.setTime(missingState.getTime() + 4000);
+
+        rulesEngine.addFact(missingState);
+
+        rulesEngine.fireNoData();
+
+        assertEquals(2, alerts.size());
+    }
+
+    @Test
+    public void missingDataTestWithData() throws Exception {
+        Trigger t1 = new Trigger("tenant", "trigger-m", "Missing test Trigger");
+        MissingCondition fmt1 = new MissingCondition("tenant", "trigger-m", "data-id", 3000L);
+
+        t1.setEnabled(true);
+
+        // Missing state is generated on reloadTrigger()
+        missingStates.add(new MissingState(t1, fmt1));
+
+        rulesEngine.addFact(t1);
+        rulesEngine.addFact(fmt1);
+
+        MissingState missingState = missingStates.iterator().next();
+
+        rulesEngine.removeFact(missingState);
+
+        // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
+        missingState.setPreviousTime(missingState.getTime());
+        missingState.setTime(missingState.getTime() + 4000);
+
+        rulesEngine.addFact(missingState);
+
+        // We add a data, so it should update the missingState and not fire any alert
+
+        Data data = Data.forAvailability("tenant", "data-id", missingState.getTime() + 4001, AvailabilityType.DOWN);
+        rulesEngine.addData(data);
+
+        rulesEngine.fire();
+
+        assertEquals(0, alerts.size());
     }
 }

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
@@ -95,7 +95,6 @@ public class RulesEngineTest {
         rulesEngine.addGlobal("pendingTimeouts", pendingTimeouts);
         rulesEngine.addGlobal("autoResolvedTriggers", autoResolvedTriggers);
         rulesEngine.addGlobal("disabledTriggers", disabledTriggers);
-        rulesEngine.addGlobal("missingStates", missingStates);
     }
 
     @After

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/RulesEngineTest.java
@@ -1914,7 +1914,6 @@ public class RulesEngineTest {
         rulesEngine.removeFact(missingState);
 
         // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
-        missingState.setPreviousTime(missingState.getTime());
         missingState.setTime(missingState.getTime() + 4000);
 
         rulesEngine.addFact(missingState);
@@ -1931,7 +1930,6 @@ public class RulesEngineTest {
         rulesEngine.removeFact(missingState);
 
         // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
-        missingState.setPreviousTime(missingState.getTime());
         missingState.setTime(missingState.getTime() + 4000);
 
         rulesEngine.addFact(missingState);
@@ -1959,7 +1957,6 @@ public class RulesEngineTest {
         rulesEngine.removeFact(missingState);
 
         // It simulates that we have not data in 4 seconds > of 3 seconds interval defined
-        missingState.setPreviousTime(missingState.getTime());
         missingState.setTime(missingState.getTime() + 4000);
 
         rulesEngine.addFact(missingState);


### PR DESCRIPTION
As described in HWKALERTS-176 this PR implements a new type of condition: MissingCondition.
The purpose of this type is the ability to alert when a data/event has not been received into the system.
Some use cases (when metrics are involved) can be handled via ExternalCondition and Alerter add-ons, others simply not.
This enhancement fills that gap.
Main use case is the ability to respond to "Do I have received an event for this ? If not, alert".
The implementation details basically maintains a timer state when this condition is active resetting when new Events or Data arrives.
