### PR TITLE
HWKALERTS-209 NelsonRules

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/Condition.java
@@ -46,7 +46,7 @@ public abstract class Condition implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public enum Type {
-        AVAILABILITY, COMPARE, STRING, THRESHOLD, RANGE, EXTERNAL, EVENT, RATE, MISSING
+        AVAILABILITY, COMPARE, STRING, THRESHOLD, RANGE, EXTERNAL, EVENT, RATE, MISSING, NELSON
     }
 
     @ApiModelProperty(value = "Tenant id owner of this condition.",

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonCondition.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonCondition.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.model.condition;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.trigger.Mode;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * A condition that uses historically collected data to perform a variety of tests for value instability. See:
+ * https://en.wikipedia.org/wiki/Nelson_rules.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@ApiModel(description = "A condition to detect instability based on historical data. + \n" +
+        " + \n" +
+        "From one to all of the defined Nelson rules can be evaluated. See + \n" +
+        "https://en.wikipedia.org/wiki/Nelson_rules for a description of the rules.")
+public class NelsonCondition extends Condition {
+    private static final long serialVersionUID = 1L;
+
+    public enum NelsonRule {
+        Rule1("One point is more than 3 standard deviations from the mean"), //
+        Rule2("Nine (or more) points in a row are on the same side of the mean."), //
+        Rule3("Six (or more) points in a row are continually increasing (or decreasing)."), //
+        Rule4("Fourteen (or more) points in a row alternate in direction, increasing then decreasing."), //
+        Rule5("At least 2 of 3 points in a row are > 2 standard deviations from the mean in the same direction."), //
+        Rule6("At least 4 of 5 points in a row are > 1 standard deviation from the mean in the same direction."), //
+        Rule7("Fifteen points in a row are all within 1 standard deviation of the mean on either side of the mean."), //
+        Rule8("Eight points in a row exist, but none within 1 standard deviation of the mean, "
+                + "and the points are in both directions from the mean.");
+
+        private String description;
+
+        NelsonRule(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    private static final int DEFAULT_SAMPLE_SIZE = 50;
+    private static final Set<NelsonRule> DEFAULT_ACTIVE_RULES = EnumSet.allOf(NelsonRule.class);
+
+    @JsonInclude(Include.NON_NULL)
+    private String dataId;
+
+    @ApiModelProperty(value = "Set of NelsonRule to evaluate.",
+            position = 1,
+            example = "All Rules",
+            required = false)
+    @JsonInclude(Include.NON_NULL)
+    private Set<NelsonRule> activeRules;
+
+    @ApiModelProperty(value = "Number of samples used to establish baseline information (mean, standard deviation).",
+            position = 2,
+            example = "50",
+            required = false)
+    @JsonInclude(Include.NON_NULL)
+    private int sampleSize;
+
+    /**
+     * Used for JSON deserialization, not for general use.
+     */
+    public NelsonCondition() {
+        /*
+            Default constructor is needed for JSON libraries in JAX-RS context.
+         */
+        this("", "", Mode.FIRING, 1, 1, null, null, null);
+    }
+
+    public NelsonCondition(String tenantId, String triggerId, String dataId) {
+
+        this(tenantId, triggerId, Mode.FIRING, 1, 1, dataId, null, null);
+    }
+
+    public NelsonCondition(String tenantId, String triggerId, String dataId, Set<NelsonRule> activeRules) {
+
+        this(tenantId, triggerId, Mode.FIRING, 1, 1, dataId, activeRules, null);
+    }
+
+    public NelsonCondition(String tenantId, String triggerId, String dataId, Set<NelsonRule> activeRules,
+            Integer sampleSize) {
+
+        this(tenantId, triggerId, Mode.FIRING, 1, 1, dataId, activeRules, sampleSize);
+    }
+
+    /**
+     * This constructor requires the tenantId be assigned prior to persistence. It can be used when
+     * creating triggers via Rest, as the tenant will be assigned automatically.
+     */
+    public NelsonCondition(String triggerId, String dataId, Set<NelsonRule> activeRules) {
+
+        this("", triggerId, Mode.FIRING, 1, 1, dataId, activeRules, null);
+    }
+
+    /**
+     * This constructor requires the tenantId be assigned prior to persistence. It can be used when
+     * creating triggers via Rest, as the tenant will be assigned automatically.
+     */
+    public NelsonCondition(String triggerId, String dataId, Set<NelsonRule> activeRules, Integer sampleSize) {
+
+        this("", triggerId, Mode.FIRING, 1, 1, dataId, activeRules, sampleSize);
+    }
+
+    /**
+     * This constructor requires the tenantId be assigned prior to persistence. It can be used when
+     * creating triggers via Rest, as the tenant will be assigned automatically.
+     */
+    public NelsonCondition(String triggerId, Mode triggerMode, int conditionSetSize, int conditionSetIndex,
+            String dataId, Set<NelsonRule> activeRules, Integer sampleSize) {
+
+        this("", triggerId, triggerMode, conditionSetSize, conditionSetIndex, dataId, activeRules, sampleSize);
+    }
+
+    public NelsonCondition(String tenantId, String triggerId, Mode triggerMode, int conditionSetSize,
+            int conditionSetIndex, String dataId, Set<NelsonRule> activeRules, Integer sampleSize) {
+
+        super(tenantId, triggerId, (null == triggerMode ? Mode.FIRING : triggerMode), conditionSetSize,
+                conditionSetIndex, Type.NELSON);
+        this.dataId = dataId;
+        setActiveRules(activeRules);
+        setSampleSize(sampleSize);
+    }
+
+    @Override
+    public String getDataId() {
+        return dataId;
+    }
+
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
+    }
+
+    public Set<NelsonRule> getActiveRules() {
+        return activeRules;
+    }
+
+    public void setActiveRules(Set<NelsonRule> activeRules) {
+        this.activeRules = (null == activeRules || activeRules.isEmpty()) ? DEFAULT_ACTIVE_RULES : activeRules;
+    }
+
+    public int getSampleSize() {
+        return sampleSize;
+    }
+
+    public void setSampleSize(Integer sampleSize) {
+        this.sampleSize = (null == sampleSize || sampleSize < 1) ? DEFAULT_SAMPLE_SIZE : sampleSize;
+    }
+
+    public String getLog(List<NelsonRule> violations, Double mean, Double standardDeviation,
+            List<Data> violationsData) {
+
+        StringBuilder sb = new StringBuilder(triggerId);
+        sb.append(" : ");
+        sb.append(violations);
+        sb.append(", mean= ");
+        sb.append(mean);
+        sb.append(", standardDeviation=");
+        sb.append(standardDeviation);
+        sb.append(", sampleSize=");
+        sb.append(sampleSize);
+        sb.append(", violationsData=");
+        sb.append(violationsData);
+        return sb.toString();
+    }
+
+    public boolean match(List<NelsonRule> violations) {
+        if (isEmpty(violations) || isEmpty(activeRules)) {
+            return false;
+        }
+
+        for (NelsonRule r : violations) {
+            if (activeRules.contains(r)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isEmpty(Collection<?> c) {
+        return null == c || c.isEmpty();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((activeRules == null) ? 0 : activeRules.hashCode());
+        result = prime * result + ((dataId == null) ? 0 : dataId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NelsonCondition other = (NelsonCondition) obj;
+        if (activeRules == null) {
+            if (other.activeRules != null)
+                return false;
+        } else if (!activeRules.equals(other.activeRules))
+            return false;
+        if (dataId == null) {
+            if (other.dataId != null)
+                return false;
+        } else if (!dataId.equals(other.dataId))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "NelsonCondition [dataId=" + dataId + ", activeRules=" + activeRules + "]";
+    }
+
+}

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonConditionEval.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonConditionEval.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.model.condition;
+
+import java.util.List;
+
+import org.hawkular.alerts.api.model.condition.Condition.Type;
+import org.hawkular.alerts.api.model.condition.NelsonCondition.NelsonRule;
+import org.hawkular.alerts.api.model.data.Data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * An evaluation state for nelson condition.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@ApiModel(description = "An evaluation state for nelson condition.")
+public class NelsonConditionEval extends ConditionEval {
+
+    private static final long serialVersionUID = 1L;
+
+    @ApiModelProperty(value = "Nelson condition linked with this state.", position = 0)
+    @JsonInclude(Include.NON_NULL)
+    private NelsonCondition condition;
+
+    @ApiModelProperty(value = "Mean applied to NelsonRules.", position = 1)
+    @JsonInclude(Include.NON_NULL)
+    private Double mean;
+
+    @ApiModelProperty(value = "Standard Deviation applied to NelsonRules.", position = 2)
+    @JsonInclude(Include.NON_NULL)
+    private Double standardDeviation;
+
+    @ApiModelProperty(value = "Data used to determine violations.", position = 3)
+    @JsonInclude(Include.NON_NULL)
+    private List<Data> violationsData;
+
+    @ApiModelProperty(value = "NelsonRule violations for the data.", position = 4)
+    @JsonInclude(Include.NON_NULL)
+    private List<NelsonRule> violations;
+
+    /**
+     * Used for JSON deserialization, not for general use.
+     */
+    public NelsonConditionEval() {
+        super(Type.NELSON, false, 0, null);
+    }
+
+    public NelsonConditionEval(NelsonCondition condition, Data data, List<NelsonRule> violations, Double mean,
+            Double standardDeviation, List<Data> violationsData) {
+        super(Type.NELSON, condition.match(violations), data.getTimestamp(), data.getContext());
+        this.condition = condition;
+        this.mean = mean;
+        this.standardDeviation = standardDeviation;
+        this.violations = violations;
+        this.violationsData = violationsData;
+    }
+
+    public NelsonCondition getCondition() {
+        return condition;
+    }
+
+    public void setCondition(NelsonCondition condition) {
+        this.condition = condition;
+    }
+
+    public Double getMean() {
+        return mean;
+    }
+
+    public void setMean(Double mean) {
+        this.mean = mean;
+    }
+
+    public Double getStandardDeviation() {
+        return standardDeviation;
+    }
+
+    public void setStandardDeviation(Double standardDeviation) {
+        this.standardDeviation = standardDeviation;
+    }
+
+    public List<Data> getViolationsData() {
+        return violationsData;
+    }
+
+    public void setViolationsData(List<Data> violationsData) {
+        this.violationsData = violationsData;
+    }
+
+    public List<NelsonRule> getViolations() {
+        return violations;
+    }
+
+    public void setViolations(List<NelsonRule> violations) {
+        this.violations = violations;
+    }
+
+    @Override
+    public String getTenantId() {
+        return condition.getTenantId();
+    }
+
+    @Override
+    public String getTriggerId() {
+        return condition.getTriggerId();
+    }
+
+    @Override
+    public int getConditionSetSize() {
+        return condition.getConditionSetSize();
+    }
+
+    @Override
+    public int getConditionSetIndex() {
+        return condition.getConditionSetIndex();
+    }
+
+    @Override
+    public String getLog() {
+        return condition.getLog(violations, mean, standardDeviation, violationsData);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((condition == null) ? 0 : condition.hashCode());
+        result = prime * result + ((violations == null) ? 0 : violations.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NelsonConditionEval other = (NelsonConditionEval) obj;
+        if (condition == null) {
+            if (other.condition != null)
+                return false;
+        } else if (!condition.equals(other.condition))
+            return false;
+        if (violations == null) {
+            if (other.violations != null)
+                return false;
+        } else if (!violations.equals(other.violations))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "NelsonConditionEval [condition=" + condition + ", mean=" + mean + ", standardDeviation="
+                + standardDeviation + ", violations=" + violations + "]";
+    }
+
+}

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -230,13 +230,9 @@ public class Alert extends Event {
 
     @Override
     public String toString() {
-        return "Alert{" +
-                "severity=" + severity +
-                ", status=" + status +
-                ", notes=" + notes +
-                ", lifecycle=" + lifecycle +
-                ", resolvedEvalSets=" + resolvedEvalSets +
-                '}';
+        return "Alert [tenantId=" + tenantId + ", triggerId=" + getTriggerId() + ", severity=" + severity
+                + ", status=" + status + ", ctime=" + ctime + ", lifecycle=" + lifecycle
+                + ", resolvedEvalSets=" + resolvedEvalSets + "]";
     }
 
     @ApiModel(description = "A simple note representation.")

--- a/hawkular-alerts-engine/pom.xml
+++ b/hawkular-alerts-engine/pom.xml
@@ -88,6 +88,12 @@
       <version>${version.com.google.guava}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>${version.org.apache.commons.commons-math3}</version>
+    </dependency>
+
     <!-- Wildfly dependencies -->
     <dependency>
       <groupId>org.jboss.logging</groupId>

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -76,6 +76,7 @@ public class CassStatement {
     public static final String INSERT_CONDITION_EVENT;
     public static final String INSERT_CONDITION_EXTERNAL;
     public static final String INSERT_CONDITION_MISSING;
+    public static final String INSERT_CONDITION_NELSON;
     public static final String INSERT_CONDITION_RATE;
     public static final String INSERT_CONDITION_STRING;
     public static final String INSERT_CONDITION_THRESHOLD;
@@ -278,6 +279,10 @@ public class CassStatement {
                 + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
                 "conditionId, dataId, interval) VALUES (?, ?, ?, 'MISSING', ?, ?, ?, ?, ?, ?) ";
 
+        INSERT_CONDITION_NELSON = "INSERT INTO " + keyspace + ".conditions "
+                + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, " +
+                "conditionId, dataId, activeRules, sampleSize) VALUES (?, ?, ?, 'NELSON', ?, ?, ?, ?, ?, ?, ?) ";
+
         INSERT_CONDITION_RATE = "INSERT INTO " + keyspace + ".conditions "
                 + "(tenantId, triggerId, triggerMode, type, context, conditionSetSize, conditionSetIndex, "
                 + "conditionId, dataId, direction, period, operator, threshold) "
@@ -405,20 +410,20 @@ public class CassStatement {
         SELECT_CONDITION_ID = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context, interval "
+                + "direction, period, tenantId, context, interval, activeRules, sampleSize "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND conditionId = ? ";
 
         SELECT_CONDITIONS_ALL = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context, interval "
+                + "direction, period, tenantId, context, interval, activeRules, sampleSize "
                 + "FROM " + keyspace + ".conditions ";
 
         SELECT_CONDITIONS_BY_TENANT = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context, interval "
+                + "direction, period, tenantId, context, interval, activeRules, sampleSize "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? ";
 
@@ -488,14 +493,14 @@ public class CassStatement {
         SELECT_TRIGGER_CONDITIONS = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, "
                 + "ignoreCase, threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context, interval "
+                + "direction, period, tenantId, context, interval, activeRules, sampleSize "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ?";
 
         SELECT_TRIGGER_CONDITIONS_TRIGGER_MODE = "SELECT triggerId, triggerMode, type, conditionSetSize, "
                 + "conditionSetIndex, conditionId, dataId, operator, data2Id, data2Multiplier, pattern, ignoreCase, "
                 + "threshold, operatorLow, operatorHigh, thresholdLow, thresholdHigh, inRange, "
-                + "direction, period, tenantId, context, interval "
+                + "direction, period, tenantId, context, interval, activeRules, sampleSize "
                 + "FROM " + keyspace + ".conditions "
                 + "WHERE tenantId = ? AND triggerId = ? AND triggerMode = ? ";
 

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/NelsonData.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/util/NelsonData.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+import org.hawkular.alerts.api.model.condition.NelsonCondition;
+import org.hawkular.alerts.api.model.condition.NelsonCondition.NelsonRule;
+import org.hawkular.alerts.api.model.data.Data;
+
+/**
+ * There is one NelsonData for each [active] NelsonCondition in Drools working memory. This gives us the ability to
+ * easily configure different sample sizes for different conditions. It also makes the NelsonData life-cycle more
+ * straightforward, as it is "tied" to the NelsonCondition. So, if the condition's owning trigger is removed from
+ * working memory (e.g. manually disabled, autoDisabled after firing, deleted), then so will be the NelsonCondition
+ * and NelsonData.  Note that this means the baseline will be re-established (new samples gathered, new mean and
+ * standard deviation) if and when the owning trigger is re-enabled.  One caveat, triggers that have autoResolve do
+ * not get removed from working memory, and as such the NelsonData will remain.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class NelsonData {
+    private NelsonCondition condition;
+
+    // Currently violated rules for the currently ruleData
+    protected List<NelsonRule> violations = new ArrayList<>(8);
+
+    // the last 15 Data used to evaluate the rules. We keep 15 because that is the most needed to eval
+    // any of the rules (rule7 uses 15)
+    private LinkedList<Data> violationsData = new LinkedList<>();
+
+    private Mean mean = new Mean();
+    private StandardDeviation standardDeviation = new StandardDeviation();
+    private double oneDeviation;
+    private double twoDeviations;
+    private double threeDeviations;
+
+    private int rule2Count;
+    private int rule3Count;
+    private Double rule3PreviousSample;
+    private int rule4Count;
+    private Double rule4PreviousSample;
+    private String rule4PreviousDirection;
+    private LinkedList<String> rule5LastThree = new LinkedList<>();
+    int rule5Above;
+    int rule5Below;
+    private LinkedList<String> rule6LastFive = new LinkedList<>();
+    int rule6Above;
+    int rule6Below;
+    private int rule7Count;
+    private int rule8Count;
+
+    public NelsonData(NelsonCondition condition) {
+        this.condition = condition;
+    }
+
+    public void clear() {
+        mean.clear();
+        standardDeviation.clear();
+
+        violations.clear();
+
+        rule2Count = 0;
+        rule3Count = 0;
+        rule3PreviousSample = null;
+        rule4Count = 0;
+        rule4PreviousSample = null;
+        rule4PreviousDirection = null;
+        rule5LastThree.clear();
+        rule5Above = 0;
+        rule5Below = 0;
+        rule6LastFive.clear();
+        rule6Above = 0;
+        rule6Below = 0;
+        rule7Count = 0;
+        rule8Count = 0;
+    }
+
+    public boolean hasViolations() {
+        return !violations.isEmpty();
+    }
+
+    public void addData(Data data) {
+        // The rulebase will try to add the same data multiple times (once for each NelsonCondition using
+        // the dataId).  Just ignore subsequent attempts.
+        if (violationsData.contains(data)) {
+            return;
+        }
+
+        Double sample;
+        try {
+            sample = Double.valueOf(data.getValue());
+        } catch (Exception e) {
+            // not a valid numeric data
+            return;
+        }
+
+        if (!isValid(sample)) {
+            // not a valid Double
+            return;
+        }
+
+        violationsData.push(data);
+        while (violationsData.size() > 15) {
+            violationsData.removeLast();
+        }
+
+        // System.out.printf("\nViolationsData (size=%s)", violationsData.size());
+        // violationsData.stream().forEach(d -> System.out.printf(" \n%d %s", d.getTimestamp(), d.getValue()));
+        // System.out.println("");
+
+        addSample(sample.doubleValue());
+    }
+
+    private void addSample(double sample) {
+        if (mean.getN() < condition.getSampleSize()) {
+            mean.increment(sample);
+            standardDeviation.increment(sample);
+
+            if (mean.getN() == condition.getSampleSize()) {
+                oneDeviation = standardDeviation.getResult();
+                twoDeviations = oneDeviation * 2;
+                threeDeviations = oneDeviation * 3;
+            }
+        }
+
+        violations.clear();
+
+        if (rule1(sample)) {
+            violations.add(NelsonRule.Rule1);
+        }
+        if (rule2(sample)) {
+            violations.add(NelsonRule.Rule2);
+        }
+        if (rule3(sample)) {
+            violations.add(NelsonRule.Rule3);
+        }
+        if (rule4(sample)) {
+            violations.add(NelsonRule.Rule4);
+        }
+        if (rule5(sample)) {
+            violations.add(NelsonRule.Rule5);
+        }
+        if (rule6(sample)) {
+            violations.add(NelsonRule.Rule6);
+        }
+        if (rule7(sample)) {
+            violations.add(NelsonRule.Rule7);
+        }
+        if (rule8(sample)) {
+            violations.add(NelsonRule.Rule8);
+        }
+    }
+
+    public boolean hasMean() {
+        return mean != null && mean.getN() == condition.getSampleSize();
+    }
+
+    // one point is more than 3 standard deviations from the mean
+    private boolean rule1(double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        return Math.abs(sample - mean.getResult()) > threeDeviations;
+    }
+
+    // Nine (or more) points in a row are on the same side of the mean
+    private boolean rule2(double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        if (sample > mean.getResult()) {
+            if (rule2Count > 0) {
+                ++rule2Count;
+            } else {
+                rule2Count = 1;
+            }
+        } else {
+            if (rule2Count < 0) {
+                --rule2Count;
+            } else {
+                rule2Count = -1;
+            }
+        }
+
+        return Math.abs(rule2Count) >= 9;
+    }
+
+    // Six (or more) points in a row are continually increasing (or decreasing)
+    private boolean rule3(double sample) {
+        if (null == rule3PreviousSample) {
+            rule3PreviousSample = sample;
+            rule3Count = 0;
+            return false;
+        }
+
+        if (sample > rule3PreviousSample) {
+            if (rule3Count > 0) {
+                ++rule3Count;
+            } else {
+                rule3Count = 1;
+            }
+        } else if (sample < rule3PreviousSample) {
+            if (rule3Count < 0) {
+                --rule3Count;
+            } else {
+                rule3Count = -1;
+            }
+        } else {
+            rule3Count = 0;
+        }
+
+        rule3PreviousSample = sample;
+
+        return Math.abs(rule3Count) >= 6;
+    }
+
+    // Fourteen (or more) points in a row alternate in direction, increasing then decreasing
+    private boolean rule4(Double sample) {
+        if (null == rule4PreviousSample || sample.doubleValue() == rule4PreviousSample.doubleValue()) {
+            rule4PreviousSample = sample;
+            rule4PreviousDirection = "=";
+            rule4Count = 0;
+            return false;
+        }
+
+        String sampleDirection = (sample > rule4PreviousSample) ? ">" : "<";
+
+        if (sampleDirection.equals(rule4PreviousDirection)) {
+            rule4Count = 0;
+        } else {
+            ++rule4Count;
+        }
+
+        rule4PreviousSample = sample;
+        rule4PreviousDirection = sampleDirection;
+
+        return Math.abs(rule4Count) >= 14;
+    }
+
+    // At least 2 of 3 points in a row are > 2 standard deviations from the mean in the same direction
+    private boolean rule5(double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        if (rule5LastThree.size() == 3) {
+            switch (rule5LastThree.removeLast()) {
+                case ">":
+                    --rule5Above;
+                    break;
+                case "<":
+                    --rule5Below;
+                    break;
+            }
+        }
+        if (Math.abs(sample - mean.getResult()) > twoDeviations) {
+            if (sample > mean.getResult()) {
+                ++rule5Above;
+                rule5LastThree.push(">");
+            } else {
+                ++rule5Below;
+                rule5LastThree.push("<");
+            }
+        } else {
+            rule5LastThree.push("");
+        }
+
+        return rule5Above >= 2 || rule5Below >= 2;
+    }
+
+    // At least 4 of 5 points in a row are > 1 standard deviation from the mean in the same direction
+    private boolean rule6(double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        if (rule6LastFive.size() == 5) {
+            switch (rule6LastFive.removeLast()) {
+                case ">":
+                    --rule6Above;
+                    break;
+                case "<":
+                    --rule6Below;
+                    break;
+            }
+        }
+
+        if (Math.abs(sample - mean.getResult()) > oneDeviation) {
+            if (sample > mean.getResult()) {
+                ++rule6Above;
+                rule6LastFive.push(">");
+            } else {
+                ++rule6Below;
+                rule6LastFive.push("<");
+            }
+        } else {
+            rule6LastFive.push("");
+        }
+
+        return rule6Above >= 4 || rule6Below >= 4;
+    }
+
+    // Fifteen points in a row are all within 1 standard deviation of the mean on either side of the mean
+    // Note: I have my doubts about this one wrt monitored metrics, i think it may not be uncommon to have
+    // a very steady metric. Minimally, I have taken away the flat-line case where all samples are the mean.
+    private boolean rule7(double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        if (sample == mean.getResult()) {
+            rule7Count = 0;
+            return false;
+        }
+
+        if (Math.abs(sample - mean.getResult()) <= oneDeviation) {
+            ++rule7Count;
+        } else {
+            rule7Count = 0;
+        }
+
+        return rule7Count >= 15;
+    }
+
+    // Eight points in a row exist, but none within 1 standard deviation of the mean
+    // and the points are in both directions from the mean
+    private boolean rule8(Double sample) {
+        if (!hasMean()) {
+            return false;
+        }
+
+        if (Math.abs(sample - mean.getResult()) > oneDeviation) {
+            ++rule8Count;
+        } else {
+            rule8Count = 0;
+        }
+
+        return rule8Count >= 8;
+    }
+
+    private boolean isValid(Double d) {
+        return null != d && !d.isNaN() && !d.isInfinite();
+    }
+
+    public NelsonCondition getCondition() {
+        return condition;
+    }
+
+    public List<NelsonRule> getViolations() {
+        return Collections.unmodifiableList(violations);
+    }
+
+    public List<Data> getViolationsData() {
+        return Collections.unmodifiableList(violationsData);
+    }
+
+    public Mean getMean() {
+        return mean;
+    }
+
+    public double getMeanResult() {
+        return mean.getResult();
+    }
+
+    public double getStandardDeviationResult() {
+        return oneDeviation;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((condition == null) ? 0 : condition.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NelsonData other = (NelsonData) obj;
+        if (condition == null) {
+            if (other.condition != null)
+                return false;
+        } else if (!condition.equals(other.condition))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "NelsonData [condition=" + condition + ", violationsData=" + violationsData
+                + ", violations=" + violations + ", mean=" + mean + ", standardDeviation=" + oneDeviation
+                + ", twoDeviations=" + twoDeviations + ", threeDeviations=" + threeDeviations + "]";
+    }
+
+}

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -28,6 +28,8 @@ import org.hawkular.alerts.api.model.condition.EventCondition;
 import org.hawkular.alerts.api.model.condition.EventConditionEval;
 import org.hawkular.alerts.api.model.condition.MissingCondition;
 import org.hawkular.alerts.api.model.condition.MissingConditionEval;
+import org.hawkular.alerts.api.model.condition.NelsonCondition;
+import org.hawkular.alerts.api.model.condition.NelsonConditionEval;
 import org.hawkular.alerts.api.model.condition.StringCondition;
 import org.hawkular.alerts.api.model.condition.StringConditionEval;
 import org.hawkular.alerts.api.model.condition.ThresholdCondition;
@@ -49,6 +51,7 @@ import org.hawkular.alerts.api.model.trigger.TriggerAction;
 import org.hawkular.alerts.api.services.ActionsService;
 import org.hawkular.alerts.engine.util.CompareData;
 import org.hawkular.alerts.engine.util.MissingState;
+import org.hawkular.alerts.engine.util.NelsonData;
 import org.hawkular.alerts.engine.util.RateData;
 
 import org.jboss.logging.Logger;
@@ -194,7 +197,7 @@ end
 rule String
     when 
         $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
-        $c : StringCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId  )
+        $c : StringCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
         StringConditionEval ce = new StringConditionEval($c, $d);
@@ -207,7 +210,7 @@ end
 rule External
     when 
         $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
-        $c : ExternalCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId  )
+        $c : ExternalCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
         ExternalConditionEval ce = new ExternalConditionEval($c, $d);
@@ -251,7 +254,7 @@ end
 // Given previous and current data for a given dataId, perform a RateCondition evaluation.
 rule Rate
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
         $c  : RateCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d  : Data( tenantId == $tenantId, source == $tsource, id == $did, $dt : timestamp )
         $rd : RateData( data.tenantId == $tenantId, data.source == $tsource, data.id == $did, data.timestamp < $dt )
@@ -261,6 +264,54 @@ rule Rate
             log.debugf("Rate Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getLog());
         }
         insert( ce );
+end
+
+// NelsonCondition is a bit different (but somewhat like RateCondition) in that it looks for violations
+// of NelsonRules (https://en.wikipedia.org/wiki/Nelson_rules), as configured by the NelsonCondition.  To do this each
+// NelsonCondition has an associated NelsonData that updates the NelsonRules as data comes in. This rule creates the
+// NelsonData for the NelsonCondition. Note that if the same dataId is used in multiple NelsonConditions we do
+// potentially duplicate the tracking, but this is anticipated to be a corner case and in return we gain the ability
+// to configure sample size on the condition, and we can tie the NelsonData life-cycle to its NelsonCondition.
+rule ProvideInitialNelsonData
+    when
+        $c : NelsonCondition ( $cid : conditionId )
+        not  NelsonData( condition.conditionId == $cid )
+    then
+        NelsonData nelsonData = new NelsonData($c);
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("ProvideInitialNelsonData: %s", nelsonData);
+        }
+        insert( nelsonData );
+end
+
+// Given current data and a NelsonData for a given dataId, perform a NelsonCondition evaluation.
+rule Nelson
+    when
+        $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $c  : NelsonCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId,
+                                $cid : conditionId )
+        $d  : Data( tenantId == $tenantId, source == $tsource, id == $did )
+        $nd : NelsonData( condition.conditionId == $cid )
+    then
+        $nd.addData($d);
+        NelsonConditionEval ce = new NelsonConditionEval($c, $d, $nd.getViolations(), $nd.getMeanResult(),
+            $nd.getStandardDeviationResult(), $nd.getViolationsData());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Nelson Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getLog());
+        }
+        insert( ce );
+end
+
+// Remove the NelsonData for a NelsonCondition which has been removed from working memory
+rule RetractNelsonData
+    when
+        $nd : NelsonData( $cid : condition.conditionId )
+        not   NelsonCondition ( conditionId == $cid )
+    then
+        retract( $nd )
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("RetractNelsonData: %s", $nd);
+        }
 end
 
 rule UpdateMissingStateFromData

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.5.0.groovy
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.5.0.groovy
@@ -14,14 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.schema
-
-include '/org/hawkular/alerts/schema/bootstrap.groovy'
 
 setKeyspace keyspace
 
-// Upgrade scripts are defined here:
-include '/org/hawkular/alerts/schema/updates/schema-1.2.1.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.2.3.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.4.0.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.5.0.groovy'
+schemaChange {
+  version '4.0'
+  author 'jshaughn'
+  tags '1.5.x'
+  cql "ALTER TABLE conditions ADD activeRules set<text>"
+}
+
+schemaChange {
+  version '4.1'
+  author 'jshaughn'
+  tags '1.5.x'
+  cql "ALTER TABLE conditions ADD sampleSize int"
+}

--- a/hawkular-alerts-engine/src/test/resources/hawkular-alerts.properties
+++ b/hawkular-alerts-engine/src/test/resources/hawkular-alerts.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <version.com.icegreen>1.4.1</version.com.icegreen>
     <version.javaee.spec>7.0</version.javaee.spec>
     <version.maven-patch-plugin>1.2</version.maven-patch-plugin>
+    <version.org.apache.commons.commons-math3>3.4.1</version.org.apache.commons.commons-math3>
     <version.org.cassalog>0.4.1</version.org.cassalog>
     <version.org.codehaus.jsr166-mirror>1.7.0</version.org.codehaus.jsr166-mirror>
     <version.org.codehaus.gpars>1.2.0</version.org.codehaus.gpars>


### PR DESCRIPTION
- Introduce a new native condition type, NelsonCondition. This
condition uses "Nelson Rules" to detect "out-of-control" metric
behavior.  The condition establishes baseline metric behavior
based on a configurable metric sample (mean, stdDev) and uses the
baseline to perform analysis on the incoming measurements.
- Introduces apache math3 dep for engine
- Introduce new activeRules field in conditions table

Also:
- fixes for HWKALERTS-208 because I was already adding some  new condition support...
- Fix bug with MISSING conditions in group trigger support
- improve the toString for Alert
- add some missing test support for a couple of condition types

@lucasponce, please review at your leisure. We can talk about it off-PR as well, if it makes sense.
