### PR TITLE
Move Indexes to impl details

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,12 +51,6 @@
       <version>${version.com.fasterxml.jackson}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-search-engine</artifactId>
-      <version>${version.org.hibernate}</version>
-    </dependency>
-
     <!-- Documentation dependencies -->
     <dependency>
       <groupId>io.swagger</groupId>

--- a/api/src/main/java/org/hawkular/alerts/api/model/action/ActionDefinition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/action/ActionDefinition.java
@@ -22,11 +22,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Store;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.swagger.annotations.ApiModel;
@@ -67,13 +62,11 @@ import io.swagger.annotations.ApiModelProperty;
         " + \n" +
         "If a <<TriggerAction>> defines any constraints the <<ActionDefinition>> constraints will be ignored. + \n" +
         "If a <<TriggerAction>> defines no constraints the <<ActionDefinition>> constraints will be used. + \n")
-@Indexed(index = "actionDefinition")
 public class ActionDefinition implements Serializable {
 
     @ApiModelProperty(value = "Tenant id owner of this trigger.",
             position = 0,
             allowableValues = "Tenant is overwritten from Hawkular-Tenant HTTP header parameter request")
-    @Field(store = Store.YES, analyze = Analyze.NO)
     @JsonInclude
     private String tenantId;
 
@@ -81,21 +74,18 @@ public class ActionDefinition implements Serializable {
             position = 1,
             required = true,
             allowableValues = "Only plugins deployed on the system are valid.")
-    @Field(store = Store.YES, analyze = Analyze.NO)
     @JsonInclude
     private String actionPlugin;
 
     @ApiModelProperty(value = "Action definition identifier.",
             position = 2,
             required = true)
-    @Field(store = Store.YES, analyze = Analyze.NO)
     @JsonInclude
     private String actionId;
 
     @ApiModelProperty(value = "Flag to indicate this is a global action.",
             position = 3,
             required = false)
-    @Field(store = Store.YES, analyze = Analyze.NO)
     @JsonInclude
     private boolean global;
 
@@ -130,6 +120,19 @@ public class ActionDefinition implements Serializable {
     public ActionDefinition(String tenantId, String actionPlugin, String actionId,
                             Map<String, String> properties) {
         this(tenantId, actionPlugin, actionId, false, properties, null, null);
+    }
+
+    public ActionDefinition(ActionDefinition actionDefinition) {
+        if (actionDefinition == null) {
+            throw new IllegalArgumentException("actionDefinition must be not null");
+        }
+        this.tenantId = actionDefinition.getTenantId();
+        this.actionPlugin = actionDefinition.getActionPlugin();
+        this.actionId = actionDefinition.getActionId();
+        this.global = actionDefinition.isGlobal();
+        this.properties = actionDefinition.getProperties() != null ? new HashMap<>(actionDefinition.getProperties()) : new HashMap<>();
+        this.states = new HashSet<>(actionDefinition.getStates());
+        this.calendar = actionDefinition.getCalendar() != null ? new TimeConstraint(actionDefinition.getCalendar()) : null;
     }
 
     public ActionDefinition(String tenantId, String actionPlugin, String actionId, boolean global,

--- a/api/src/main/java/org/hawkular/alerts/api/model/action/TimeConstraint.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/action/TimeConstraint.java
@@ -390,6 +390,17 @@ public class TimeConstraint implements Serializable {
         this(startTime, endTime, null, relative, inRange);
     }
 
+    public TimeConstraint(TimeConstraint timeConstraint) {
+        if (timeConstraint == null) {
+            throw new IllegalArgumentException("timeConstraint must be not null");
+        }
+        this.startTime = timeConstraint.getStartTime();
+        this.endTime = timeConstraint.getEndTime();
+        this.relative = timeConstraint.isRelative();
+        this.inRange = timeConstraint.isInRange();
+        setTimeZoneName(timeConstraint.getTimeZoneName());
+    }
+
     public TimeConstraint(String startTime, String endTime, String timeZoneName, boolean relative, boolean inRange) {
         if (isEmpty(startTime)) {
             throw new IllegalArgumentException("startTime must be not null");

--- a/api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -258,6 +258,22 @@ public class Dampening implements Serializable {
         return new Dampening(tenantId, triggerId, triggerMode, Type.STRICT_TIMEOUT, 0, 0, evalPeriod);
     }
 
+    public Dampening(Dampening dampening) {
+        if (dampening == null) {
+            throw new IllegalArgumentException("dampening must be not null");
+        }
+        this.tenantId = dampening.getTenantId();
+        this.triggerId = dampening.getTriggerId();
+        this.type = dampening.getType();
+        this.evalTrueSetting = dampening.getEvalTrueSetting();
+        this.evalTotalSetting = dampening.getEvalTotalSetting();
+        this.evalTimeSetting = dampening.getEvalTimeSetting();
+        this.triggerMode = dampening.getTriggerMode();
+        updateId();
+
+        reset();
+    }
+
     public Dampening(String tenantId, String triggerId, Mode triggerMode, Type type, int evalTrueSetting,
             int evalTotalSetting, long evalTimeSetting) {
         super();

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -27,7 +27,6 @@ import org.hawkular.alerts.api.model.Severity;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.trigger.Trigger;
-import org.hibernate.search.annotations.Indexed;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -60,7 +59,6 @@ import io.swagger.annotations.ApiModelProperty;
         " + \n" +
         "There are many options on triggers to help ensure that alerts are not generated too frequently, + \n" +
         "including ways of automatically disabling and enabling the trigger. + \n")
-@Indexed(index = "alert")
 public class Alert extends Event {
 
     public enum Status {
@@ -108,6 +106,18 @@ public class Alert extends Event {
         this(tenantId, trigger, null, evalSets);
     }
 
+    public Alert(Alert alert) {
+        super((Event) alert);
+
+        this.status = alert.getStatus();
+        this.severity = alert.getSeverity();
+        this.eventType = alert.getEventType();
+        this.lifecycle = new ArrayList<>();
+        for (LifeCycle item : alert.getLifecycle()) {
+            this.lifecycle.add(new LifeCycle(item));
+        }
+    }
+
     public Alert(String tenantId, Trigger trigger, Dampening dampening, List<Set<ConditionEval>> evalSets) {
         super(tenantId, trigger, dampening, evalSets);
 
@@ -115,16 +125,6 @@ public class Alert extends Event {
         this.severity = trigger.getSeverity();
         this.eventType = EventType.ALERT.name();
         addLifecycle(this.status, "system", this.ctime);
-    }
-
-    // TODO Workaround for infinispan/objectfilter
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    // TODO Workaround for infinispan/objectfilter
-    public Map<String, String> getTags() {
-        return tags;
     }
 
     @JsonIgnore
@@ -367,6 +367,15 @@ public class Alert extends Event {
 
         public LifeCycle() {
             // for json assembly
+        }
+
+        public LifeCycle(LifeCycle lifeCycle) {
+            if (lifeCycle == null) {
+                throw new IllegalArgumentException("lifeCycle must be not null");
+            }
+            this.status = lifeCycle.getStatus();
+            this.user = lifeCycle.getUser();
+            this.stime = lifeCycle.getStime();
         }
 
         public LifeCycle(Status status, String user, long stime) {

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
 
 import org.hawkular.alerts.api.model.Severity;
@@ -119,6 +120,11 @@ public class Alert extends Event {
     // TODO Workaround for infinispan/objectfilter
     public String getTenantId() {
         return tenantId;
+    }
+
+    // TODO Workaround for infinispan/objectfilter
+    public Map<String, String> getTags() {
+        return tags;
     }
 
     @JsonIgnore

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -26,9 +26,11 @@ import java.util.UUID;
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.index.TagsBridge;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
 
@@ -152,6 +154,7 @@ public class Event implements Comparable<Event>, Serializable {
             "Tags can be used as part of Event conditions expressions and criteria in finder methods. + \n" +
             "Tag value cannot be null.",
             position = 9)
+    @FieldBridge(impl = TagsBridge.class)
     @JsonInclude(Include.NON_EMPTY)
     protected Map<String, String> tags;
 

--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -26,12 +26,6 @@ import java.util.UUID;
 import org.hawkular.alerts.api.model.Severity;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.EventType;
-import org.hawkular.alerts.api.model.index.TagsBridge;
-import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.FieldBridge;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Store;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -60,7 +54,6 @@ import io.swagger.annotations.ApiModelProperty;
         " + \n" +
         "The mode is also needed when defining a trigger, to indicate the relevant mode for a conditions or " +
         "dampening definition.")
-@Indexed(index = "trigger")
 public class Trigger implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -69,7 +62,6 @@ public class Trigger implements Serializable {
             position = 0,
             required = true,
             allowableValues = "Tenant is overwritten from Hawkular-Tenant HTTP header parameter request")
-    @Field(store = Store.YES, analyze = Analyze.NO)
     @JsonInclude
     private String tenantId;
 
@@ -139,8 +131,6 @@ public class Trigger implements Serializable {
             "Tags can be used as criteria on finder methods. + \n" +
             "Tag value cannot be null.",
             position = 10)
-    @Field(store = Store.YES, analyze = Analyze.NO)
-    @FieldBridge(impl = TagsBridge.class)
     @JsonInclude(Include.NON_EMPTY)
     protected Map<String, String> tags;
 
@@ -261,6 +251,40 @@ public class Trigger implements Serializable {
 
     public Trigger(String tenantId, String id, String name, Map<String, String> context) {
         this(tenantId, id, name, context, null);
+    }
+
+    public Trigger(Trigger trigger) {
+        if (trigger == null) {
+            throw new IllegalArgumentException("trigger must be not null");
+        }
+        this.tenantId = trigger.getTenantId();
+        this.id = trigger.getId();
+        this.name = trigger.getName();
+        this.context = new HashMap<>(trigger.getContext());
+        this.tags = new HashMap<>(trigger.getTags());
+        this.actions = new HashSet<>();
+        for (TriggerAction action : trigger.getActions()) {
+            this.actions.add(new TriggerAction(action));
+        }
+        this.autoDisable = trigger.isAutoDisable();
+        this.autoEnable = trigger.isAutoEnable();
+        this.autoResolve = trigger.isAutoResolve();
+        this.autoResolveAlerts = trigger.isAutoResolveAlerts();
+        this.autoResolveMatch = trigger.getAutoResolveMatch();
+        this.dataIdMap = new HashMap<>(trigger.getDataIdMap() != null ? trigger.getDataIdMap() : new HashMap<>());
+        this.eventCategory = trigger.getEventCategory();
+        this.eventText = trigger.getEventText();
+        this.eventType = trigger.getEventType();
+        this.memberOf = trigger.getMemberOf();
+        this.description = trigger.getDescription();
+        this.enabled = trigger.isEnabled();
+        this.firingMatch = trigger.getFiringMatch();
+        this.type = trigger.getType();
+        this.source = trigger.getSource();
+        this.severity = trigger.getSeverity();
+
+        this.match = trigger.getMatch();
+        this.mode = trigger.getMode();
     }
 
     public Trigger(String tenantId, String id, String name, Map<String, String> context, Map<String, String> tags) {

--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerAction.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/TriggerAction.java
@@ -107,6 +107,17 @@ public class TriggerAction implements Serializable {
         this(tenantId, actionPlugin, actionId, new HashSet<>(), calendar);
     }
 
+    public TriggerAction(TriggerAction triggerAction) {
+        if (triggerAction == null) {
+            throw new IllegalArgumentException("triggerAction must be not null");
+        }
+        this.tenantId = triggerAction.getTenantId();
+        this.actionPlugin = triggerAction.getActionPlugin();
+        this.actionId = triggerAction.getActionId();
+        this.states = new HashSet<>(triggerAction.getStates());
+        this.calendar = new TimeConstraint(triggerAction.getCalendar());
+    }
+
     public TriggerAction(String tenantId, String actionPlugin, String actionId, Set<String> states,
                          TimeConstraint calendar) {
         this.tenantId = tenantId;

--- a/commons/src/main/resources/alerting-local.xml
+++ b/commons/src/main/resources/alerting-local.xml
@@ -28,10 +28,9 @@
       </persistence>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.alerts.api.model.action.ActionDefinition</indexed-entity>
-          <indexed-entity>org.hawkular.alerts.api.model.trigger.Trigger</indexed-entity>
-          <indexed-entity>org.hawkular.alerts.api.model.event.Alert</indexed-entity>
-          <indexed-entity>org.hawkular.alerts.api.model.event.Event</indexed-entity>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnActionDefinition</indexed-entity>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnTrigger</indexed-entity>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnEvent</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 import org.hawkular.alerts.api.model.condition.ConditionEval;
 import org.hawkular.alerts.api.model.data.Data;
@@ -44,6 +45,7 @@ import org.hawkular.alerts.api.services.DefinitionsService;
 import org.hawkular.alerts.api.services.EventsCriteria;
 import org.hawkular.alerts.api.services.PropertiesService;
 import org.hawkular.alerts.cache.IspnCacheManager;
+import org.hawkular.alerts.engine.impl.ispn.model.IspnEvent;
 import org.hawkular.alerts.engine.service.AlertsEngine;
 import org.hawkular.alerts.engine.service.IncomingDataManager;
 import org.hawkular.alerts.log.AlertingLogger;
@@ -123,7 +125,7 @@ public class IspnAlertsServiceImpl implements AlertsService {
         }
         log.debugf("Adding %s alerts", alerts.size());
         for (Alert alert : alerts) {
-            backend.put(pk(alert), alert);
+            backend.put(pk(alert), new IspnEvent(alert));
         }
     }
 
@@ -182,7 +184,8 @@ public class IspnAlertsServiceImpl implements AlertsService {
             log.debugf("getAlerts criteria: %s", criteria.toString());
         }
 
-        StringBuilder query = new StringBuilder("from org.hawkular.alerts.api.model.event.Alert where ");
+        StringBuilder query = new StringBuilder("from org.hawkular.alerts.engine.impl.ispn.model.IspnEvent where ");
+        query.append("eventType = 'ALERT' and ");
         query.append("(");
         Iterator<String> iter = tenantIds.iterator();
         while (iter.hasNext()) {
@@ -192,7 +195,7 @@ public class IspnAlertsServiceImpl implements AlertsService {
                 query.append("or ");
             }
         }
-        query.append(")");
+        query.append(") ");
 
         if (filter) {
            if (criteria.hasAlertIdCriteria()) {
@@ -200,7 +203,7 @@ public class IspnAlertsServiceImpl implements AlertsService {
                iter = criteria.getAlertIds().iterator();
                while (iter.hasNext()) {
                    String alertId = iter.next();
-                   query.append("alertId = '").append(alertId).append("' ");
+                   query.append("id = '").append(alertId).append("' ");
                    if (iter.hasNext()) {
                        query.append("or ");
                    }
@@ -214,7 +217,8 @@ public class IspnAlertsServiceImpl implements AlertsService {
            }
         }
 
-        List<Alert> alerts = queryFactory.create(query.toString()).list();
+        List<IspnEvent> ispnEvents = queryFactory.create(query.toString()).list();
+        List<Alert> alerts = ispnEvents.stream().map(e -> (Alert) e.getEvent()).collect(Collectors.toList());
         if (alerts.isEmpty()) {
             return new Page<>(alerts, pager, 0);
         } else {

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -207,6 +207,11 @@ public class IspnAlertsServiceImpl implements AlertsService {
                }
                query.append(") ");
            }
+           if (criteria.hasTagQueryCriteria()) {
+               query.append("and (");
+               parseTagQuery(criteria.getTagQuery(), query);
+               query.append(") ");
+           }
         }
 
         List<Alert> alerts = queryFactory.create(query.toString()).list();
@@ -308,5 +313,9 @@ public class IspnAlertsServiceImpl implements AlertsService {
             Collections.sort(alerts, comparator);
             return new Page<>(alerts, pager, alerts.size());
         }
+    }
+
+    private void parseTagQuery(String tagQuery, StringBuilder query) {
+        // TODO Parse tagQuery
     }
 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnActionDefinition.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnActionDefinition.java
@@ -1,0 +1,125 @@
+package org.hawkular.alerts.engine.impl.ispn.model;
+
+import java.io.Serializable;
+
+import org.hawkular.alerts.api.model.action.ActionDefinition;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Indexed(index = "actionDefinition")
+public class IspnActionDefinition implements Serializable {
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String tenantId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String actionPlugin;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String actionId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private boolean global;
+
+    private ActionDefinition actionDefinition;
+
+    public IspnActionDefinition() {
+    }
+
+    public IspnActionDefinition(ActionDefinition actionDefinition) {
+        updateActionDefinition(actionDefinition);
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getActionPlugin() {
+        return actionPlugin;
+    }
+
+    public void setActionPlugin(String actionPlugin) {
+        this.actionPlugin = actionPlugin;
+    }
+
+    public String getActionId() {
+        return actionId;
+    }
+
+    public void setActionId(String actionId) {
+        this.actionId = actionId;
+    }
+
+    public boolean isGlobal() {
+        return global;
+    }
+
+    public void setGlobal(boolean global) {
+        this.global = global;
+    }
+
+    public ActionDefinition getActionDefinition() {
+        return actionDefinition;
+    }
+
+    public void setActionDefinition(ActionDefinition actionDefinition) {
+        updateActionDefinition(actionDefinition);
+    }
+
+    private void updateActionDefinition(ActionDefinition actionDefinition) {
+        if (actionDefinition == null) {
+            throw new IllegalArgumentException("actionDefinitions must be not null");
+        }
+        this.tenantId = actionDefinition.getTenantId();
+        this.actionPlugin = actionDefinition.getActionPlugin();
+        this.actionId = actionDefinition.getActionId();
+        this.global = actionDefinition.isGlobal();
+        this.actionDefinition = new ActionDefinition(actionDefinition);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IspnActionDefinition that = (IspnActionDefinition) o;
+
+        if (global != that.global) return false;
+        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (actionPlugin != null ? !actionPlugin.equals(that.actionPlugin) : that.actionPlugin != null) return false;
+        if (actionId != null ? !actionId.equals(that.actionId) : that.actionId != null) return false;
+        return actionDefinition != null ? actionDefinition.equals(that.actionDefinition) : that.actionDefinition == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tenantId != null ? tenantId.hashCode() : 0;
+        result = 31 * result + (actionPlugin != null ? actionPlugin.hashCode() : 0);
+        result = 31 * result + (actionId != null ? actionId.hashCode() : 0);
+        result = 31 * result + (global ? 1 : 0);
+        result = 31 * result + (actionDefinition != null ? actionDefinition.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IspnActionDefinition{" +
+                "tenantId='" + tenantId + '\'' +
+                ", actionPlugin='" + actionPlugin + '\'' +
+                ", actionId='" + actionId + '\'' +
+                ", global=" + global +
+                ", actionDefinition=" + actionDefinition +
+                '}';
+    }
+
+
+}

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnActionPlugin.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnActionPlugin.java
@@ -17,6 +17,7 @@
 package org.hawkular.alerts.engine.impl.ispn.model;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.search.annotations.Analyze;
@@ -29,17 +30,17 @@ import org.hibernate.search.annotations.Store;
  * @author Lucas Ponce
  */
 @Indexed(index = "actionPlugin")
-public class ActionPlugin implements Serializable {
+public class IspnActionPlugin implements Serializable {
     @Field(store = Store.YES, analyze = Analyze.NO)
     private String actionPlugin;
     private Map<String, String> defaultProperties;
 
-    public ActionPlugin() {
+    public IspnActionPlugin() {
     }
 
-    public ActionPlugin(String actionPlugin, Map<String, String> defaultProperties) {
+    public IspnActionPlugin(String actionPlugin, Map<String, String> defaultProperties) {
         this.actionPlugin = actionPlugin;
-        this.defaultProperties = defaultProperties;
+        this.defaultProperties = new HashMap<>(defaultProperties);
     }
 
     public String getActionPlugin() {
@@ -51,11 +52,11 @@ public class ActionPlugin implements Serializable {
     }
 
     public Map<String, String> getDefaultProperties() {
-        return defaultProperties;
+        return new HashMap<>(defaultProperties);
     }
 
     public void setDefaultProperties(Map<String, String> defaultProperties) {
-        this.defaultProperties = defaultProperties;
+        this.defaultProperties = new HashMap<>(defaultProperties);
     }
 
     @Override
@@ -63,7 +64,7 @@ public class ActionPlugin implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        ActionPlugin that = (ActionPlugin) o;
+        IspnActionPlugin that = (IspnActionPlugin) o;
 
         if (actionPlugin != null ? !actionPlugin.equals(that.actionPlugin) : that.actionPlugin != null) return false;
         return defaultProperties != null ? defaultProperties.equals(that.defaultProperties) : that.defaultProperties == null;
@@ -78,7 +79,7 @@ public class ActionPlugin implements Serializable {
 
     @Override
     public String toString() {
-        return "ActionPlugin{" +
+        return "IspnActionPlugin{" +
                 "actionPlugin='" + actionPlugin + '\'' +
                 ", defaultProperties=" + defaultProperties +
                 '}';

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnEvent.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnEvent.java
@@ -1,0 +1,135 @@
+package org.hawkular.alerts.engine.impl.ispn.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hawkular.alerts.api.model.event.Alert;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Indexed(index = "event")
+public class IspnEvent implements Serializable {
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String eventType;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String tenantId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String id;
+
+    @FieldBridge(impl = TagsBridge.class)
+    private Map<String, String> tags;
+
+    private Event event;
+
+    public IspnEvent() {
+    }
+
+    public IspnEvent(Event event) {
+        updateEvent(event);
+    }
+
+    private void updateEvent(Event event) {
+        if (event == null) {
+            throw new IllegalArgumentException("event must be not null");
+        }
+        if (event instanceof Alert) {
+            this.event = new Alert((Alert) event);
+        } else {
+            this.event = new Event(event);
+        }
+        this.id = event.getId();
+        this.eventType = event.getEventType();
+        this.tenantId = event.getTenantId();
+        this.tags = this.event.getTags();
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public Map<String, String> getTags() {
+        return new HashMap<>(tags);
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = new HashMap<>(tags);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Event getEvent() {
+        if (event instanceof Alert) {
+            return new Alert((Alert) event);
+        }
+        return new Event(event);
+    }
+
+    public void setEvent(Event event) {
+        updateEvent(event);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IspnEvent ispnEvent = (IspnEvent) o;
+
+        if (eventType != null ? !eventType.equals(ispnEvent.eventType) : ispnEvent.eventType != null) return false;
+        if (tenantId != null ? !tenantId.equals(ispnEvent.tenantId) : ispnEvent.tenantId != null) return false;
+        if (id != null ? !id.equals(ispnEvent.id) : ispnEvent.id != null) return false;
+        if (tags != null ? !tags.equals(ispnEvent.tags) : ispnEvent.tags != null) return false;
+        return event != null ? event.equals(ispnEvent.event) : ispnEvent.event == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = eventType != null ? eventType.hashCode() : 0;
+        result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+        result = 31 * result + (id != null ? id.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + (event != null ? event.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IspnEvent{" +
+                "eventType='" + eventType + '\'' +
+                ", tenantId='" + tenantId + '\'' +
+                ", id='" + id + '\'' +
+                ", tags=" + tags +
+                ", event=" + event +
+                '}';
+    }
+}

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnTrigger.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/IspnTrigger.java
@@ -1,0 +1,113 @@
+package org.hawkular.alerts.engine.impl.ispn.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Indexed(index = "trigger")
+public class IspnTrigger implements Serializable {
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String tenantId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    private String triggerId;
+
+    @Field(store = Store.YES, analyze = Analyze.NO)
+    @FieldBridge(impl = TagsBridge.class)
+    private Map<String, String> tags;
+
+    private Trigger trigger;
+
+    public IspnTrigger() {
+    }
+
+    public IspnTrigger(Trigger trigger) {
+        updateTrigger(trigger);
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public Map<String, String> getTags() {
+        return new HashMap<>(tags);
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = new HashMap<>(tags);
+    }
+
+    public Trigger getTrigger() {
+        return new Trigger(this.trigger);
+    }
+
+    public void setTrigger(Trigger trigger) {
+        updateTrigger(trigger);
+    }
+
+    public String getTriggerId() {
+        return triggerId;
+    }
+
+    public void setTriggerId(String triggerId) {
+        this.triggerId = triggerId;
+    }
+
+    private void updateTrigger(Trigger trigger) {
+        if (trigger == null) {
+            throw new IllegalArgumentException("trigger must be not null");
+        }
+        this.trigger = new Trigger(trigger);
+        this.tenantId = trigger.getTenantId();
+        this.triggerId = trigger.getId();
+        this.tags = this.trigger.getTags();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IspnTrigger that = (IspnTrigger) o;
+
+        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (triggerId != null ? !triggerId.equals(that.triggerId) : that.triggerId != null) return false;
+        if (tags != null ? !tags.equals(that.tags) : that.tags != null) return false;
+        return trigger != null ? trigger.equals(that.trigger) : that.trigger == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tenantId != null ? tenantId.hashCode() : 0;
+        result = 31 * result + (triggerId != null ? triggerId.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + (trigger != null ? trigger.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IspnTrigger{" +
+                "tenantId='" + tenantId + '\'' +
+                ", triggerId='" + triggerId + '\'' +
+                ", tags=" + tags +
+                ", trigger=" + trigger +
+                '}';
+    }
+}

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/TagsBridge.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/model/TagsBridge.java
@@ -1,4 +1,4 @@
-package org.hawkular.alerts.api.model.index;
+package org.hawkular.alerts.engine.impl.ispn.model;
 
 import java.util.Map;
 

--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImplTest.java
@@ -112,15 +112,18 @@ public class IspnAlertsServiceImplTest {
         assertEquals(1 * 5 * 100, alerts.getAlerts(tenantIds, null, null).size());
 
         List<Alert> testAlerts = alerts.getAlerts(tenantIds, null, null);
+        tenantIds.clear();
         Set<String> alertIds = new HashSet<>();
-        for (int i = 0; i < 25; i++) {
-            alertIds.add(testAlerts.get(i).getAlertId());
+        for (int i = 0; i < 3; i++) {
+            Alert alertX = testAlerts.get(i);
+            tenantIds.add(alertX.getTenantId());
+            alertIds.add(alertX.getAlertId());
         }
 
         AlertsCriteria criteria = new AlertsCriteria();
         criteria.setAlertIds(alertIds);
 
-        assertEquals(25, alerts.getAlerts(tenantIds, criteria, null).size());
+        assertEquals(3, alerts.getAlerts(tenantIds, criteria, null).size());
 
         removeAllAlerts();
     }

--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImplTest.java
@@ -247,15 +247,12 @@ public class IspnDefinitionsServiceImplTest {
         assertEquals(trigger.getTags(), updated.getTags());
 
         try {
-            // note, this changes the "persisted" in-memory mapped trigger. Change it back after this test.
             trigger.setId("trigger2");
             definitions.updateTrigger(TENANT, trigger);
         } catch (NotFoundException e) {
             // Expected
         }
 
-        // change back the "persisted" in-memory mapped trigger for the remove test
-        trigger.setId("trigger1");
         definitions.removeTrigger(TENANT, "trigger1");
         try {
             definitions.getTrigger(TENANT, "trigger1");


### PR DESCRIPTION
As follow up of https://github.com/hawkular/hawkular-alerts/pull/336 I prepared this PR.
It moves the indexes annotation into the impl package, so api does not need to have visibility of them.
Also, continue with the discussion, we can store copies on the backend, two reasons: make idempotent the objects stored in the backend cache and simplify the indexes on polimorphics classes to avoid workarounds of ispn-objectfilter package.

@jshaughn I think this is in good shape to merge and it will simplify the work on the Conditions side.
From me I will continue with the queries for Alerts/Events.