### PR TITLE
HWKALERTS-221 Fix Events propagation on cluster environments

### DIFF
--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -561,7 +561,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
         addEvents(events);
 
         if (distributed) {
-            partitionManager.notifyEvents(events);
+            partitionManager.notifyEvents(new ArrayList<>(events));
         }
     }
 
@@ -658,7 +658,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                         /*
                             Generated events on a node should be notified to other nodes for chained triggers
                          */
-                        partitionManager.notifyEvents(events);
+                        partitionManager.notifyEvents(new ArrayList<>(events));
                     }
                     events.clear();
                     handleDisabledTriggers();


### PR DESCRIPTION
@jshaughn I have splitted the HWKALERTS-218 in order to introduce the priorities changes in 1.5.1.Final.

This one is important as some events tests on cluster were broken due this bug.

