### PR TITLE
Unify email properties

### DIFF
--- a/hawkular-alerts-actions/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/hawkular-alerts-actions-email-plugin/src/test/java/org/hawkular/alerts/actions/email/SmtpSecureTest.java
+++ b/hawkular-alerts-actions/hawkular-alerts-actions-plugins/hawkular-alerts-actions-email/hawkular-alerts-actions-email-plugin/src/test/java/org/hawkular/alerts/actions/email/SmtpSecureTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.actions.email;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.mail.Message;
+
+import org.hawkular.alerts.actions.api.ActionMessage;
+import org.hawkular.alerts.actions.api.ActionPluginSender;
+import org.hawkular.alerts.actions.api.ActionResponseMessage;
+import org.hawkular.alerts.actions.tests.MultipleAllJvmData;
+import org.hawkular.alerts.actions.tests.TestActionMessage;
+import org.hawkular.alerts.api.json.JsonUtil;
+import org.hawkular.alerts.api.model.action.Action;
+import org.hawkular.alerts.api.model.event.Alert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This test is to show how to configure EmailPlugin on secure scenarios.
+ *
+ * It needs connectivity with smtp.mailtrap.io where there is a specific account for Hawkular Alerting testing.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class SmtpSecureTest {
+
+    private static final String MAILTRAP_URL = "https://mailtrap.io/api/v1/inboxes/";
+    private static final String INBOX_ID = "158842";
+    private static final String CLEAN_INBOX_URL = MAILTRAP_URL + INBOX_ID + "/clean";
+    private static final String GET_INBOX_URL = MAILTRAP_URL + INBOX_ID;
+    private static final String API_TOKEN = "Api-Token";
+    private static final String INBOX_TOKEN = "c8b383b4352277421308f32f8dad4ca5";
+    private static final String GET_METHOD = "GET";
+    private static final String POST_METHOD = "POST";
+    private static final String PATCH_METHOD = "PATCH";
+    private static final String METHOD_OVERRIDE = "X-HTTP-Method-Override";
+    private static final int    DEFAULT_TIMEOUT = 5000;
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String APPLICATION_JSON = "application/json";
+
+    private static EmailPlugin plugin;
+    private static Map<String, String> properties;
+    private static TestSecurePluginSender secureSender = new TestSecurePluginSender();
+
+    @BeforeClass
+    public static void prepareMessages() {
+        plugin = new EmailPlugin();
+        plugin.setSender(secureSender);
+
+        properties= new HashMap<>();
+        properties.put("to", "admin@hawkular.org");
+        properties.put("cc", "bigboss@hawkular.org");
+        properties.put("cc.acknowledged", "acknowledged@hawkular.org");
+        properties.put("cc.resolved", "resolved@hawkular.org");
+        properties.put("template.hawkular.url", "http://www.hawkular.org");
+    }
+
+    @Before
+    public void cleanRemoteInbox() throws Exception {
+        URL inboxUrl = new URL(CLEAN_INBOX_URL);
+        HttpURLConnection conn = (HttpURLConnection) inboxUrl.openConnection();
+        conn.setRequestProperty(METHOD_OVERRIDE, PATCH_METHOD);
+        conn.setRequestMethod(POST_METHOD);
+        conn.setRequestProperty(CONTENT_TYPE, APPLICATION_JSON);
+        conn.setRequestProperty(API_TOKEN, INBOX_TOKEN);
+        conn.setConnectTimeout(DEFAULT_TIMEOUT);
+        conn.setReadTimeout(DEFAULT_TIMEOUT);
+        conn.connect();
+        try {
+            int responseCode = conn.getResponseCode();
+            if (responseCode >= 300) {
+                throw new Exception("INBOX cleaning returned a [" + responseCode + "] response code.");
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    public int getRemoteInboxSize() throws Exception {
+        URL inboxUrl = new URL(GET_INBOX_URL);
+        HttpURLConnection conn = (HttpURLConnection) inboxUrl.openConnection();
+        conn.setRequestMethod(GET_METHOD);
+        conn.setRequestProperty(CONTENT_TYPE, APPLICATION_JSON);
+        conn.setRequestProperty(API_TOKEN, INBOX_TOKEN);
+        conn.setConnectTimeout(DEFAULT_TIMEOUT);
+        conn.setReadTimeout(DEFAULT_TIMEOUT);
+
+        InputStream inputStream = conn.getInputStream();
+        ByteArrayOutputStream response = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = inputStream.read(buffer)) != -1) {
+            response.write(buffer, 0, length);
+        }
+        try {
+            Map<String, Object> responseMap = JsonUtil.fromJson(response.toString("UTF-8"), Map.class);
+            return (Integer) responseMap.get("emails_count");
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @After
+    public void waitAfterTest() throws Exception {
+        Thread.sleep(2000);
+    }
+
+    @Test
+    public void smtpUserPassTest() throws Exception {
+        Alert openAlert = MultipleAllJvmData.getOpenAlert();
+
+        Action openAction = new Action(openAlert.getTriggerId(), "email", "email-to-test", openAlert);
+
+        properties.put("mail.smtp.host", "mailtrap.io");
+        properties.put("mail.smtp.port", "2525");
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.user", "5d80cef05f244e");
+        properties.put("mail.smtp.pass", "a7775710279a87");
+
+        openAction.setProperties(properties);
+        ActionMessage openMessage = new TestActionMessage(openAction);
+
+        Message email = plugin.createMimeMessage(openMessage);
+        assertNotNull(email);
+
+        plugin.process(openMessage);
+
+        assertFalse(secureSender.isFailed());
+        assertEquals(1, getRemoteInboxSize());
+    }
+
+    private void assertEquals(int i, int remoteInboxSize) {
+    }
+
+    @Test
+    public void smtpSslTest() throws Exception {
+        Alert openAlert = MultipleAllJvmData.getOpenAlert();
+
+        Action openAction = new Action(openAlert.getTriggerId(), "email", "email-to-test", openAlert);
+
+        properties.put("mail.smtp.host", "mailtrap.io");
+        properties.put("mail.smtp.port", "2525");
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.starttls.enable", "true");
+        properties.put("mail.smtp.user", "5d80cef05f244e");
+        properties.put("mail.smtp.pass", "a7775710279a87");
+
+        openAction.setProperties(properties);
+        ActionMessage openMessage = new TestActionMessage(openAction);
+
+        Message email = plugin.createMimeMessage(openMessage);
+        assertNotNull(email);
+
+        plugin.process(openMessage);
+
+        assertFalse(secureSender.isFailed());
+        assertEquals(1, getRemoteInboxSize());
+    }
+
+
+    public static class TestSecurePluginMessage implements ActionResponseMessage {
+
+        private Operation operation;
+        public Map<String, String> payload;
+
+        public TestSecurePluginMessage(Operation operation, Map<String, String> payload) {
+            this.operation = operation;
+            this.payload = payload;
+        }
+
+        @Override
+        public Operation getOperation() {
+            return operation;
+        }
+
+        @Override
+        public Map<String, String> getPayload() {
+            return payload;
+        }
+    }
+
+    public static class TestSecurePluginSender implements ActionPluginSender {
+
+        boolean failed = false;
+
+        @Override
+        public ActionResponseMessage createMessage(ActionResponseMessage.Operation operation) {
+            return new TestSecurePluginMessage(operation, new HashMap<>());
+        }
+
+        @Override
+        public void send(ActionResponseMessage msg) throws Exception {
+            Action action = JsonUtil.fromJson(msg.getPayload().get("action"), Action.class);
+            failed = action.getResult().equals("FAILED");
+        }
+
+        public boolean isFailed() {
+            return failed;
+        }
+    }
+
+}

--- a/hawkular-alerts-actions/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/hawkular-alerts-actions-webhook-plugin/src/main/java/org/hawkular/alerts/actions/webhook/WebHookPlugin.java
+++ b/hawkular-alerts-actions/hawkular-alerts-actions-plugins/hawkular-alerts-actions-webhook/hawkular-alerts-actions-webhook-plugin/src/main/java/org/hawkular/alerts/actions/webhook/WebHookPlugin.java
@@ -35,6 +35,8 @@ import org.hawkular.alerts.api.model.action.Action;
 import org.jboss.logging.Logger;
 
 /**
+ * Action Webhook plugin.
+ *
  * An example of listener for basic webhook processing.
  *
  * @author Jay Shaughnessy
@@ -49,6 +51,28 @@ public class WebHookPlugin implements ActionPluginListener {
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
 
+    /*
+        This is the list of properties supported for the WebHook plugin.
+        Properties are personalized per action.
+        If not properties found per action, then plugin looks into default properties set at plugin level.
+        If not default properties found at plugin level, then it takes to default ones defined inside plugin.
+     */
+
+    /**
+     * "url" property defines the url of the webhook to invoke.
+     */
+    public static final String PROP_URL = "url";
+
+    /**
+     * "method" property defines the HTTP method used with the webhook url to invoke.
+     */
+    public static final String PROP_METHOD = "method";
+
+    /**
+     * "timeout" property defines the connection timeout for the webhook url to invoke.
+     */
+    public static final String PROP_TIMEOUT = "timeout";
+
     private final MsgLogger msgLog = MsgLogger.LOGGER;
     private static final Logger log = Logger.getLogger(WebHookPlugin.class);
     Map<String, String> defaultProperties = new HashMap<>();
@@ -60,9 +84,9 @@ public class WebHookPlugin implements ActionPluginListener {
     private static final String MESSAGE_FAILED = "FAILED";
 
     public WebHookPlugin() {
-        defaultProperties.put("url", DEFAULT_URL);
-        defaultProperties.put("method", DEFAULT_METHOD);
-        defaultProperties.put("timeout", DEFAULT_TIMEOUT);
+        defaultProperties.put(PROP_URL, DEFAULT_URL);
+        defaultProperties.put(PROP_METHOD, DEFAULT_METHOD);
+        defaultProperties.put(PROP_TIMEOUT, DEFAULT_TIMEOUT);
     }
 
     @Override
@@ -93,11 +117,11 @@ public class WebHookPlugin implements ActionPluginListener {
         if (action.getProperties() == null) {
             throw new IllegalArgumentException("Received action without properties");
         }
-        String url = isEmpty(action.getProperties().get("url")) ? DEFAULT_URL : action.getProperties().get("url");
-        String method = isEmpty(action.getProperties().get("method")) ? DEFAULT_METHOD :
-                action.getProperties().get("method");
-        int timeout = isEmpty(action.getProperties().get("timeout")) ? Integer.parseInt(DEFAULT_TIMEOUT) :
-                Integer.parseInt(action.getProperties().get("timeout"));
+        String url = isEmpty(action.getProperties().get(PROP_URL)) ? DEFAULT_URL : action.getProperties().get(PROP_URL);
+        String method = isEmpty(action.getProperties().get(PROP_METHOD)) ? DEFAULT_METHOD :
+                action.getProperties().get(PROP_METHOD);
+        int timeout = isEmpty(action.getProperties().get(PROP_TIMEOUT)) ? Integer.parseInt(DEFAULT_TIMEOUT) :
+                Integer.parseInt(action.getProperties().get(PROP_TIMEOUT));
 
         String jsonEvent = JsonUtil.toJson(action.getEvent());
         URL webHookUrl = new URL(url);

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -183,7 +183,14 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         }
         Set<String> pluginProperties = getActionPlugin(plugin);
         actionDefinition.getProperties().keySet().stream().forEach(property -> {
-            if (!pluginProperties.contains(property)) {
+            boolean isPluginProperty = false;
+            for (String pluginProperty : pluginProperties) {
+                if (property.startsWith(pluginProperty)) {
+                    isPluginProperty = true;
+                    break;
+                }
+            }
+            if (!isPluginProperty) {
                 throw new IllegalArgumentException("Property: " + property + " is not valid on plugin: " + plugin);
             }
         });
@@ -2753,7 +2760,20 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
         if (isEmpty(actionDefinition.getProperties())) {
             throw new IllegalArgumentException("Properties must be not null");
         }
-
+        Set<String> pluginProperties = getActionPlugin(actionDefinition.getActionPlugin());
+        actionDefinition.getProperties().keySet().stream().forEach(property -> {
+            boolean isPluginProperty = false;
+            for (String pluginProperty : pluginProperties) {
+                if (property.startsWith(pluginProperty)) {
+                    isPluginProperty = true;
+                    break;
+                }
+            }
+            if (!isPluginProperty) {
+                throw new IllegalArgumentException("Property: " + property + " is not valid on plugin: " +
+                        actionDefinition.getActionPlugin());
+            }
+        });
         PreparedStatement updateAction = CassStatement.get(session, CassStatement.UPDATE_ACTION_DEFINITION);
         if (updateAction == null) {
             throw new RuntimeException("updateAction PreparedStatement is null");

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
@@ -147,6 +147,44 @@ class ActionsITest extends AbstractITestBase {
     }
 
     @Test
+    void createExplicitEmailPropertiesAction() {
+        String actionPlugin = "email"
+        String actionId = "test-action";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-default@company.org");
+        actionProperties.put("from.resolved", "from-resolved@company.org");
+        actionProperties.put("from.acknowledged", "from-acknowledged@company.org");
+        actionProperties.put("to", "to-default@company.org");
+        actionProperties.put("to.acknowledged", "to-acknowledged@company.org");
+        actionProperties.put("cc", "cc-email@company.org");
+        actionProperties.put("mail.smtp.host", "localhost");
+        actionProperties.put("mail.smtp.port", "25");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId);
+        assertEquals(200, resp.status)
+        assertEquals("from-default@company.org", resp.data.properties["from"])
+        assertEquals("from-resolved@company.org", resp.data.properties["from.resolved"])
+        assertEquals("from-acknowledged@company.org", resp.data.properties["from.acknowledged"])
+
+        actionDefinition.getProperties().put("cc", "cc-modified@company.org")
+        resp = client.put(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+        assertEquals("cc-modified@company.org", resp.data.properties.cc)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
     void availabilityTest() {
         String start = String.valueOf(System.currentTimeMillis());
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
@@ -93,6 +93,60 @@ class ActionsITest extends AbstractITestBase {
     }
 
     @Test
+    void createComplexAction() {
+        String actionPlugin = "email"
+        String actionId = "test-action";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-default@company.org");
+        actionProperties.put("from.resolved", "from-resolved@company.org");
+        actionProperties.put("from.acknowledged", "from-acknowledged@company.org");
+        actionProperties.put("to", "to-default@company.org");
+        actionProperties.put("to.acknowledged", "to-acknowledged@company.org");
+        actionProperties.put("cc", "cc-email@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId);
+        assertEquals(200, resp.status)
+        assertEquals("from-default@company.org", resp.data.properties["from"])
+        assertEquals("from-resolved@company.org", resp.data.properties["from.resolved"])
+        assertEquals("from-acknowledged@company.org", resp.data.properties["from.acknowledged"])
+
+        actionDefinition.getProperties().put("cc", "cc-modified@company.org")
+        resp = client.put(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+        assertEquals("cc-modified@company.org", resp.data.properties.cc)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void failWithUnknownPropertyOnPlugin() {
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+        actionProperties.put("bad-property", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(400 == resp.status)
+    }
+
+    @Test
     void availabilityTest() {
         String start = String.valueOf(System.currentTimeMillis());
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
@@ -631,23 +631,4 @@ class TriggersITest extends AbstractITestBase {
         resp = client.post(path: "triggers/trigger", body: jsonTrigger)
         assertEquals(400, resp.status)
     }
-
-    @Test
-    void failWithUnknownPropertyOnPlugin() {
-        // CREATE the action definition
-        String actionPlugin = "email"
-        String actionId = "email-to-admin";
-
-        Map<String, String> actionProperties = new HashMap<>();
-        actionProperties.put("from", "from-alerts@company.org");
-        actionProperties.put("to", "to-admin@company.org");
-        actionProperties.put("cc", "cc-developers@company.org");
-        actionProperties.put("bad-property", "cc-developers@company.org");
-
-        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
-
-        def resp = client.post(path: "actions", body: actionDefinition)
-        assert(400 == resp.status)
-    }
-
 }


### PR DESCRIPTION
- Fixing bug to let properties with suffixes (used in email plugin for properties on lifecycle state or localization).
- Unifying all properties used on email at plugin level. Originally email server was configured at system properties only, now both approaches are merged taking priority configuration at plugin level.
- Adding security support. 