### PR TITLE
HWKALERTS-203 Fix issue in Event.compareTo

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -332,21 +332,21 @@ public class Data implements Comparable<Data>, Serializable {
     }
 
     /* (non-Javadoc)
-     * Natural Ordering provided: TenantId asc, Id asc, Timestamp asc. This is important to ensure that the engine
-     * naturally processes datums for the same dataId is ascending time order.
+     * Natural Ordering provided: Id asc, TenantId asc, Source asc, Timestamp asc. This is important to ensure
+     * that the engine naturally processes datums for the same dataId is ascending time order.
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     @Override
     public int compareTo(Data o) {
-        int c = this.tenantId.compareTo(o.tenantId);
+        int c = this.id.compareTo(o.id);
+        if (0 != c)
+            return c;
+
+        c = this.tenantId.compareTo(o.tenantId);
         if (0 != c)
             return c;
 
         c = this.source.compareTo(o.source);
-        if (0 != c)
-            return c;
-
-        c = this.id.compareTo(o.id);
         if (0 != c)
             return c;
 
@@ -369,15 +369,15 @@ public class Data implements Comparable<Data>, Serializable {
                 return false;
         } else if (!id.equals(other.id))
             return false;
-        if (source == null) {
-            if (other.source != null)
-                return false;
-        } else if (!source.equals(other.source))
-            return false;
         if (tenantId == null) {
             if (other.tenantId != null)
                 return false;
         } else if (!tenantId.equals(other.tenantId))
+            return false;
+        if (source == null) {
+            if (other.source != null)
+                return false;
+        } else if (!source.equals(other.source))
             return false;
         return true;
     }

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -446,8 +446,8 @@ public class Event implements Comparable<Event>, Serializable {
     }
 
     /* (non-Javadoc)
-     * Natural Ordering provided: dataId asc, Timestamp asc, id asc. This is important to ensure that the engine
-     * naturally processes events for the same dataId is ascending time order.
+     * Natural Ordering provided: dataId asc, tenantId asc, dataSource asc, Timestamp asc, id asc. This is important
+     * to ensure that the engine naturally processes events for the same dataId is ascending time order.
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     @Override
@@ -458,13 +458,24 @@ public class Event implements Comparable<Event>, Serializable {
         if (this.dataId == null) {
             return this.id.compareTo(o.id);
         }
+
         int c = this.dataId.compareTo(o.dataId);
         if (0 != c)
             return c;
+
+        c = this.tenantId.compareTo(o.tenantId);
+        if (0 != c)
+            return c;
+
+        c = this.dataSource.compareTo(o.dataSource);
+        if (0 != c)
+            return c;
+
         c = Long.compare(this.ctime, o.ctime);
         if (0 != c) {
             return c;
         }
+
         return this.id.compareTo(o.id);
     }
 


### PR DESCRIPTION
- add in tenantId and dataSource, otherwise we may defer an
  event that should have been sent to the engine.
- also: change natural ordering of Alert to be analogous to Event.
  This is a micro-optimization, Because Data.id is more discriminating
  that tenantId or source, there will be less String matching
  when sorting.