### PR TITLE
HWKALERTS-191 Prevent excessive cache updates

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsEvent.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +16,11 @@
  */
 package org.hawkular.alerts.api.services;
 
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
 /**
- * Immutable definitions event.
+ * Immutable definitions change event.  The target object depends on the change type.
  *
  * @author jay shaughnessy
  * @author lucas ponce
@@ -25,22 +28,48 @@ package org.hawkular.alerts.api.services;
 public class DefinitionsEvent {
 
     public enum Type {
-        CONDITION_CHANGE,
         DAMPENING_CHANGE,
+        TRIGGER_CONDITION_CHANGE,
         TRIGGER_CREATE,
         TRIGGER_REMOVE,
         TRIGGER_UPDATE
     };
 
     private Type type;
+    private String targetTenantId;
+    private String targetId;
 
-    public DefinitionsEvent(Type type) {
+    public DefinitionsEvent(Type type, Dampening dampening) {
+        this(type, dampening.getTenantId(), dampening.getDampeningId());
+    }
+
+    public DefinitionsEvent(Type type, Trigger trigger) {
+        this(type, trigger.getTenantId(), trigger.getId());
+    }
+
+    public DefinitionsEvent(Type type, String targetTenantId, String targetId) {
         super();
         this.type = type;
+        this.targetTenantId = targetTenantId;
+        this.targetId = targetId;
     }
 
     public Type getType() {
         return type;
+    }
+
+    public String getTargetTenantId() {
+        return targetTenantId;
+    }
+
+    public String getTargetId() {
+        return targetId;
+    }
+
+    @Override
+    public String toString() {
+        return "DefinitionsEvent [type=" + type + ", targetTenantId=" + targetTenantId + ", targetId=" + targetId
+                + "]";
     }
 
 }


### PR DESCRIPTION
- batch update requests if the cache is already updating
- add more context to definition change events
  - note, unused now but I did the work and it doesn't
    hurt anything. So, I think we may as well keep it.