### PR TITLE
HWKALERTS-220 Fix Schema upgrade logic

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,6 @@ import org.jboss.logging.Logger;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.JdkSSLOptions;
-import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
@@ -285,31 +284,14 @@ public class CassCluster {
     private void initScheme() throws IOException {
 
         log.infof("Checking Schema existence for keyspace: %s", keyspace);
-
-        KeyspaceMetadata keyspaceMetadata = cluster.getMetadata().getKeyspace(keyspace);
-        if (keyspaceMetadata != null) {
-            // If overwrite flag is true it should not check if all tables are created
-            if (!overwrite) {
-                waitForSchemaCheck();
-                if (!checkSchema()) {
-                    log.errorf("Keyspace %s detected, but failed on check phase.", keyspace);
-                    initialized = false;
-                } else {
-                    log.infof("Schema already exist. Skipping schema creation.");
-                    initialized = true;
-                }
-            }
+        createSchema(session, keyspace, overwrite);
+        waitForSchemaCheck();
+        if (!checkSchema()) {
+            log.errorf("Schema %s not created correctly", keyspace);
+            initialized = false;
         } else {
-            log.infof("Creating Schema for keyspace %s", keyspace);
-            createSchema(session, keyspace, overwrite);
-            waitForSchemaCheck();
-            if (!checkSchema()) {
-                log.errorf("Schema %s not created correctly", keyspace);
-                initialized = false;
-            } else {
-                initialized = true;
-                log.infof("Done creating Schema for keyspace: %s", keyspace);
-            }
+            initialized = true;
+            log.infof("Done creating Schema for keyspace: %s", keyspace);
         }
     }
 

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/checker.cql
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/checker.cql
@@ -1,5 +1,5 @@
 --
--- Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+-- Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
 -- and other contributors as indicated by the @author tags.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,6 +48,16 @@ WHERE keyspace_name='${keyspace}' AND table_name = 'conditions';
 
 SELECT column_name FROM system_schema.columns
 WHERE keyspace_name='${keyspace}' AND table_name = 'conditions' AND column_name = 'interval';
+
+-- #
+
+SELECT column_name FROM system_schema.columns
+WHERE keyspace_name='${keyspace}' AND table_name = 'conditions' AND column_name = 'activerules';
+
+-- #
+
+SELECT column_name FROM system_schema.columns
+WHERE keyspace_name='${keyspace}' AND table_name = 'conditions' AND column_name = 'samplesize';
 
 -- #
 


### PR DESCRIPTION
There was a bug in the initScheme() logic that prevented to apply properly the schema changes.
As commented in the JIRA, no possibility to replace bootstrap.groovy, as we have current system in production.

I have tested the bug manually with an external C*:
- Installing an Alerting 1.3.3.Final scheme.
- Upgrading an Alerting 1.5.x scheme.

So, cassalog tables look correct:

```
cqlsh> select * from hawkular_alerts.cassalog ;

 bucket | revision | applied_at               | author | description | hash                                       | tags      | version
--------+----------+--------------------------+--------+-------------+--------------------------------------------+-----------+--------------
      0 |        0 | 2017-01-31 16:14:56+0000 |   null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        1 | 2017-01-31 16:14:56+0000 |   null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        2 | 2017-01-31 16:14:56+0000 | lponce |        null | 0xb76131bcbf701907e5527e9b9d553902d21e75a0 | {'1.2.x'} |          1.0
      0 |        3 | 2017-01-31 16:14:56+0000 |   null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        4 | 2017-01-31 16:14:56+0000 | lponce |        null | 0xbad785890692885ea53f8441c7018352c47c6c64 | {'1.2.x'} |          2.0

(5 rows)
cqlsh> select * from hawkular_alerts.cassalog ;

 bucket | revision | applied_at               | author   | description | hash                                       | tags      | version
--------+----------+--------------------------+----------+-------------+--------------------------------------------+-----------+--------------
      0 |        0 | 2017-01-31 16:14:56+0000 |     null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        1 | 2017-01-31 16:14:56+0000 |     null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        2 | 2017-01-31 16:14:56+0000 |   lponce |        null | 0xb76131bcbf701907e5527e9b9d553902d21e75a0 | {'1.2.x'} |          1.0
      0 |        3 | 2017-01-31 16:14:56+0000 |     null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        4 | 2017-01-31 16:14:56+0000 |   lponce |        null | 0xbad785890692885ea53f8441c7018352c47c6c64 | {'1.2.x'} |          2.0
      0 |        5 | 2017-01-31 16:21:18+0000 |     null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        6 | 2017-01-31 16:21:19+0000 | jshaughn |        null | 0x44ad1197ee560f2b21729bd2a601b07bb4122a94 | {'1.4.x'} |          3.0
      0 |        7 | 2017-01-31 16:21:20+0000 | jshaughn |        null | 0xa5c6ddf4d0e1b158bdb2b509531dee23b6e71fda | {'1.4.x'} |          3.1
      0 |        8 | 2017-01-31 16:21:20+0000 |     null |        null | 0x30792b4fdd7d2ff8c6dfa26241948b0575bec1d8 |      null | set-keyspace
      0 |        9 | 2017-01-31 16:21:20+0000 | jshaughn |        null | 0x2d1d64f7affdaa44d22df2b4b4ee166c526dbf61 | {'1.5.x'} |          4.0
      0 |       10 | 2017-01-31 16:21:20+0000 | jshaughn |        null | 0x18b4ea1aa2afd01e0c191ce2a6187f4dd7bef957 | {'1.5.x'} |          4.1
```

And no suspicious log messages sent so far.

Perf, ITest and cluster profiles running correctly.

Thanks @jsanda for reporting this bug.

Please @jshaughn, take a look.

Thanks,
