### PR TITLE
HWKALERTS-181 Add clustering information on status endpoint

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/StatusService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/StatusService.java
@@ -41,10 +41,10 @@ public interface StatusService {
     /**
      * Show additional information about distributed status.
      * In distributed scenarios
-     *  - getDistributedStatus().get("currentNode") will store a string with the identifier of the current node
-     *  - getDistributedStatus().get("members") will store a string with a list comma identifiers of the nodes of the topology
+     *  - getDistributedStatus().get("currentNode") returns a string with the identifier of the current node
+     *  - getDistributedStatus().get("members") returns a string with a list comma identifiers of the topology nodes
      *    at the moment of the call
-     * In standalone scenarios getDistributedStatus() will return an empty map.
+     * In standalone scenarios getDistributedStatus() returns an empty map.
      *
      * @return Map with currentNode and members information for distributed scenarios
      */

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/StatusService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/StatusService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.services;
+
+import java.util.Map;
+
+/**
+ * Interface that allows to check main status of Hawkular Alerting system
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public interface StatusService {
+
+    /**
+     * @return true if system has initialized Cassandra backend correctly
+     *         false otherwise
+     */
+    boolean isStarted();
+
+    /**
+     * @return true if system is running on a distributed scenario.
+     *         false if system is running on a standalone scenario.
+     */
+    boolean isDistributed();
+
+    /**
+     * Show additional information about distributed status.
+     * In distributed scenarios
+     *  - getDistributedStatus().get("currentNode") will store a string with the identifier of the current node
+     *  - getDistributedStatus().get("members") will store a string with a list comma identifiers of the nodes of the topology
+     *    at the moment of the call
+     * In standalone scenarios getDistributedStatus() will return an empty map.
+     *
+     * @return Map with currentNode and members information for distributed scenarios
+     */
+    Map<String, String> getDistributedStatus();
+}

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
@@ -402,6 +402,10 @@ public class CassCluster {
         return session;
     }
 
+    public boolean isInitialized() {
+        return initialized;
+    }
+
     @PreDestroy
     public void shutdown() {
         log.info("Closing Cassandra cluster session");

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/StatusServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/StatusServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.impl;
+
+import java.util.Map;
+
+import javax.ejb.EJB;
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
+
+import org.hawkular.alerts.api.services.StatusService;
+import org.hawkular.alerts.engine.service.PartitionManager;
+
+import com.datastax.driver.core.Session;
+
+/**
+ * An implementation of {@link org.hawkular.alerts.api.services.StatusService}.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Local(StatusService.class)
+@Stateless
+@TransactionAttribute(value = TransactionAttributeType.NOT_SUPPORTED)
+public class StatusServiceImpl implements StatusService {
+
+    @EJB
+    PartitionManager partitionManager;
+
+    @Inject
+    @CassClusterSession
+    Session session;
+
+    @Override
+    public boolean isStarted() {
+        return session != null && !session.isClosed();
+    }
+
+    @Override
+    public boolean isDistributed() {
+        return partitionManager.isDistributed();
+    }
+
+    @Override
+    public Map<String, String> getDistributedStatus() {
+        return partitionManager.getStatus();
+    }
+}

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/PartitionManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/PartitionManager.java
@@ -75,10 +75,10 @@ public interface PartitionManager {
     /**
      * Show additional information about partition status.
      * In distributed scenarios
-     *  - getStatus().get("currentNode") will store a string with the identifier of the current node
-     *  - getStatus().get("members") will store a string with a list comma identifiers of the nodes of the topology
+     *  - getStatus().get("currentNode") returns a string with the identifier of the current node
+     *  - getStatus().get("members") returns a string with a list comma identifiers of the topology nodes
      *    at the moment of the call
-     * In standalone scenarios getStatus() will return an empty map.
+     * In standalone scenarios getStatus() returns an empty map.
      *
      * @return Map with currentNode and members information for distributed scenarios
      */

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/PartitionManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/PartitionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package org.hawkular.alerts.engine.service;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Event;
@@ -70,6 +71,18 @@ public interface PartitionManager {
      *         false otherwise
      */
     boolean isDistributed();
+
+    /**
+     * Show additional information about partition status.
+     * In distributed scenarios
+     *  - getStatus().get("currentNode") will store a string with the identifier of the current node
+     *  - getStatus().get("members") will store a string with a list comma identifiers of the nodes of the topology
+     *    at the moment of the call
+     * In standalone scenarios getStatus() will return an empty map.
+     *
+     * @return Map with currentNode and members information for distributed scenarios
+     */
+    Map<String, String> getStatus();
 
     /**
      * Notify partition manager when a trigger, dampening or condition has been added,updated or removed.


### PR DESCRIPTION
Refactor Status logic to have its own service

Basically two things on this PR:
- To have a proper StatusService on the impl, before that the status endpoint was calculated by a simple DefinitionsService call, StatusService might hide and encapsulate other future complex checks.
- Add clustering info on status endpoint.