### PR TITLE
Move to commons 0.8.0 and match parent pom version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>43</version>
+    <version>49</version>
   </parent>
 
   <groupId>org.hawkular.alerts</groupId>
@@ -79,7 +79,7 @@
     <version.org.codehaus.groovy.maven>1.0</version.org.codehaus.groovy.maven>
     <version.org.drools>6.4.0.Final</version.org.drools>
     <version.org.freemarker>2.3.23</version.org.freemarker>
-    <version.org.hawkular.commons>0.7.10.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.8.0.Final</version.org.hawkular.commons>
     <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
     <version.org.infinispan.eap64>5.2.9.Final</version.org.infinispan.eap64>
     <version.org.jboss.jboss-vfs>3.2.10.Final</version.org.jboss.jboss-vfs>


### PR DESCRIPTION
This transitively updates the c* and driver version's to 3.0.9 and 3.0.5, respectively.

@lucasponce It looks like we'll need to update to the latest commons to match Hservices infrastructure (c* driver version).  We'll probably need a release fairly soon, to allow for Hmetrics to do the same.  Either a 1.3.x or a 1.4.0 version, we can discuss which one we prefer.

cc @stefannegrea 