### PR TITLE
HWKALERTS-199 Improve CacheManager updates

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsEvent.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsEvent.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.services;
 
+import java.util.Set;
+
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 
@@ -38,20 +40,26 @@ public class DefinitionsEvent {
     private Type type;
     private String targetTenantId;
     private String targetId;
+    private Set<String> dataIds;
 
     public DefinitionsEvent(Type type, Dampening dampening) {
-        this(type, dampening.getTenantId(), dampening.getDampeningId());
+        this(type, dampening.getTenantId(), dampening.getDampeningId(), null);
     }
 
     public DefinitionsEvent(Type type, Trigger trigger) {
-        this(type, trigger.getTenantId(), trigger.getId());
+        this(type, trigger.getTenantId(), trigger.getId(), null);
     }
 
     public DefinitionsEvent(Type type, String targetTenantId, String targetId) {
+        this(type, targetTenantId, targetId, null);
+    }
+
+    public DefinitionsEvent(Type type, String targetTenantId, String targetId, Set<String> dataIds) {
         super();
         this.type = type;
         this.targetTenantId = targetTenantId;
         this.targetId = targetId;
+        this.dataIds = dataIds;
     }
 
     public Type getType() {
@@ -66,10 +74,41 @@ public class DefinitionsEvent {
         return targetId;
     }
 
-    @Override
-    public String toString() {
-        return "DefinitionsEvent [type=" + type + ", targetTenantId=" + targetTenantId + ", targetId=" + targetId
-                + "]";
+    public Set<String> getDataIds() {
+        return dataIds;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DefinitionsEvent that = (DefinitionsEvent) o;
+
+        if (type != that.type) return false;
+        if (targetTenantId != null ? !targetTenantId.equals(that.targetTenantId) : that.targetTenantId != null)
+            return false;
+        if (targetId != null ? !targetId.equals(that.targetId) : that.targetId != null) return false;
+        return dataIds != null ? dataIds.equals(that.dataIds) : that.dataIds == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (targetTenantId != null ? targetTenantId.hashCode() : 0);
+        result = 31 * result + (targetId != null ? targetId.hashCode() : 0);
+        result = 31 * result + (dataIds != null ? dataIds.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DefinitionsEvent{" +
+                "type=" + type +
+                ", targetTenantId='" + targetTenantId + '\'' +
+                ", targetId='" + targetId + '\'' +
+                ", dataIds=" + dataIds +
+                '}';
+    }
 }

--- a/hawkular-alerts-filter-api/src/main/java/org/hawkular/alerts/filter/CacheClient.java
+++ b/hawkular-alerts-filter-api/src/main/java/org/hawkular/alerts/filter/CacheClient.java
@@ -40,9 +40,10 @@ import org.infinispan.Cache;
 @ApplicationScoped
 public class CacheClient {
 
-    /** key=CacheKey, value="" */
+    // It stores a list of triggerIds used per key (tenantId, dataId).
+    // This cache is used by CacheClient to check wich dataIds are published and forwarded from metrics.
     @Resource(lookup = "java:jboss/infinispan/cache/hawkular-alerts/publish")
-    private Cache<CacheKey, String> cache;
+    private Cache<CacheKey, Set<String>> cache;
 
     public Set<CacheKey> keySet() {
         return cache.keySet();
@@ -52,7 +53,7 @@ public class CacheClient {
         return cache.containsKey(key);
     }
 
-    public String get(CacheKey key) {
+    public Set<String> get(CacheKey key) {
         return cache.get(key);
     }
 
@@ -85,7 +86,7 @@ public class CacheClient {
     /**
      *  This is here for testing purposes only and should not be called in production code.
      */
-    public void addTestKey(CacheKey key, String value) {
+    public void addTestKey(CacheKey key, Set<String> value) {
         cache.put(key, value);
     }
 }

--- a/hawkular-alerts-rest-tests/pom.xml
+++ b/hawkular-alerts-rest-tests/pom.xml
@@ -226,6 +226,7 @@
               <excludes>
                 <excludeFile>org/hawkular/alerts/rest/ClusterITest.class</excludeFile>
                 <excludeFile>org/hawkular/alerts/rest/PerfCrudITest.class</excludeFile>
+                <excludeFile>org/hawkular/alerts/rest/PerfImportITest.class</excludeFile>
                 <excludeFile>org/hawkular/alerts/rest/CORSITest.class</excludeFile>
                 <exclude>${hawkular.itest-exclude}</exclude>
               </excludes>
@@ -497,6 +498,7 @@
                     <excludeFile>org/hawkular/alerts/rest/ClusterITest.class</excludeFile>
                     <excludeFile>org/hawkular/alerts/rest/PerfCrudITest.class</excludeFile>
                     <excludeFile>org/hawkular/alerts/rest/PerfSendITest.class</excludeFile>
+                    <excludeFile>org/hawkular/alerts/rest/PerfImportITest.class</excludeFile>
                     <exclude>${hawkular.itest-exclude}</exclude>
                   </excludes>
                 </configuration>
@@ -761,6 +763,7 @@
                   <includes>
                     <include>org/hawkular/alerts/rest/PerfCrudITest.class</include>
                     <include>org/hawkular/alerts/rest/PerfSendITest.class</include>
+                    <include>org/hawkular/alerts/rest/PerfImportITest.class</include>
                   </includes>
                   <excludes>
                     <excludeFile>org/hawkular/alerts/rest/ClusterITest.class</excludeFile>

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -1060,7 +1060,7 @@ class LifecycleITest extends AbstractITestBase {
 
         // ADD AutoResolve condition
         AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-manual-autoresolve-trigger",
-                Mode.AUTORESOLVE, "test-autoresolve-avail", Operator.UP);
+                Mode.AUTORESOLVE, "test-manual-autoresolve-avail", Operator.UP);
 
         conditions.clear();
         conditions.add( autoResolveCond );

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/PerfCrudITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/PerfCrudITest.groovy
@@ -51,6 +51,12 @@ class PerfCrudITest extends AbstractITestBase {
 
         int numTriggers = 2000;
         long startCall, endCall, timeCall, numCalls = 0, totalTimeCalls = 0, more1sec = 0;
+        long numPostTrigger = 0, numDeleteTrigger = 0;
+        long totalPostTrigger = 0, totalDeleteTrigger = 0;
+        long numPostDampening = 0, numGetDampening = 0, numPutDampening = 0, numDeleteDampening = 0;
+        long totalPostDampening = 0, totalGetDampening = 0, totalPutDampening = 0, totalDeleteDampening = 0;
+        long numPutConditions = 0, numGetConditions = 0;
+        long totalPutConditions = 0, totalGetConditions = 0;
 
         for (int i = 0; i < numTriggers; i++) {
 
@@ -61,6 +67,8 @@ class PerfCrudITest extends AbstractITestBase {
             endCall = System.currentTimeMillis();
             numCalls++;
             timeCall = (endCall - startCall);
+            numDeleteTrigger++;
+            totalDeleteTrigger += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -74,6 +82,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPostTrigger++;
+            totalPostTrigger += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -90,6 +100,8 @@ class PerfCrudITest extends AbstractITestBase {
             d = resp.data // get the assigned dampeningId
             numCalls++;
             timeCall = (endCall - startCall);
+            numPostDampening++;
+            totalPostDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -102,6 +114,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals("RELAXED_COUNT", resp.data.type)
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetDampening++;
+            totalGetDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -114,6 +128,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutDampening++;
+            totalPutDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -126,6 +142,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals("STRICT", resp.data.type)
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetDampening++;
+            totalGetDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -138,6 +156,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(1, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetDampening++;
+            totalGetDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -151,17 +171,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals("test-crud-" + i, resp.data[0].triggerId)
             numCalls++;
             timeCall = (endCall - startCall);
-            if (timeCall > 1000) {
-                more1sec++;
-            }
-            totalTimeCalls += timeCall;
-
-            startCall = System.currentTimeMillis();
-            resp = client.delete(path: "triggers/test-crud-" + i + "/dampenings/" + d.getDampeningId())
-            endCall = System.currentTimeMillis();
-            assertEquals(200, resp.status)
-            numCalls++;
-            timeCall = (endCall - startCall);
+            numGetDampening++;
+            totalGetDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -183,6 +194,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(2, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutConditions++;
+            totalPutConditions += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -195,6 +208,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(2, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetConditions++;
+            totalGetConditions += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -208,6 +223,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutConditions++;
+            totalPutConditions += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -220,6 +237,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals("LTE", resp.data[0].operator)
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetConditions++;
+            totalGetConditions += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -234,17 +253,33 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutConditions++;
+            totalPutConditions += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
             totalTimeCalls += timeCall;
-
             startCall = System.currentTimeMillis();
             resp = client.get(path: "triggers/test-crud-" + i + "/conditions")
             endCall = System.currentTimeMillis();
             assertEquals(1, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numGetConditions++;
+            totalGetConditions += timeCall;
+            if (timeCall > 1000) {
+                more1sec++;
+            }
+            totalTimeCalls += timeCall;
+
+            startCall = System.currentTimeMillis();
+            resp = client.delete(path: "triggers/test-crud-" + i + "/dampenings/" + d.getDampeningId())
+            endCall = System.currentTimeMillis();
+            assertEquals(200, resp.status)
+            numCalls++;
+            timeCall = (endCall - startCall);
+            numDeleteDampening++;
+            totalDeleteDampening += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -256,6 +291,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numDeleteTrigger++;
+            totalDeleteTrigger += timeCall;
             if (timeCall > 1000) {
                 more1sec++;
             }
@@ -265,7 +302,22 @@ class PerfCrudITest extends AbstractITestBase {
             logger.info("Total calls: " + numCalls);
             logger.info("Avg: " + ((double)totalTimeCalls / (double)numCalls) + " ms");
             logger.info("> 1 sec: " + more1sec);
-
+            logger.info("POST   Trigger #: " + numPostTrigger);
+            logger.info("POST   Trigger Avg: " + ((double)totalPostTrigger / (double)numPostTrigger) + " ms");
+            logger.info("DELETE Trigger #: " + numDeleteTrigger);
+            logger.info("DELETE Trigger Avg: " + ((double)totalDeleteTrigger / (double)numDeleteTrigger) + " ms");
+            logger.info("GET    Dampening #: " + numGetDampening);
+            logger.info("GET    Dampening Avg: " + ((double)totalGetDampening / (double)numGetDampening) + " ms");
+            logger.info("POST   Dampening #: " + numPostDampening);
+            logger.info("POST   Dampening Avg: " + ((double)totalPostDampening / (double)numPostDampening) + " ms");
+            logger.info("PUT    Dampening #: " + numPutDampening);
+            logger.info("PUT    Dampening Avg: " + ((double)totalPutDampening / (double)numPutDampening) + " ms");
+            logger.info("DELETE Dampening #: " + numDeleteDampening);
+            logger.info("DELETE Dampening Avg: " + ((double)totalDeleteDampening / (double)numDeleteDampening) + " ms");
+            logger.info("GET    Conditions #: " + numGetConditions);
+            logger.info("GET    Conditions Avg: " + ((double)totalGetConditions / (double)numGetConditions) + " ms");
+            logger.info("PUT    Conditions #: " + numPutConditions);
+            logger.info("PUT    Conditions Avg: " + ((double)totalPutConditions / (double)numPutConditions) + " ms");
         }
 
     }
@@ -279,6 +331,12 @@ class PerfCrudITest extends AbstractITestBase {
 
         int numTriggers = 2000;
         long startCall, endCall, timeCall, numCalls = 0, totalTimeCalls = 0, more1sec = 0;
+        long numPostTrigger = 0, numDeleteTrigger = 0;
+        long totalPostTrigger = 0, totalDeleteTrigger = 0;
+        long numPostDampening = 0;
+        long totalPostDampening = 0;
+        long numPutConditionsFiring = 0, numPutConditionsAutoresolve = 0;
+        long totalPutConditionsFiring = 0, totalPutConditionsAutoresolve = 0;
 
         for (int i = 0; i < numTriggers; i++) {
 
@@ -289,6 +347,8 @@ class PerfCrudITest extends AbstractITestBase {
             endCall = System.currentTimeMillis();
             numCalls++;
             timeCall = (endCall - startCall);
+            numDeleteTrigger++;
+            totalDeleteTrigger += timeCall;
             if (timeCall > 1000) {
                 logger.warn("WARNING: >1s call with " + timeCall + " ms (delete)")
                 more1sec++;
@@ -303,6 +363,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPostTrigger++;
+            totalPostTrigger += timeCall;
             if (timeCall > 1000) {
                 logger.warn("WARNING: >1s call with " + timeCall + " ms (trigger)")
                 more1sec++;
@@ -319,6 +381,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(200, resp.status)
             numCalls++;
             timeCall = (endCall - startCall);
+            numPostDampening++;
+            totalPostDampening += timeCall;
             if (timeCall > 1000) {
                 logger.warn("WARNING: >1s call with " + timeCall + " ms (dampenings)")
                 more1sec++;
@@ -342,6 +406,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(2, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutConditionsFiring++;
+            totalPutConditionsFiring += timeCall;
             if (timeCall > 1000) {
                 logger.warn("WARNING: >1s call with " + timeCall + " ms (firing)")
                 more1sec++;
@@ -350,9 +416,9 @@ class PerfCrudITest extends AbstractITestBase {
 
             // Autoresolve Conditions
 
-            ThresholdCondition testAutoCond1 = new ThresholdCondition("test-crud-" + i, Mode.FIRING,
+            ThresholdCondition testAutoCond1 = new ThresholdCondition("test-crud-" + i, Mode.AUTORESOLVE,
                     "No-Metric", ThresholdCondition.Operator.LTE, 10.12);
-            ThresholdCondition testAutoCond2 = new ThresholdCondition("test-crud-" + i, Mode.FIRING,
+            ThresholdCondition testAutoCond2 = new ThresholdCondition("test-crud-" + i, Mode.AUTORESOLVE,
                     "No-Metric", ThresholdCondition.Operator.GTE, 4.10);
             Collection<Condition> autoConditions = new ArrayList<>(2);
             autoConditions.add( testAutoCond1 );
@@ -364,6 +430,8 @@ class PerfCrudITest extends AbstractITestBase {
             assertEquals(2, resp.data.size())
             numCalls++;
             timeCall = (endCall - startCall);
+            numPutConditionsAutoresolve++;
+            totalPutConditionsAutoresolve += timeCall;
             if (timeCall > 1000) {
                 logger.warn("WARNING: >1s call with " + timeCall + " ms (autoresolve)")
                 more1sec++;
@@ -374,6 +442,18 @@ class PerfCrudITest extends AbstractITestBase {
             logger.info("Total calls: " + numCalls);
             logger.info("Avg: " + ((double)totalTimeCalls / (double)numCalls) + " ms");
             logger.info("> 1 sec: " + more1sec);
+            logger.info("POST   Trigger #: " + numPostTrigger);
+            logger.info("POST   Trigger Avg: " + ((double)totalPostTrigger / (double)numPostTrigger) + " ms");
+            logger.info("DELETE Trigger #: " + numDeleteTrigger);
+            logger.info("DELETE Trigger Avg: " + ((double)totalDeleteTrigger / (double)numDeleteTrigger) + " ms");
+            logger.info("POST   Dampening #: " + numPostDampening);
+            logger.info("POST   Dampening Avg: " + ((double)totalPostDampening / (double)numPostDampening) + " ms");
+            logger.info("PUT    Conditions Firing #: " + numPutConditionsFiring);
+            logger.info("PUT    Conditions Firing Avg: "
+                    + ((double)totalPutConditionsFiring / (double)numPutConditionsFiring) + " ms");
+            logger.info("PUT    Conditions Autoresolve #: " + numPutConditionsFiring);
+            logger.info("PUT    Conditions Autoresolve Avg: "
+                    + ((double)totalPutConditionsAutoresolve / (double)numPutConditionsAutoresolve) + " ms");
 
         }
 
@@ -382,9 +462,10 @@ class PerfCrudITest extends AbstractITestBase {
     /*
         This test is designed to study performance on REST endpoints.
         This is a concurrent version where dampening and conditions are called concurrently.
+
+        This is a pure experimental test.
      */
-    @Test
-    void concurrentlWithAutoResolve() {
+    void concurrentWithAutoResolve() {
 
         def numTriggers = 2000;
         def numCalls = 0

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/PerfImportITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/PerfImportITest.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovy.org.hawkular.alerts.rest
+
+import groovyx.gpars.dataflow.Promise
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+import org.hawkular.alerts.api.model.action.ActionDefinition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.dampening.Dampening
+import org.hawkular.alerts.api.model.dampening.Dampening.Type
+import org.hawkular.alerts.api.model.export.Definitions
+import org.hawkular.alerts.api.model.trigger.FullTrigger
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.rest.AbstractITestBase
+import org.junit.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import static groovyx.gpars.dataflow.Dataflow.task
+import static org.junit.Assert.assertEquals
+
+/**
+ * CRUD REST operations taking figures for performance investigation.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+class PerfImportITest extends AbstractITestBase {
+
+    static Logger logger = LoggerFactory.getLogger(PerfImportITest.class)
+
+    Definitions prepareDefinitions(String prefix, int numTriggers) {
+        Definitions definitions = new Definitions();
+        List<FullTrigger> triggers = new ArrayList<>(numTriggers);
+        for (int i = 0; i < numTriggers; i++) {
+            Trigger importTrigger = new Trigger(prefix + "-" + i, "Test-Import");
+            Dampening d = Dampening.forRelaxedCount("", prefix + "-" + i, Mode.FIRING, 1, 2);
+            List<Dampening> dampenings = new ArrayList<>(1);
+            dampenings.add(d);
+            ThresholdCondition testCond1 = new ThresholdCondition(prefix + "-" + i, Mode.FIRING,
+                    "Metric-" + i, ThresholdCondition.Operator.GT, 10.12);
+            ThresholdCondition testCond2 = new ThresholdCondition(prefix + "-" + i, Mode.FIRING,
+                    "Metric-" + i, ThresholdCondition.Operator.LT, 4.10);
+            List<Condition> conditions = new ArrayList<>(2);
+            conditions.add( testCond1 );
+            conditions.add( testCond2 );
+            FullTrigger fullTrigger = new FullTrigger();
+            fullTrigger.setTrigger(importTrigger);
+            fullTrigger.setDampenings(dampenings);
+            fullTrigger.setConditions(conditions);
+            triggers.add(fullTrigger);
+        }
+        definitions.setTriggers(triggers);
+        definitions.setActions(new ArrayList<>());
+        return definitions;
+    }
+
+    void importTest(String prefix, numTriggers) {
+        long startCall, endCall, timeCall;
+
+        Definitions definitions = prepareDefinitions(prefix, numTriggers);
+
+        startCall = System.currentTimeMillis();
+        def resp = client.post(path: "import/all", body: definitions)
+        endCall = System.currentTimeMillis();
+        timeCall = (endCall - startCall);
+        assertEquals(200, resp.status)
+
+        logger.info("Import " + numTriggers + " took " + timeCall + " ms")
+    }
+
+    @Test
+    void import1000() {
+        importTest("import1000", 1000);
+    }
+
+    @Test
+    void import2000() {
+        importTest("import2000", 2000);
+    }
+
+    @Test
+    void import3000() {
+        importTest("import3000", 3000);
+    }
+
+    @Test
+    void import4000() {
+        importTest("import4000", 4000);
+    }
+
+    @Test
+    void import5000() {
+        importTest("import5000", 5000);
+    }
+
+    @Test
+    void import6000() {
+        importTest("import6000", 6000);
+    }
+}

--- a/hawkular-alerts-rest-tests/src/test/resources/domain.xsl
+++ b/hawkular-alerts-rest-tests/src/test/resources/domain.xsl
@@ -49,6 +49,9 @@
       <replicated-cache name="publish" mode="ASYNC">
         <transaction mode="BATCH"/>
       </replicated-cache>
+      <replicated-cache name="dataIds" mode="ASYNC">
+        <transaction mode="BATCH"/>
+      </replicated-cache>
       <replicated-cache name="schema" mode="SYNC">
         <transaction mode="NON_XA"/>
       </replicated-cache>

--- a/hawkular-alerts-rest-tests/src/test/resources/standalone-ha.xsl
+++ b/hawkular-alerts-rest-tests/src/test/resources/standalone-ha.xsl
@@ -67,6 +67,9 @@
       <replicated-cache name="publish" mode="ASYNC">
         <transaction mode="BATCH"/>
       </replicated-cache>
+      <replicated-cache name="dataIds" mode="ASYNC">
+        <transaction mode="BATCH"/>
+      </replicated-cache>
       <replicated-cache name="schema" mode="SYNC">
         <transaction mode="NON_XA"/>
       </replicated-cache>

--- a/hawkular-alerts-rest-tests/src/test/resources/standalone-hawkular.xsl
+++ b/hawkular-alerts-rest-tests/src/test/resources/standalone-hawkular.xsl
@@ -42,6 +42,7 @@
       <local-cache name="triggers"/>
       <local-cache name="data"/>
       <local-cache name="publish"/>
+      <local-cache name="dataIds" />
       <local-cache name="schema"/>
     </cache-container>
   </xsl:template>

--- a/hawkular-alerts-rest-tests/src/test/resources/standalone.xsl
+++ b/hawkular-alerts-rest-tests/src/test/resources/standalone.xsl
@@ -40,6 +40,7 @@
       <local-cache name="triggers"/>
       <local-cache name="data"/>
       <local-cache name="publish"/>
+      <local-cache name="dataIds" />
       <local-cache name="schema"/>
     </cache-container>
   </xsl:template>

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-metrics/src/main/webapp/WEB-INF/web.xml
@@ -46,4 +46,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/dataIds</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/dataIds</lookup-name>
+  </resource-env-ref>
+
 </web-app>

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-services/src/main/webapp/WEB-INF/web.xml
@@ -75,4 +75,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/dataIds</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/dataIds</lookup-name>
+  </resource-env-ref>
+
 </web-app>

--- a/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/web.xml
+++ b/hawkular-alerts-rest/deployments/hawkular-alerts-rest-standalone/src/main/webapp/WEB-INF/web.xml
@@ -46,4 +46,9 @@
     <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/publish</lookup-name>
   </resource-env-ref>
 
+  <resource-env-ref>
+    <resource-env-ref-name>cache/dataIds</resource-env-ref-name>
+    <lookup-name>java:jboss/infinispan/cache/hawkular-alerts/dataIds</lookup-name>
+  </resource-env-ref>
+
 </web-app>


### PR DESCRIPTION
HWKALERTS-196 Improve perf examples for CRUD scenarios

This PR implement some enhancements on the CacheManager algorithm.
In an initial step, it fetches from backend the triggersIds/dataIds relation.
Using listeners, it maintains a triggerId -> dataIds relation used to update the published cache.
Now, the published cache holds a dataIds -> triggerIds relation.
On this way, we can maintain multiple references on N:M dataIds:triggerIds.

Improvements are good, PerfCrudITest shows that penalties queries have been minimized.

Please @jshaughn, let's start looking at this PR.

Note that I focus on the CacheManager only.
I will the DataDrivenGroupCacheManager in an following PR.

But I think we can review this one.