### PR TITLE
HWKALERTS-236 Watchers for events and alerts

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/paging/AlertComparator.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/model/paging/AlertComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@ public class AlertComparator implements Comparator<Alert> {
         CTIME("ctime"),
         SEVERITY("severity"),
         STATUS("status"),
+        STIME("stime"),
         CONTEXT("context");
 
         private String text;
@@ -110,6 +111,8 @@ public class AlertComparator implements Comparator<Alert> {
                 return o1.getAlertId().compareTo(o2.getAlertId()) * iOrder;
             case CTIME:
                 return (int) ((o1.getCtime() - o2.getCtime()) * iOrder);
+            case STIME:
+                return (int) ((o1.getCurrentLifecycle().getStime() - o2.getCurrentLifecycle().getStime()) * iOrder);
             case SEVERITY:
                 if (o1.getSeverity() == null && o2.getSeverity() == null) {
                     return 0;

--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -36,6 +36,8 @@ public class AlertsCriteria {
     Long endResolvedTime = null;
     Long startAckTime = null;
     Long endAckTime = null;
+    Long startStatusTime = null;
+    Long endStatusTime = null;
     String alertId = null;
     Collection<String> alertIds = null;
     Alert.Status status = null;
@@ -53,7 +55,8 @@ public class AlertsCriteria {
 
     public AlertsCriteria(Long startTime, Long endTime, String alertIds, String triggerIds,
                           String statuses, String severities, String tagQuery, Long startResolvedTime,
-                          Long endResolvedTime, Long startAckTime, Long endAckTime, Boolean thin) {
+                          Long endResolvedTime, Long startAckTime, Long endAckTime, Long startStatusTime,
+                          Long endStatusTime, Boolean thin) {
         setStartTime(startTime);
         setEndTime(endTime);
         if (!isEmpty(alertIds)) {
@@ -81,6 +84,8 @@ public class AlertsCriteria {
         setEndResolvedTime(endResolvedTime);
         setStartAckTime(startAckTime);
         setEndAckTime(endAckTime);
+        setStartStatusTime(startStatusTime);
+        setEndStatusTime(endStatusTime);
         if (null != thin) {
             setThin(thin.booleanValue());
         }
@@ -159,6 +164,30 @@ public class AlertsCriteria {
      */
     public void setEndAckTime(Long endAckTime) {
         this.endAckTime = endAckTime;
+    }
+
+    public Long getStartStatusTime() {
+        return startStatusTime;
+    }
+
+    /**
+     * @param startStatusTime fetched Alerts must have at least one statusTime in the lifecycle greater than or equal to
+     *                     startStatusTime.
+     */
+    public void setStartStatusTime(Long startStatusTime) {
+        this.startStatusTime = startStatusTime;
+    }
+
+    public Long getEndStatusTime() {
+        return endStatusTime;
+    }
+
+    /**
+     * @param endStatusTime fetched Alerts must have at least one statusTime in the lifecycle less than or equal to
+     *                   endStatusTime.
+     */
+    public void setEndStatusTime(Long endStatusTime) {
+        this.endStatusTime = endStatusTime;
     }
 
     public String getAlertId() {
@@ -299,6 +328,10 @@ public class AlertsCriteria {
         return (null != startAckTime || null != endAckTime);
     }
 
+    public boolean hasStatusTimeCriteria() {
+        return (null != startStatusTime || null != endStatusTime);
+    }
+
     public boolean hasCriteria() {
         return hasAlertIdCriteria()
                 || hasStatusCriteria()
@@ -307,17 +340,32 @@ public class AlertsCriteria {
                 || hasCTimeCriteria()
                 || hasTriggerIdCriteria()
                 || hasResolvedTimeCriteria()
-                || hasAckTimeCriteria();
+                || hasAckTimeCriteria()
+                || hasStatusTimeCriteria();
     }
 
     @Override
     public String toString() {
-        return "AlertsCriteria [startTime=" + startTime + ", endTime=" + endTime + ", alertId=" + alertId
-                + ", alertIds=" + alertIds + ", status=" + status + ", statusSet=" + statusSet + ", severity="
-                + severity + ", severities=" + severities + ", triggerId=" + triggerId + ", triggerIds=" + triggerIds
-                + ", tagQuery=" + tagQuery + ", startAckTime=" + startAckTime
-                + ", endAckTime=" + endAckTime + ", " + "startResolvedTime=" + startResolvedTime
-                + ", endResolvedTime=" + endResolvedTime + ", " + "thin=" + thin + "]";
+        return "AlertsCriteria{" +
+                "startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", startResolvedTime=" + startResolvedTime +
+                ", endResolvedTime=" + endResolvedTime +
+                ", startAckTime=" + startAckTime +
+                ", endAckTime=" + endAckTime +
+                ", startStatusTime=" + startStatusTime +
+                ", endStatusTime=" + endStatusTime +
+                ", alertId='" + alertId + '\'' +
+                ", alertIds=" + alertIds +
+                ", status=" + status +
+                ", statusSet=" + statusSet +
+                ", severity=" + severity +
+                ", severities=" + severities +
+                ", triggerId='" + triggerId + '\'' +
+                ", triggerIds=" + triggerIds +
+                ", tagQuery='" + tagQuery + '\'' +
+                ", thin=" + thin +
+                '}';
     }
 
     private static boolean isEmpty(String s) {

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
@@ -100,6 +100,7 @@ public class PublishCacheManager {
             definitions.registerListener(events -> {
                 log.debugf("Receiving %s", events);
                 events.stream().forEach(e -> {
+                    log.debugf("Received %s", e);
                     String tenantId = e.getTargetTenantId();
                     String triggerId = e.getTargetId();
                     TriggerKey triggerKey = new TriggerKey(tenantId, triggerId);

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/impl/CassStatement.java
@@ -46,6 +46,7 @@ public class CassStatement {
     public static final String DELETE_ALERT;
     public static final String DELETE_ALERT_CTIME;
     public static final String DELETE_ALERT_LIFECYCLE;
+    public static final String DELETE_ALERT_STIME;
     public static final String DELETE_ALERT_TRIGGER;
     public static final String DELETE_CONDITIONS;
     public static final String DELETE_CONDITIONS_MODE;
@@ -70,6 +71,7 @@ public class CassStatement {
     public static final String INSERT_ALERT;
     public static final String INSERT_ALERT_CTIME;
     public static final String INSERT_ALERT_LIFECYCLE;
+    public static final String INSERT_ALERT_STIME;
     public static final String INSERT_ALERT_TRIGGER;
     public static final String INSERT_CONDITION_AVAILABILITY;
     public static final String INSERT_CONDITION_COMPARE;
@@ -116,6 +118,9 @@ public class CassStatement {
     public static final String SELECT_ALERT_LIFECYCLE_END;
     public static final String SELECT_ALERT_LIFECYCLE_START;
     public static final String SELECT_ALERT_LIFECYCLE_START_END;
+    public static final String SELECT_ALERT_STIME_END;
+    public static final String SELECT_ALERT_STIME_START;
+    public static final String SELECT_ALERT_STIME_START_END;
     public static final String SELECT_ALERT_TRIGGER;
     public static final String SELECT_ALERTS_BY_TENANT;
     public static final String SELECT_CONDITION_ID;
@@ -188,6 +193,9 @@ public class CassStatement {
         DELETE_ALERT_LIFECYCLE = "DELETE FROM " + keyspace + ".alerts_lifecycle "
                 + "WHERE tenantId = ? AND status = ? AND stime = ? AND alertId = ? ";
 
+        DELETE_ALERT_STIME = "DELETE FROM " + keyspace + ".alerts_stimes "
+                + "WHERE tenantId = ? AND stime = ? AND alertId = ? ";
+
         DELETE_ALERT_TRIGGER = "DELETE FROM " + keyspace + ".alerts_triggers "
                 + "WHERE tenantId = ? AND triggerId = ? AND alertId = ? ";
 
@@ -256,6 +264,9 @@ public class CassStatement {
 
         INSERT_ALERT_LIFECYCLE = "INSERT INTO " + keyspace + ".alerts_lifecycle "
                 + "(tenantId, alertId, status, stime) VALUES (?, ?, ?, ?) ";
+
+        INSERT_ALERT_STIME = "INSERT INTO " + keyspace + ".alerts_stimes "
+                + "(tenantId, alertId, stime) VALUES (?, ?, ?) ";
 
         INSERT_ALERT_TRIGGER = "INSERT INTO " + keyspace + ".alerts_triggers "
                 + "(tenantId, alertId, triggerId) VALUES (?, ?, ?) ";
@@ -405,6 +416,15 @@ public class CassStatement {
 
         SELECT_ALERT_LIFECYCLE_START_END = "SELECT alertId FROM " + keyspace + ".alerts_lifecycle "
                 + "WHERE tenantId = ? AND status = ? AND stime >= ? AND stime <= ? ";
+
+        SELECT_ALERT_STIME_END = "SELECT alertId FROM " + keyspace + ".alerts_stimes "
+                + "WHERE tenantId = ? AND stime <= ? ";
+
+        SELECT_ALERT_STIME_START = "SELECT alertId FROM " + keyspace + ".alerts_stimes "
+                + "WHERE tenantId = ? AND stime >= ? ";
+
+        SELECT_ALERT_STIME_START_END = "SELECT alertId FROM " + keyspace + ".alerts_stimes "
+                + "WHERE tenantId = ? AND stime >= ? AND stime <= ? ";
 
         SELECT_ALERTS_BY_TENANT = "SELECT payload FROM " + keyspace + ".alerts " + "WHERE tenantId = ? ";
 

--- a/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.6.0.groovy
+++ b/hawkular-alerts-engine/src/main/resources/org/hawkular/alerts/schema/updates/schema-1.6.0.groovy
@@ -14,15 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.alerts.schema
-
-include '/org/hawkular/alerts/schema/bootstrap.groovy'
 
 setKeyspace keyspace
 
-// Upgrade scripts are defined here:
-include '/org/hawkular/alerts/schema/updates/schema-1.2.1.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.2.3.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.4.0.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.5.0.groovy'
-include '/org/hawkular/alerts/schema/updates/schema-1.6.0.groovy'
+schemaChange {
+  version '5.0'
+  author 'lponce'
+  tags '1.6.x'
+  cql """
+CREATE TABLE alerts_stimes (
+    tenantId text,
+    alertId text,
+    stime bigint,
+    PRIMARY KEY (tenantId, stime, alertId)
+)
+"""
+  verify { tableExists(keyspace, "alerts_stimes") }
+}

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
@@ -653,7 +653,7 @@ class ActionsITest extends AbstractITestBase {
 
         // Check actions generated
         // This used to fail randomly, therefore try several times before failing
-        for ( int i=0; i < 20; ++i ) {
+        for ( int i=0; i < 30; ++i ) {
             resp = client.get(path: "actions/history",
                     query: [startTime:start,actionPlugins:"email",
                             actionIds:"global-action-notify-to-admins,global-action-notify-to-developers"])

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
@@ -57,6 +57,9 @@ class AlertsITest extends AbstractITestBase {
 
         resp = client.get(path: "", query: [endAckTime:now, startAckTime:"0"] )
         assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endStatusTime:now, startStatusTime:"0"] )
+        assert resp.status == 200 : resp.status
     }
 
     @Test
@@ -88,6 +91,9 @@ class AlertsITest extends AbstractITestBase {
         assert resp.status == 200 : resp.status
 
         resp = client.put(path: "delete", query: [endAckTime:now, startAckTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endStatusTime:now, startStatusTime:"0"] )
         assert resp.status == 200 : resp.status
     }
 

--- a/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/StreamWatcher.java
+++ b/hawkular-alerts-rest/hawkular-alerts-rest-api/src/main/java/org/hawkular/alerts/rest/StreamWatcher.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.rest;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ws.rs.core.StreamingOutput;
+
+import org.hawkular.alerts.api.json.JsonUtil;
+import org.hawkular.alerts.api.model.event.Alert;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.paging.Order;
+import org.hawkular.alerts.api.model.paging.Page;
+import org.hawkular.alerts.api.model.paging.PageContext;
+import org.hawkular.alerts.api.model.paging.Pager;
+import org.hawkular.alerts.api.services.AlertsCriteria;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.EventsCriteria;
+import org.jboss.logging.Logger;
+
+/**
+ * Handle StreamingOutput logic for events/alerts Watchers.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Stateless
+public class StreamWatcher {
+    private static final Logger log = Logger.getLogger(StreamWatcher.class);
+    private static final Pager ctimePager;
+    private static final Pager stimePager;
+    private static final long WATCHER_INTERVAL_DEFAULT = 5 * 1000;
+    private static final long CLEAN_INTERVAL = 10 * 1000;
+    private static final long LEAP_INTERVAL = 1 * 1000;
+
+    @EJB
+    AlertsService alertsService;
+
+    static {
+        List<Order> ordering = new ArrayList<>();
+        ordering.add(Order.by("stime", Order.Direction.ASCENDING));
+        stimePager = new Pager(0, PageContext.UNLIMITED_PAGE_SIZE, ordering);
+        ordering = new ArrayList<>();
+        ordering.add(Order.by("ctime", Order.Direction.ASCENDING));
+        ctimePager = new Pager(0, PageContext.UNLIMITED_PAGE_SIZE, ordering);
+    }
+
+    public StreamingOutput watchAlerts(Set<String> tenantIds, AlertsCriteria criteria, Long watchInterval) {
+        return output -> {
+            Writer writer = new BufferedWriter(new OutputStreamWriter(output));
+            Long startWatchTime = criteria.getEndStatusTime();
+            Page<Alert> initialAlerts;
+            try {
+                initialAlerts = alertsService.getAlerts(tenantIds, criteria, stimePager);
+            } catch (Exception e) {
+                log.debug(e.getMessage(), e);
+                try {
+                    writer.write(JsonUtil.toJson(new ResponseUtil.ApiError(e.getMessage())) + "\r\n");
+                    writer.flush();
+                } catch (IOException io) {
+                    log.debug("Watcher client disconnected");
+                    try {
+                        writer.close();
+                    } catch (Exception ignored) {}
+                }
+                return;
+            }
+            if (initialAlerts == null) {
+                return;
+            }
+            Set<WatchedId> watchedIds = new HashSet<>();
+            initialAlerts.stream().forEach(alert -> {
+                try {
+                    writer.write(JsonUtil.toJson(alert) + "\r\n");
+                    writer.flush();
+                } catch (IOException io) {
+                    log.debug("Watcher client disconnected");
+                    try {
+                        writer.close();
+                    } catch (Exception ignored) {}
+                    return;
+                }
+                watchedIds.add(new WatchedId(alert.getId(), alert.getCurrentLifecycle().getStime()));
+            });
+            startWatchTime = startWatchTime == null ? System.currentTimeMillis() : startWatchTime;
+            long sleepWatcher = watchInterval == null ? WATCHER_INTERVAL_DEFAULT : watchInterval * 1000;
+            /*
+                Watcher will reuse the AlertsCriteria but without time constraints.
+                Time constraints are defined by the watcher on stime via regular intervals.
+             */
+            criteria.setStartTime(null);
+            criteria.setEndTime(null);
+            criteria.setStartAckTime(null);
+            criteria.setEndAckTime(null);
+            criteria.setStartResolvedTime(null);
+            criteria.setEndResolvedTime(null);
+            boolean connected = true;
+            long lastWatched = System.currentTimeMillis();
+            Set<WatchedId> newWatchedIds = new HashSet<>();
+            while (connected) {
+                startWatchTime = criteria.getEndStatusTime() == null ? startWatchTime : criteria.getEndStatusTime();
+                criteria.setStartStatusTime(startWatchTime);
+                criteria.setEndStatusTime(System.currentTimeMillis());
+                try {
+                    Thread.sleep(LEAP_INTERVAL);
+                    log.debugf("Query timestamp %s. startStatusTime: %s endStatusTime: %s",
+                            System.currentTimeMillis(), criteria.getStartStatusTime(), criteria.getEndStatusTime());
+                    Page<Alert> watchedAlerts = alertsService.getAlerts(tenantIds, criteria, stimePager);
+                    for (Alert alert : watchedAlerts) {
+                        WatchedId watchedId = new WatchedId(alert.getId(), alert.getCurrentLifecycle().getStime());
+                        if (!watchedIds.contains(watchedId)) {
+                            try {
+                                writer.write(JsonUtil.toJson(alert) + "\r\n");
+                                writer.flush();
+                            } catch (IOException io) {
+                                log.debug("Watcher client disconnected");
+                                connected = false;
+                                try {
+                                    writer.close();
+                                } catch (Exception ignored) {}
+                            }
+                            newWatchedIds.add(watchedId);
+                        }
+                    }
+                    if (System.currentTimeMillis() - lastWatched > CLEAN_INTERVAL) {
+                        watchedIds.clear();
+                        lastWatched = System.currentTimeMillis();
+                    }
+                    watchedIds.addAll(newWatchedIds);
+                    try {
+                        writer.write(0);
+                        writer.flush();
+                    } catch (IOException io) {
+                        log.debug("Watcher client disconnected");
+                        connected = false;
+                        try {
+                            writer.close();
+                        } catch (Exception ignored) {}
+                    }
+                    Thread.sleep(sleepWatcher);
+                } catch (InterruptedException e) {
+                    log.debug("Watcher interrupted");
+                    try {
+                        writer.close();
+                    } catch (Exception ignored) {}
+                    return;
+                } catch (Exception e) {
+                    log.debug(e.getMessage(), e);
+                    try {
+                        writer.write(JsonUtil.toJson(new ResponseUtil.ApiError(e.getMessage())) + "\r\n");
+                        writer.flush();
+                        writer.close();
+                    } catch (IOException io) {
+                        log.debug("Watcher client disconnected");
+                    }
+                    return;
+                }
+            }
+        };
+    }
+
+    public StreamingOutput watchEvents(Set<String> tenantIds, EventsCriteria criteria, Long watchInterval) {
+        return output -> {
+            Writer writer = new BufferedWriter(new OutputStreamWriter(output));
+            Long startWatchTime = criteria.getEndTime();
+            Page<Event> initialEvents;
+            try {
+                initialEvents = alertsService.getEvents(tenantIds, criteria, ctimePager);
+            } catch (Exception e) {
+                log.debug(e.getMessage(), e);
+                try {
+                    writer.write(JsonUtil.toJson(new ResponseUtil.ApiError(e.getMessage())) + "\r\n");
+                    writer.flush();
+                } catch (IOException io) {
+                    log.debug("Watcher client disconnected");
+                }
+                return;
+            }
+            if (initialEvents == null) {
+                return;
+            }
+            Set<WatchedId> watchedIds = new HashSet<>();
+            initialEvents.stream().forEach(event -> {
+                try {
+                    writer.write(JsonUtil.toJson(event) + "\r\n");
+                    writer.flush();
+                } catch (IOException io) {
+                    log.debug("Watcher client disconnected");
+                    return;
+                }
+                watchedIds.add(new WatchedId(event.getId(), event.getCtime()));
+            });
+            startWatchTime = startWatchTime == null ? System.currentTimeMillis() : startWatchTime;
+            long sleepWatcher = watchInterval == null ? WATCHER_INTERVAL_DEFAULT : watchInterval * 1000;
+            /*
+                Watcher will reuse the AlertsCriteria but without time constraints.
+                Time constraints are defined by the watcher on stime via regular intervals.
+             */
+            criteria.setStartTime(null);
+            criteria.setEndTime(null);
+            boolean connected = true;
+            long lastWatched = System.currentTimeMillis();
+            Set<WatchedId> newWatchedIds = new HashSet<>();
+            while (connected) {
+                startWatchTime = criteria.getEndTime() == null ? startWatchTime : criteria.getEndTime();
+                criteria.setStartTime(startWatchTime);
+                criteria.setEndTime(System.currentTimeMillis());
+                try {
+                    Thread.sleep(LEAP_INTERVAL);
+                    log.debugf("Query timestamp %s. startTime: %s endTime: %s",
+                            System.currentTimeMillis(), criteria.getStartTime(), criteria.getEndTime());
+                    Page<Event> watchedEvents = alertsService.getEvents(tenantIds, criteria, ctimePager);
+                    for (Event event : watchedEvents) {
+                        WatchedId watchedId = new WatchedId(event.getId(), event.getCtime());
+                        if (!watchedIds.contains(watchedId)) {
+                            try {
+                                writer.write(JsonUtil.toJson(event) + "\r\n");
+                                writer.flush();
+                            } catch (IOException io) {
+                                log.debug("Watcher client disconnected");
+                                connected = false;
+                            }
+                            newWatchedIds.add(watchedId);
+                        }
+                    }
+                    if (System.currentTimeMillis() - lastWatched > CLEAN_INTERVAL) {
+                        watchedIds.clear();
+                        lastWatched = System.currentTimeMillis();
+                    }
+                    watchedIds.addAll(newWatchedIds);
+                    try {
+                        writer.write(0);
+                        writer.flush();
+                    } catch (IOException io) {
+                        log.debug("Watcher client disconnected");
+                        connected = false;
+                    }
+                    Thread.sleep(sleepWatcher);
+                } catch (InterruptedException e) {
+                    log.debug("Watcher interrupted");
+                    return;
+                } catch (Exception e) {
+                    log.debug(e.getMessage(), e);
+                    try {
+                        writer.write(JsonUtil.toJson(new ResponseUtil.ApiError(e.getMessage())) + "\r\n");
+                        writer.flush();
+                    } catch (IOException io) {
+                        log.debug("Watcher client disconnected");
+                    }
+                    return;
+                }
+            }
+        };
+    }
+
+    private static class WatchedId {
+        String id;
+        long stime;
+
+        public WatchedId(String id, long stime) {
+            this.id = id;
+            this.stime = stime;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            WatchedId watchedId = (WatchedId) o;
+
+            if (stime != watchedId.stime) return false;
+            return id != null ? id.equals(watchedId.id) : watchedId.id == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id != null ? id.hashCode() : 0;
+            result = 31 * result + (int) (stime ^ (stime >>> 32));
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
- Add support for filtering alerts by stime field without requiring status
- Introduce a REST stream watchers feature for alerts and events
- Make this feature available for crosstenant operations

I have started two approaches for this feature, a preliminar one (available here https://github.com/lucasponce/hawkular-alerts/tree/watchers-support-without-polling) uses a listener directly from the engine. This one has the advantages that does not require quering the backend, and that seemed a nice approach at the beginning. After some development, I realized that ensuring an ordered timeline could be more complex, as the asynchornous nature of our distributed design. So, I started this second approach which I think it is also interesting, as it offers to watch alerts and events in a timeline.
Guaranteeing that all alerts and events are watched in a strict timeline.

So, with this feature in place, no need to add additional mechanism as tagging to mark alerts as "seen", when a watcher session is open, all alerts and lifecycle states can be observed and client can use timestamps in a reliable way, as when an alert is observed, system guarantees that there is not possibility (*) of observation of an alert before.

(*) Disclaimer: to fully stand this, we should need a strong transactional system between several components, which is something we don't handle, but algorithm design should guarantee this under normal circumstances (i.e. no corrupted scenarios or similar unhandled situations).
