### PR TITLE
HWKALERTS-262 Fix notification issues when setting conditions

### DIFF
--- a/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
+++ b/hawkular-alerts-api/src/main/java/org/hawkular/alerts/api/services/DefinitionsService.java
@@ -369,66 +369,31 @@ public interface DefinitionsService {
      */
 
     /**
-     * A convenience method that adds a new Condition to the existing condition set for the specified
-     * Trigger and trigger mode.  The new condition will be assigned the highest conditionSetIndex for the
-     * updated conditionSet.
+     * The condition set for a trigger's trigger mode is treated as a whole.  When making any change to the
+     * conditions just [re-]set all of the conditions.  This method replaces all existing conditions (regardless
+     * of trigger mode) with the provided set of new conditions. triggerMode is required to be set for each
+     * provided condition.
      * <p>
-     * IMPORTANT! Add/Delete/Update of a condition effectively replaces the condition set for the trigger.  The new
-     * condition set is returned. Clients code should then use the new condition set as ConditionIds may have changed!
+     * IMPORTANT! The new condition set is returned. Clients code should then use the new condition set as
+     * ConditionIds may have changed!
      * </p>
-     * The following Condition fields are ignored for the incoming condition, and set in the returned collection set:
+     * The following Condition fields are ignored for the incoming conditions, and set in the returned collection:
      * <pre>
      *   conditionId
      *   triggerId
-     *   triggerMode
      *   conditionSetSize
      *   conditionSetIndex
      * </pre>
-     * @param tenantId Tenant where trigger is stored
-     * @param triggerId Trigger where condition will be stored
-     * @param triggerMode Mode where condition is applied
-     * @param condition Not null
-     * @return The updated, persisted condition set
-     * @throws NotFoundException if trigger is not found
-     * @throws Exception on any problem
-     * @see {@link #addGroupCondition(String, String, Mode, Condition, Map)} for group-level conditions.
-     * @deprecated use {@link #setConditions(String, String, Mode, Collection)}
-     */
-    @Deprecated
-    Collection<Condition> addCondition(String tenantId, String triggerId, Mode triggerMode, Condition condition)
-            throws Exception;
-
-    /**
-     * A convenience method that removes a Condition from an existing condition set.
-     * <p>
-     * IMPORTANT! Add/Delete/Update of a condition effectively replaces the condition set for the trigger.  The new
-     * condition set is returned. Clients code should then use the new condition set as ConditionIds may have changed!
-     * </p>
      * @param tenantId Tenant where trigger and his conditions are stored
-     * @param conditionId Condition id to be removed
-     * @return The updated, persisted condition set. Not null. Can be empty.
+     * @param triggerId Trigger where conditions will be stored
+     * @param conditions Not null, Not Empty
+     * @return The persisted condition set
      * @throws Exception on any problem
-     * @see {@link #removeGroupCondition(String, String)} for group-level conditions.
-     * @deprecated use {@link #setConditions(String, String, Mode, Collection)}
+     * @see {@link #removeGroupCondition(String, String)} to remove a group condition.
+     * @see {@link #addGroupCondition(String, String, Mode, Condition, Map)} to add a group condition.
      */
-    @Deprecated
-    Collection<Condition> removeCondition(String tenantId, String conditionId) throws Exception;
-
-    /**
-     * A convenience method that updates an existing condition.
-     * <p>
-     * IMPORTANT! Add/Delete/Update of a condition effectively replaces the condition set for the trigger.  The new
-     * condition set is returned. Clients code should then use the new condition set as ConditionIds may have changed!
-     * </p>
-     * @param tenantId
-     * @param condition Not null. conditionId must be for an existing condition.
-     * @return The updated, persisted condition set. Not null. Can be empty.
-     * @throws Exception on any problem
-     * @see {@link #updateGroupCondition(String, Condition)} for group-level conditions.
-     * @deprecated use {@link #setConditions(String, String, Mode, Collection)}
-     */
-    @Deprecated
-    Collection<Condition> updateCondition(String tenantId, Condition condition) throws Exception;
+    Collection<Condition> setAllConditions(String tenantId, String triggerId,
+            Collection<Condition> conditions) throws Exception;
 
     /**
      * The condition set for a trigger's trigger mode is treated as a whole.  When making any change to the
@@ -446,10 +411,6 @@ public interface DefinitionsService {
      *   conditionSetIndex
      * </pre>
      * <p>
-     * Note that due to the complexity of adding group-level conditions, it is only supported to
-     * add or remove a single group condition at one time.  So there is no <code>setGroupConditions</code>.
-     * Instead, use {@link #addGroupCondition(String, String, Mode, Condition, Map)} and
-     * {@link #removeGroupCondition(String, String)} as needed.
      * @param tenantId Tenant where trigger and his conditions are stored
      * @param triggerId Trigger where conditions will be stored
      * @param triggerMode Mode where conditions are applied

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
@@ -21,6 +21,7 @@ import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.TRIGGER_REM
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -77,7 +78,7 @@ public class PublishCacheManager {
     private Cache<TriggerKey, Set<String>> publishDataIdsCache;
 
     // It stores a list of triggerIds used per key (tenantId, dataId).
-    // This cache is used by CacheClient to check wich dataIds are published and forwarded from metrics.
+    // This cache is used by CacheClient to check which dataIds are published and forwarded from metrics.
     @Resource(lookup = "java:jboss/infinispan/cache/hawkular-alerts/publish")
     private Cache<CacheKey, Set<String>> publishCache;
 
@@ -99,25 +100,39 @@ public class PublishCacheManager {
 
             definitions.registerListener(events -> {
                 log.debugf("Receiving %s", events);
-                events.stream().forEach(e -> {
-                    log.debugf("Received %s", e);
-                    String tenantId = e.getTargetTenantId();
-                    String triggerId = e.getTargetId();
-                    TriggerKey triggerKey = new TriggerKey(tenantId, triggerId);
-                    publishCache.startBatch();
-                    publishDataIdsCache.startBatch();
-                    Set<String> oldDataIds = publishDataIdsCache.get(triggerKey);
-                    removePublishCache(tenantId, triggerId, oldDataIds);
-                    if (e.getType().equals(TRIGGER_CONDITION_CHANGE)) {
-                        Set<String> newDataIds = e.getDataIds();
-                        publishDataIdsCache.put(triggerKey, newDataIds);
-                        addPublishCache(tenantId, triggerId, newDataIds);
-                    }
-                    publishDataIdsCache.endBatch(true);
-                    publishCache.endBatch(true);
-                });
+                events.stream()
+                        .forEach(e -> {
+                            log.debugf("Received %s", e);
+                            String tenantId = e.getTargetTenantId();
+                            String triggerId = e.getTargetId();
+                            TriggerKey triggerKey = new TriggerKey(tenantId, triggerId);
+                            publishCache.startBatch();
+                            publishDataIdsCache.startBatch();
+                            switch (e.getType()) {
+                                case TRIGGER_CONDITION_CHANGE: {
+                                    Set<String> oldDataIds = publishDataIdsCache.getOrDefault(triggerKey,
+                                            Collections.emptySet());
+                                    Set<String> newDataIds = e.getDataIds();
+                                    if (!oldDataIds.equals(newDataIds)) {
+                                        removePublishCache(tenantId, triggerId, oldDataIds);
+                                        addPublishCache(tenantId, triggerId, newDataIds);
+                                        publishDataIdsCache.put(triggerKey, newDataIds);
+                                    }
+                                    break;
+                                }
+                                case TRIGGER_REMOVE: {
+                                    Set<String> oldDataIds = publishDataIdsCache.get(triggerKey);
+                                    removePublishCache(tenantId, triggerId, oldDataIds);
+                                    publishDataIdsCache.remove(triggerKey);
+                                    break;
+                                }
+                                default:
+                                    throw new IllegalStateException("Unexpected notification: " + e.toString());
+                            }
+                            publishDataIdsCache.endBatch(true);
+                            publishCache.endBatch(true);
+                        });
             }, TRIGGER_CONDITION_CHANGE, TRIGGER_REMOVE);
-
 
         } else {
             msgLog.warnDisabledPublishCache();


### PR DESCRIPTION
A couple of related problems fixed here:
- remove deprecated java API add/remove/updateCondition
  - internal use caused some problems, just kill them
- avoid unnecessary cache updates in publishCacheManager
- add setAllConditions() to java API
  - avoids multiple notifications
  - ensures all dataids for a trigger (both modes) are correctly cached

@lucasponce please review. The problems here were subtle, they hit me only intermittently after I had made a change to the metrics alerter's notification listener and "refresh" code.