### PR TITLE
Dampening update: set correct TriggerId to dampening object

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -1538,7 +1538,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new IllegalArgumentException("TenantId must be not null");
         }
         if (isEmpty(dampening)) {
-            throw new IllegalArgumentException("DampeningId must be not null");
+            throw new IllegalArgumentException("DampeningId and TriggerId must be not null");
         }
 
         checkTenantId(tenantId, dampening);
@@ -1565,7 +1565,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             throw new IllegalArgumentException("TenantId must be not null");
         }
         if (isEmpty(dampening)) {
-            throw new IllegalArgumentException("DampeningId must be not null");
+            throw new IllegalArgumentException("DampeningId and TriggerId must be not null");
         }
 
         try {

--- a/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
+++ b/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/TriggersHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -899,6 +899,7 @@ public class TriggersHandler {
             boolean exists = (definitions.getDampening(tenantId, dampeningId) != null);
             if (exists) {
                 // make sure we have the best chance of clean data..
+                dampening.setTriggerId(triggerId);
                 Dampening d = getCleanDampening(dampening);
                 definitions.updateDampening(tenantId, d);
                 if (log.isDebugEnabled()) {
@@ -943,6 +944,7 @@ public class TriggersHandler {
             boolean exists = (definitions.getDampening(tenantId, dampeningId) != null);
             if (exists) {
                 // make sure we have the best chance of clean data..
+                dampening.setTriggerId(groupId);
                 Dampening d = getCleanDampening(dampening);
                 definitions.updateGroupDampening(tenantId, d);
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
When updating trigger dampening (also for a group trigger) with a wrong triggerId, the `getCleanDampening()` would generate a wrong dampening.

In addition, in the case of missing DampeningId or TriggerId, only the DampeningId is mentioned in the Bad Argument HTTP error message. This change also suggests a missing TriggerId.

fixes: https://issues.jboss.org/browse/HWKALERTS-215