### PR TITLE
HWKALERTS-239

### DIFF
--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
@@ -63,6 +63,28 @@ class AlertsITest extends AbstractITestBase {
     }
 
     @Test
+    void findAlertsUnknownParams() {
+        String now = String.valueOf(System.currentTimeMillis());
+        def resp = client.get(path: "", query: [
+            startTime:"0", endTime:now,
+            startAckTime:"0", endAckTime:now,
+            startResolvedTime:"0", endResolvedTime:now,
+            alertIds:"Alert-01", triggerIds:"Trigger-01,Trigger-02", statuses: "OPEN", severities: "LOW",
+            tags: "a|b", tagQuery: "foo", thin: true] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [
+            startyTime:"0", endTime:now,
+            alertIds:"Alert-01", triggrIds:"Trigger-01,Trigger-02", statuses: "OPEN"])
+        assert resp.status == 400 : resp.status
+        assert failureEntity.contains("startyTime")
+        assert failureEntity.contains("triggrIds")
+        assert !failureEntity.contains("endTime")
+        assert !failureEntity.contains("alertIds")
+        assert !failureEntity.contains("statuses")
+    }
+
+    @Test
     void deleteAlerts() {
         String now = String.valueOf(System.currentTimeMillis());
 

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/CORSITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/CORSITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,7 +120,7 @@ class CORSITest extends AbstractITestBase {
 
     // Now query for the event
     response = client.get(path: "events",
-        query: [ids: "cors-test-event-id",tags: "cors-test-tag-name|cors-test-tag-value"],
+        query: [eventIds: "cors-test-event-id",tags: "cors-test-tag-name|cors-test-tag-value"],
         headers: [(tenantHeaderName): tenantId])
 
     assertEquals(200, response.status)
@@ -149,7 +149,7 @@ class CORSITest extends AbstractITestBase {
     assertEquals(responseHeaders, (72 * 60 * 60) + "", response.headers[ACCESS_CONTROL_MAX_AGE].value)
 
     //Requery "metrics" endpoint to make sure data gets returned and check headers
-    response = client.get(path: "events", query: [ids: "cors-test-event-id"],
+    response = client.get(path: "events", query: [eventIds: "cors-test-event-id"],
         headers: [
             (tenantHeaderName): tenantId,
             (ORIGIN): testOrigin

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
@@ -75,7 +75,7 @@ class EventsITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         resp = client.put(path: "events/delete",
-                          query: [endTime:now, startTime:"0",alertIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+                          query: [endTime:now, startTime:"0", eventIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
         assertEquals(200, resp.status)
 
         resp = client.put(path: "events/delete",

--- a/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/QueryParamValidation.java
+++ b/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/QueryParamValidation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface QueryParamValidation {
+    String name();
+}

--- a/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/RequestUtil.java
+++ b/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/RequestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,10 @@
 package org.hawkular.alerts.rest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -31,6 +34,10 @@ import org.hawkular.alerts.api.model.paging.Pager;
  * @author Lukas Krejci
  */
 public class RequestUtil {
+
+    public static final Set<String> PARAMS_PAGING = new HashSet<>(Arrays.asList(new String[] {
+            "page", "per_page", "sort", "order"
+    }));
 
     private RequestUtil() {
     }


### PR DESCRIPTION
This is just a POC for the validation part of the issue.  In this approach we'd apply a new check to the endpoints we want to protect.  Note, if a client includes the 'ignoreUnknownQueryParams' query param, the check will always pass, making it possible for a client to override if the need arises.

Here I am applying it to just one endpoint, the alerts criteria search.

@lucasponce take a look when you have a moment.