### PR TITLE
HWKALERTS-197 move hawkular-alerts.properties

### DIFF
--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,3 +23,4 @@ hawkular-alerts.cassandra-retry-attempts=15
 hawkular-alerts.cassandra-retry-timeout=3000
 hawkular-alerts.engine-delay=1000
 hawkular-alerts.engine-period=2000
+hawkular-alerts.data-driven-triggers-enabled=false

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
@@ -1,0 +1,26 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Internal configuration registration, used to provide default values
+hawkular-alerts.cassandra-cql-port=9042
+hawkular-alerts.cassandra-nodes=127.0.0.1
+hawkular-alerts.cassandra-keyspace=hawkular_alerts
+hawkular-alerts.cassandra-retry-attempts=15
+hawkular-alerts.cassandra-retry-timeout=3000
+hawkular-alerts.engine-delay=1000
+hawkular-alerts.engine-period=2000
+hawkular-alerts.data-driven-triggers-enabled=false

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/classes/hawkular-alerts.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Internal configuration registration, used to provide default values
+hawkular-alerts.cassandra-cql-port=9042
+hawkular-alerts.cassandra-nodes=127.0.0.1
+hawkular-alerts.cassandra-keyspace=hawkular_alerts
+hawkular-alerts.cassandra-retry-attempts=15
+hawkular-alerts.cassandra-retry-timeout=3000
+hawkular-alerts.engine-delay=1000
+hawkular-alerts.engine-period=2000


### PR DESCRIPTION
- move from engine jar to war dists such that defaults can be
  modified more easily for different distributions.
- disable data-driven group triggers for metrics and services
  distributions, because the primary use case is data forwarded
  from metrics, and that Data will not have 'source' field values.