### PR TITLE
[HWKALERTS-183] Remove xmlpull and xpp3

### DIFF
--- a/hawkular-alerts-engine/pom.xml
+++ b/hawkular-alerts-engine/pom.xml
@@ -59,6 +59,16 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
       <version>${version.org.drools}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xmlpull</groupId>
+          <artifactId>xmlpull</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xpp3</groupId>
+          <artifactId>xpp3_min</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
These two transitive deps do not seem to be needed at build time or runtime, so they should
be excluded from the build and the distribution war files.