### PR TITLE
HWKALERTS-243 Ensure DefinitionsEvents are notified to listeners in order

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsListener.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsListener.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.alerts.api.services;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * A listener for reacting to definitions changes.
@@ -37,5 +37,5 @@ public interface DefinitionsListener {
      *
      * @param events change events triggering the notification.
      */
-    void onChange(Set<DefinitionsEvent> events);
+    void onChange(List<DefinitionsEvent> events);
 }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,6 +98,7 @@ public class PublishCacheManager {
             initialCacheUpdate();
 
             definitions.registerListener(events -> {
+                log.debugf("Receiving %s", events);
                 events.stream().forEach(e -> {
                     String tenantId = e.getTargetTenantId();
                     String triggerId = e.getTargetId();

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsContext.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsContext.java
@@ -131,7 +131,7 @@ public class AlertsContext {
         return actionsListeners;
     }
 
-    public void notifyListeners(Set<DefinitionsEvent> notifications) {
+    public void notifyListeners(List<DefinitionsEvent> notifications) {
         Set<DefinitionsEvent.Type> notificationTypes = notifications.stream()
                 .map(n -> n.getType())
                 .collect(Collectors.toSet());
@@ -142,7 +142,7 @@ public class AlertsContext {
                     log.debugf("Notified Listener %s of %s", e.getKey(), notificationTypes);
                     e.getKey().onChange(notifications.stream()
                             .filter(de -> e.getValue().contains(de.getType()))
-                            .collect(Collectors.toSet()));
+                            .collect(Collectors.toList()));
                 });
         if (!distributed) {
             distributedListener.stream().forEach(listener -> listener.onChange(mapDistributedEvents(notifications)));
@@ -155,7 +155,7 @@ public class AlertsContext {
         return !intersection.isEmpty();
     }
 
-    private Set<DistributedEvent> mapDistributedEvents(Set<DefinitionsEvent> notification) {
+    private Set<DistributedEvent> mapDistributedEvents(List<DefinitionsEvent> notification) {
         if (notification == null) {
             return null;
         }

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassDefinitionsServiceImpl.java
@@ -21,12 +21,12 @@ import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.ACTION_DEFI
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.ACTION_DEFINITION_UPDATE;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -124,7 +124,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
     // desirable to only send a listener update one time, at the end, because we want listeners to be
     // efficient (i.e. don't update a cache 100 times in a row for one import of 100 triggers). Methods should not
     // manipulate these variables directly, instead call deferNotifications() and releaseNotifications().
-    private Set<DefinitionsEvent> deferredNotifications = new LinkedHashSet<>();
+    private List<DefinitionsEvent> deferredNotifications = new ArrayList<>();
     private int deferNotificationsCount = 0;
     private int batchSize;
     private final BatchStatement.Type batchType = BatchStatement.Type.LOGGED;
@@ -3110,7 +3110,7 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             deferredNotifications.add(de);
             return;
         }
-        alertsContext.notifyListeners(Collections.singleton(de));
+        alertsContext.notifyListeners(Arrays.asList(de));
     }
 
     private void notifyListenersDeferred() {
@@ -3118,8 +3118,8 @@ public class CassDefinitionsServiceImpl implements DefinitionsService {
             return;
         }
 
-        Set<DefinitionsEvent> notifications = deferredNotifications;
-        deferredNotifications = new LinkedHashSet<>();
+        List<DefinitionsEvent> notifications = deferredNotifications;
+        deferredNotifications = new ArrayList<>();
         alertsContext.notifyListeners(notifications);
     }
 


### PR DESCRIPTION
Please @jshaughn, could you take a look on this ?
There were a missing unordered set and this could cause potentially problems.
```
2017-03-24 17:08:30,816 DEBUG [org.hawkular.alerts.engine.impl.AlertsContext] (default task-3) Notifying applicable listeners 
{
	org.hawkular.alerts.engine.cache.PublishCacheManager$$Lambda$315/339771229@4859fd80=[TRIGGER_CONDITION_CHANGE, TRIGGER_REMOVE], 
	org.hawkular.alerts.engine.cache.ActionsCacheManager$$Lambda$314/196075570@3237d86d=[ACTION_DEFINITION_CREATE, ACTION_DEFINITION_REMOVE, ACTION_DEFINITION_UPDATE]
} of events 
[
	DefinitionsEvent{type=ACTION_DEFINITION_REMOVE, targetTenantId='my-organization', targetId='notify-to-admins', dataIds=null, actionPlugin='email', actionDefinition=null, tags=null}, 
	DefinitionsEvent{type=ACTION_DEFINITION_CREATE, targetTenantId='my-organization', targetId='notify-to-admins', dataIds=null, actionPlugin='email', actionDefinition=ActionDefinition{tenantId='my-organization', actionPlugin='email', actionId='notify-to-admins', global=false, properties={to=admins@hawkular.org, cc=developers@hawkular.org}, states=[], calendar=null}, tags=null}, 
	DefinitionsEvent{type=TRIGGER_REMOVE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=null, actionPlugin='null', actionDefinition=null, tags={}}, 
	DefinitionsEvent{type=TRIGGER_CREATE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=null, actionPlugin='null', actionDefinition=null, tags={}}, 
	DefinitionsEvent{type=TRIGGER_CONDITION_CHANGE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=[data-x], actionPlugin='null', actionDefinition=null, tags=null}, 
	DefinitionsEvent{type=TRIGGER_CONDITION_CHANGE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=[data-x, data-y], actionPlugin='null', actionDefinition=null, tags=null}
]

2017-03-24 17:08:30,816 DEBUG [org.hawkular.alerts.engine.cache.PublishCacheManager] (default task-3) Receiving 
[
	DefinitionsEvent{type=TRIGGER_CONDITION_CHANGE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=[data-x], actionPlugin='null', actionDefinition=null, tags=null}, 
	DefinitionsEvent{type=TRIGGER_CONDITION_CHANGE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=[data-x, data-y], actionPlugin='null', actionDefinition=null, tags=null}, 
	DefinitionsEvent{type=TRIGGER_REMOVE, targetTenantId='my-organization', targetId='hello-world-trigger', dataIds=null, actionPlugin='null', actionDefinition=null, tags={}}
]
```
For example, in an import operation, first the old trigger is removed and the new one is created, but due a unordered collector, the events are processed wrongly in the listener, removing the trigger.

I think this fix is enough for this bug.