### PR TITLE
[POC] Batching data/events on the async threads

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManager.java
@@ -17,7 +17,10 @@
 package org.hawkular.alerts.engine.impl;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.Resource;
 import javax.ejb.EJB;
@@ -45,6 +48,9 @@ import org.jboss.logging.Logger;
 public class IncomingDataManager {
     private final Logger log = Logger.getLogger(IncomingDataManager.class);
 
+    private static final String MIN_REPORTING_INTERVAL = "hawkular-alerts.min-reporting-interval";
+    private int minRepInterval;
+
     @Resource
     private ManagedExecutorService executor;
 
@@ -60,15 +66,60 @@ public class IncomingDataManager {
     @Inject
     CacheClient dataIdCache;
 
+    public IncomingDataManager() {
+        minRepInterval = new Integer(AlertProperties.getProperty(MIN_REPORTING_INTERVAL, "1000"));
+    }
+
     public void bufferData(IncomingData incomingData) {
         executor.submit(() -> {
-            sendData(filterIncomingData(incomingData));
+            Collection<Data> filteredData = filterIncomingData(incomingData);
+            while (!filteredData.isEmpty()) {
+                TreeSet<Data> batchData = new TreeSet<>(filteredData);
+                Data previousData = null;
+                filteredData.clear();
+                for (Iterator<Data> i = batchData.iterator(); i.hasNext();) {
+                    Data data = i.next();
+                    if (null == previousData ||
+                            !(previousData.getId().equals(data.getId())
+                                    && previousData.getTenantId().equals(data.getTenantId()))) {
+                        previousData = data;
+                    } else {
+                        i.remove();
+                        if (data.getTimestamp() - previousData.getTimestamp() > minRepInterval) {
+                            filteredData.add(data);
+                        }
+                    }
+                }
+                log.debugf("Send %s data", batchData);
+                sendData(batchData);
+            }
         });
     }
 
     public void bufferEvents(Collection<Event> events) {
         executor.submit(() ->  {
-            sendEvents(events);
+            Collection<Event> incomingEvents = new HashSet<>(events);
+            while (!incomingEvents.isEmpty()) {
+                TreeSet<Event> batchEvents = new TreeSet<>(incomingEvents);
+                Event previousEvent = null;
+                incomingEvents.clear();
+                for (Iterator<Event> i = batchEvents.iterator(); i.hasNext();) {
+                    Event event = i.next();
+                    if (null == previousEvent ||
+                            !(null != event.getDataId()
+                                    && !(event.getDataId().equals(previousEvent.getDataId())
+                                            && event.getTenantId().equals(previousEvent.getTenantId())))) {
+                        previousEvent = event;
+                    } else {
+                        i.remove();
+                        if (event.getCtime() - previousEvent.getCtime() > minRepInterval) {
+                            incomingEvents.add(event);
+                        }
+                    }
+                }
+                log.debugf("Send %s events", batchEvents);
+                sendEvents(batchEvents);
+            }
         });
     }
 


### PR DESCRIPTION
I haven't tested yet.
The idea of this PR is to extract the batching and ordering operation to the callers async threads.
On this way, the single thread for the rules engine doesn't have to perform this task, and this can be done in a better way.

Probably additional tests/modifications could be needed but I wanted to share for discussing.