### PR TITLE
HWKALERTS-193 Split min-reporting-interval config

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DroolsRulesEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/DroolsRulesEngineImpl.java
@@ -57,7 +57,8 @@ public class DroolsRulesEngineImpl implements RulesEngine {
     private static final long PERF_BATCHING_THRESHOLD = 3000L; // 3 seconds
     private static final long PERF_FIRING_THRESHOLD = 5000L; // 5 seconds
 
-    private int minReportingInterval;
+    private int minReportingIntervalData;
+    private int minReportingIntervalEvents;
 
     private KieServices ks;
     private KieContainer kc;
@@ -77,10 +78,15 @@ public class DroolsRulesEngineImpl implements RulesEngine {
             kSession.addEventListener(new DebugRuleRuntimeEventListener());
         }
 
-        minReportingInterval = new Integer(
-                AlertProperties.getProperty(MIN_REPORTING_INTERVAL,
-                        MIN_REPORTING_INTERVAL_ENV,
-                        MIN_REPORTING_INTERVAL_DEFAULT));
+        minReportingIntervalData = new Integer(
+                AlertProperties.getProperty(MIN_REPORTING_INTERVAL_DATA,
+                        MIN_REPORTING_INTERVAL_DATA_ENV,
+                        MIN_REPORTING_INTERVAL_DATA_DEFAULT));
+
+        minReportingIntervalEvents = new Integer(
+                AlertProperties.getProperty(MIN_REPORTING_INTERVAL_EVENTS,
+                        MIN_REPORTING_INTERVAL_EVENTS_ENV,
+                        MIN_REPORTING_INTERVAL_EVENTS_DEFAULT));
     }
 
     @Override
@@ -204,7 +210,7 @@ public class DroolsRulesEngineImpl implements RulesEngine {
                 kSession.insert(d);
 
             } else {
-                if ((d.getTimestamp() - previousData.getTimestamp()) < minReportingInterval) {
+                if ((d.getTimestamp() - previousData.getTimestamp()) < minReportingIntervalData) {
                     log.tracef("MinReportingInterval violation, prev: %s, removed: %s", previousData, d);
                 } else {
                     pendingData.add(d);
@@ -239,7 +245,7 @@ public class DroolsRulesEngineImpl implements RulesEngine {
                 kSession.insert(e);
 
             } else {
-                if ((e.getCtime() - previousEvent.getCtime()) < minReportingInterval) {
+                if ((e.getCtime() - previousEvent.getCtime()) < minReportingIntervalEvents) {
                     log.tracef("MinReportingInterval violation, prev: %s, removed: %s", previousEvent, e);
                 } else {
                     pendingEvents.add(e);

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManagerImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManagerImpl.java
@@ -53,7 +53,8 @@ import org.jboss.logging.Logger;
 public class IncomingDataManagerImpl implements IncomingDataManager {
     private final Logger log = Logger.getLogger(IncomingDataManagerImpl.class);
 
-    private int minReportingInterval;
+    private int minReportingIntervalData;
+    private int minReportingIntervalEvents;
 
     @Resource
     private ManagedExecutorService executor;
@@ -76,10 +77,15 @@ public class IncomingDataManagerImpl implements IncomingDataManager {
     @PostConstruct
     public void init() {
         try {
-            minReportingInterval = new Integer(
-                    AlertProperties.getProperty(RulesEngine.MIN_REPORTING_INTERVAL,
-                            RulesEngine.MIN_REPORTING_INTERVAL_ENV,
-                            RulesEngine.MIN_REPORTING_INTERVAL_DEFAULT));
+            minReportingIntervalData = new Integer(
+                    AlertProperties.getProperty(RulesEngine.MIN_REPORTING_INTERVAL_DATA,
+                            RulesEngine.MIN_REPORTING_INTERVAL_DATA_ENV,
+                            RulesEngine.MIN_REPORTING_INTERVAL_DATA_DEFAULT));
+
+            minReportingIntervalEvents = new Integer(
+                    AlertProperties.getProperty(RulesEngine.MIN_REPORTING_INTERVAL_EVENTS,
+                            RulesEngine.MIN_REPORTING_INTERVAL_EVENTS_ENV,
+                            RulesEngine.MIN_REPORTING_INTERVAL_EVENTS_DEFAULT));
         } catch (Throwable t) {
             if (log.isDebugEnabled()) {
                 t.printStackTrace();
@@ -165,7 +171,7 @@ public class IncomingDataManagerImpl implements IncomingDataManager {
             if (!d.same(prev)) {
                 prev = d;
             } else {
-                if ((d.getTimestamp() - prev.getTimestamp()) < minReportingInterval) {
+                if ((d.getTimestamp() - prev.getTimestamp()) < minReportingIntervalData) {
                     log.tracef("MinReportingInterval violation, prev: %s, removed: %s", prev, d);
                     i.remove();
                 }
@@ -184,7 +190,7 @@ public class IncomingDataManagerImpl implements IncomingDataManager {
             if (!e.same(prev)) {
                 prev = e;
             } else {
-                if ((e.getCtime() - prev.getCtime()) < minReportingInterval) {
+                if ((e.getCtime() - prev.getCtime()) < minReportingIntervalEvents) {
                     log.tracef("MinReportingInterval violation, prev: %s, removed: %s", prev, e);
                     i.remove();
                 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/RulesEngine.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/service/RulesEngine.java
@@ -32,9 +32,13 @@ import org.hawkular.alerts.api.model.event.Event;
  */
 public interface RulesEngine {
 
-    String MIN_REPORTING_INTERVAL = "hawkular-alerts.min-reporting-interval";
-    String MIN_REPORTING_INTERVAL_ENV = "HAWKULAR_MIN_REPORTING_INTERVAL";
-    String MIN_REPORTING_INTERVAL_DEFAULT = "1000";
+    String MIN_REPORTING_INTERVAL_DATA = "hawkular-alerts.min-reporting-interval-data";
+    String MIN_REPORTING_INTERVAL_DATA_ENV = "HAWKULAR_MIN_REPORTING_INTERVAL_DATA";
+    String MIN_REPORTING_INTERVAL_DATA_DEFAULT = "1000";
+
+    String MIN_REPORTING_INTERVAL_EVENTS = "hawkular-alerts.min-reporting-interval-events";
+    String MIN_REPORTING_INTERVAL_EVENTS_ENV = "HAWKULAR_MIN_REPORTING_INTERVAL_EVENTS";
+    String MIN_REPORTING_INTERVAL_EVENTS_DEFAULT = "0";
 
     void addGlobal(String name, Object global);
 


### PR DESCRIPTION
Splitting min-reporting-interval config as Data and Events scenarios could be very different.
So it makes sense to configure them by separate.
