### PR TITLE
ElasticSearch Tutorial as Docker Container

### DIFF
--- a/examples/elasticsearch/Dockerfile
+++ b/examples/elasticsearch/Dockerfile
@@ -1,0 +1,72 @@
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# @author Guilherme Baufaker Rêgo
+
+# Hawkular Alerting ElasticSearch Sample
+
+FROM fedora
+
+MAINTAINER Hawkular Alerting <hawkular-dev@lists.jboss.org>
+
+RUN dnf -y install wget git
+
+EXPOSE 5601 8080 9200
+
+
+### Java Version
+
+ENV JAVA_VERSION 8u111
+ENV BUILD_VERSION b14
+
+# Downloading Java and Installing Java
+RUN wget --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-$BUILD_VERSION/jdk-$JAVA_VERSION-linux-x64.rpm" -O /tmp/jdk-8-linux-x64.rpm
+RUN yum -y install /tmp/jdk-8-linux-x64.rpm
+
+RUN alternatives --install /usr/bin/java jar /usr/java/latest/bin/java 200000
+RUN alternatives --install /usr/bin/javaws javaws /usr/java/latest/bin/javaws 200000
+RUN alternatives --install /usr/bin/javac javac /usr/java/latest/bin/javac 200000
+ENV JAVA_HOME /usr/java/latest
+
+Run dnf -y install maven unzip
+# Install Elastic Search
+RUN wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.4.4/elasticsearch-2.4.4.zip
+RUN unzip elasticsearch-2.4.4.zip -d /opt/
+RUN mv /opt/elasticsearch-2.4.4/ /opt/elasticsearch/
+
+# Install Kibana
+RUN wget https://download.elastic.co/kibana/kibana/kibana-4.6.4-linux-x86_64.tar.gz
+RUN mkdir -p tar /opt/kibana/ && tar xvfz kibana-4.6.4-linux-x86_64.tar.gz -C /opt/kibana/ --strip-components=1
+
+# Clone the repository
+RUN git clone https://github.com/hawkular/hawkular-alerts.git /opt/hawkular-alerts
+
+
+# Copy the resources 
+
+COPY create-definitions.sh \ /opt/
+
+COPY create-logs.sh \ /opt/
+
+COPY elasticsearch-triggers.json \ /opt/
+
+
+RUN  cd /opt/hawkular-alerts/ && mvn clean install
+
+# CMD /opt/hawkular-alerts/hawkular-alerts-rest-tests/target/wildfly-10.0.0.Final/bin/standalone.sh 2>&1
+# CMD /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true
+# CMD /opt/kibana/bin/kibana
+# CMD /opt/create-definitions.sh
+# CMD /opt/create-logs.sh

--- a/examples/elasticsearch/Dockerfile
+++ b/examples/elasticsearch/Dockerfile
@@ -1,3 +1,4 @@
+#
 # Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
@@ -12,10 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-# @author Guilherme Baufaker Rêgo
-
-# Hawkular Alerting ElasticSearch Sample
+# @author Guilherme Baufaker Rêgo (@gbaufake)
+# Docker Container for Tutorial on Hawkular Alerts with ElasticSearh
 
 FROM fedora
 
@@ -54,7 +55,7 @@ RUN mkdir -p tar /opt/kibana/ && tar xvfz kibana-4.6.4-linux-x86_64.tar.gz -C /o
 RUN git clone https://github.com/hawkular/hawkular-alerts.git /opt/hawkular-alerts
 
 
-# Copy the resources 
+# Copy the resources
 
 COPY create-definitions.sh \ /opt/
 

--- a/examples/elasticsearch/README.adoc
+++ b/examples/elasticsearch/README.adoc
@@ -58,6 +58,25 @@ Start the standalone server
     bin/standalone.sh
 ----
 
+== Alternative as Docker Container
+
+This tutorial can be followed as docker container.
+
+That can be done by the following commands:
+
+[source,shell,subs="+attributes"]
+----
+docker build -t hawkular-alerts-elasticsearch .
+docker run -i -t  hawkular-alerts-elasticsearch /bin/bash
+nohup /opt/hawkular-alerts/hawkular-alerts-rest-tests/target/wildfly-10.0.0.Final/bin/standalone.sh > hawkular-alerts.out 
+nohup /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true > elastic-search.out 
+nohup /opt/kibana/bin/kibana > kibana.out 
+/opt/create-definitions.sh
+/opt/create-logs.sh
+----
+
+
+
 [TIP]
 .Test Email server
 ==================


### PR DESCRIPTION
Hi guys!

I converted the elasticsearch tutorial to a docker container.

Run the tutorial as docker container by the following commands

```
docker build -t hawkular-alerts-elasticsearch .
docker run -i -t  hawkular-alerts-elasticsearch /bin/bash
nohup /opt/hawkular-alerts/hawkular-alerts-rest-tests/target/wildfly-10.0.0.Final/bin/standalone.sh > hawkular-alerts.out 
nohup /opt/elasticsearch/bin/elasticsearch -Des.insecure.allow.root=true > elastic-search.out 
nohup /opt/kibana/bin/kibana > kibana.out 
/opt/create-definitions.sh
/opt/create-logs.sh
```

Best Regards!
Guilherme Baufaker Rêgo
