### PR TITLE
Port Alerters architecture

### DIFF
--- a/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/ActionPlugins.java
+++ b/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/ActionPlugins.java
@@ -99,7 +99,7 @@ public class ActionPlugins {
                                 }
                             }
                         } catch (Exception e) {
-                            log.errorf("Error loading Handler %s. Reason: %s", className, e.toString());
+                            log.errorf("Error loading ActionPlugin %s. Reason: %s", className, e.toString());
                             System.exit(1);
                         }
                     }

--- a/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/StandaloneActionPluginRegister.java
+++ b/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/StandaloneActionPluginRegister.java
@@ -64,7 +64,7 @@ public class StandaloneActionPluginRegister {
                     definitions.addActionPlugin(actionPlugin, properties);
                 }
             } catch (Exception e) {
-                log.errorCannotRegisterPlugin(actionPlugin, e.getMessage());
+                log.errorCannotRegisterPlugin(actionPlugin, e.toString());
             }
         }
         ActionListener actionListener = new StandaloneActionPluginListener(ActionPlugins.getPlugins(), executor);
@@ -95,5 +95,6 @@ public class StandaloneActionPluginRegister {
                 }
             });
         }
+        instance = null;
     }
 }

--- a/alerters/alerters-api/pom.xml
+++ b/alerters/alerters-api/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-alerters</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-api</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerting: Alerters Api</name>
+
+</project>

--- a/alerters/alerters-api/src/main/java/org/hawkular/alerts/alerters/api/Alerter.java
+++ b/alerters/alerters-api/src/main/java/org/hawkular/alerts/alerters/api/Alerter.java
@@ -1,0 +1,20 @@
+package org.hawkular.alerts.alerters.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Define an alerters plugin implementation
+ * Plugin must have a unique name that will be used at registration phase
+ * Plugin must implement AlerterPlugin interface
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Alerter {
+    String name();
+}

--- a/alerters/alerters-api/src/main/java/org/hawkular/alerts/alerters/api/AlerterPlugin.java
+++ b/alerters/alerters-api/src/main/java/org/hawkular/alerts/alerters/api/AlerterPlugin.java
@@ -1,0 +1,16 @@
+package org.hawkular.alerts.alerters.api;
+
+import java.util.concurrent.ExecutorService;
+
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public interface AlerterPlugin {
+
+    void init(DefinitionsService definitions, AlertsService alerts, ExecutorService executor);
+    void stop();
+}

--- a/alerters/alerters-impl/pom.xml
+++ b/alerters/alerters-impl/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-alerters</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-impl</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerting: Alerters Implementation</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-engine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/alerters/alerters-impl/src/main/java/org/hawkular/alerts/alerters/standalone/AlerterPlugins.java
+++ b/alerters/alerters-impl/src/main/java/org/hawkular/alerts/alerters/standalone/AlerterPlugins.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.alerters.standalone;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.hawkular.alerts.alerters.api.Alerter;
+import org.hawkular.alerts.alerters.api.AlerterPlugin;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.engine.StandaloneAlerts;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+/**
+ * Helper class to find the classes annotated with ActionPlugin and instantiate them.
+ *
+ * @author Lucas Ponce
+ */
+public class AlerterPlugins {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(AlerterPlugins.class);
+    private static AlerterPlugins instance;
+    private Map<String, AlerterPlugin> plugins;
+    private ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+    DefinitionsService definitions;
+    AlertsService alerts;
+    ExecutorService executor;
+
+    public static synchronized Map<String, AlerterPlugin> getPlugins() {
+        if (instance == null) {
+            instance = new AlerterPlugins();
+        }
+        return Collections.unmodifiableMap(instance.plugins);
+    }
+
+    private AlerterPlugins() {
+        try {
+            plugins = new HashMap<>();
+            definitions = StandaloneAlerts.getDefinitionsService();
+            alerts = StandaloneAlerts.getAlertsService();
+            executor = StandaloneAlerts.getExecutor();
+            scan();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void scan() throws IOException {
+        String[] classpath = System.getProperty("java.class.path").split(":");
+        for (int i=0; i<classpath.length; i++) {
+            if (classpath[i].contains("hawkular") && classpath[i].endsWith("jar")) {
+                ZipInputStream zip = new ZipInputStream(new FileInputStream(classpath[i]));
+                for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
+                    if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+                        String className = entry.getName().replace('/', '.'); // including ".class"
+                        className = className.substring(0, className.length() - 6);
+                        try {
+                            Class clazz = cl.loadClass(className);
+                            if (clazz.isAnnotationPresent(Alerter.class)) {
+                                Alerter alerter = (Alerter)clazz.getAnnotation(Alerter.class);
+                                String name = alerter.name();
+                                Object newInstance = clazz.newInstance();
+                                log.infof("Scanning %s", clazz.getName());
+                                if (newInstance instanceof AlerterPlugin) {
+                                    AlerterPlugin pluginInstance = (AlerterPlugin)newInstance;
+                                    pluginInstance.init(definitions, alerts, executor);
+                                    plugins.put(name, pluginInstance);
+                                } else {
+                                    throw new IllegalStateException("Alerter [" + name + "] is not instance of " +
+                                            "AlerterPlugin");
+                                }
+                            }
+                        } catch (Exception e) {
+                            log.errorf("Error loading AlerterPlugin %s. Reason: %s", className, e.toString());
+                            System.exit(1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/alerters/alerters-impl/src/main/java/org/hawkular/alerts/alerters/standalone/StandaloneAlerterPluginRegister.java
+++ b/alerters/alerters-impl/src/main/java/org/hawkular/alerts/alerters/standalone/StandaloneAlerterPluginRegister.java
@@ -1,0 +1,51 @@
+package org.hawkular.alerts.alerters.standalone;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import org.hawkular.alerts.alerters.api.AlerterPlugin;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class StandaloneAlerterPluginRegister {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(StandaloneAlerterPluginRegister.class);
+
+    private static StandaloneAlerterPluginRegister instance;
+    private static ExecutorService executor;
+
+    Map<String, AlerterPlugin> plugins;
+
+    private StandaloneAlerterPluginRegister() {
+        init();
+    }
+
+    public static void setExecutor(ExecutorService executor) {
+        StandaloneAlerterPluginRegister.executor = executor;
+    }
+
+    public void init() {
+        plugins = AlerterPlugins.getPlugins();
+        log.info("Alerter Plugins load finished");
+    }
+
+    public static synchronized void start() {
+        if (instance == null) {
+            instance = new StandaloneAlerterPluginRegister();
+        }
+    }
+
+    public static synchronized void stop() {
+        if (instance != null && instance.plugins != null) {
+            instance.plugins.entrySet().stream().forEach(pluginEntry -> {
+                log.infof("Stopping Alerter %s", pluginEntry.getKey());
+                pluginEntry.getValue().stop();
+            });
+        }
+        instance = null;
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/pom.xml
+++ b/alerters/alerters-plugins/alerters-elasticsearch/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-alerters-plugins</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-elasticsearch</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerting: Alerter Elasticsearch Plugin</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>rest</artifactId>
+      <version>${version.org.elasticsearch.client}</version>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <version>${version.junit}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchAlerter.java
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchAlerter.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.elasticsearch;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.hawkular.alerts.alerters.api.Alerter;
+import org.hawkular.alerts.alerters.api.AlerterPlugin;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.api.services.DistributedEvent;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+import org.hawkular.commons.properties.HawkularProperties;
+
+/**
+ * This is the main class of the Elasticsearch Alerter.
+ *
+ * The Elasticsearch Alerter will listen for triggers tagged with "Elasticsearch" tag. The Alerter will schedule a
+ * periodic query to an Elasticsearch system with the info provided from the tagged trigger context. The Alerter
+ * will convert Elasticsearch documents into Hawkular Alerting Events and send them into the Alerting engine.
+ *
+ * The Elasticsearch Alerter uses the following conventions for trigger tags and context:
+ *
+ * <pre>
+ *
+ * - [Required]    trigger.tags["Elasticsearch"] = "<value reserved for future uses>"
+ *
+ *   An "Elasticsearch" tag is required for the alerter to detect this trigger will query to an Elasticsearch system.
+ *   Value is not necessary, it can be used as a description, it is reserved for future uses.
+ *
+ *   i.e.   trigger.tags["Elasticsearch"] = ""                          // Empty value is valid
+ *          trigger.tags["Elasticsearch"] = "OpenShift Logging System"  // It can be used as description
+ *
+ * - [Required]    trigger.context["timestamp"] = "<timestamp field>"
+ *
+ *   Documents fetched from Elasticsearch need a date field to indicate the timestamp.
+ *   This timestamp will be used in the queries to fetch documents in interval basis.
+ *
+ *   If there is not defined a specific pattern under the trigger.context["timestamp_pattern"] it will follow the
+ *   default patterns:
+ *
+ *      "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"
+ *      "yyyy-MM-dd'T'HH:mm:ssZ"
+ *
+ * - [Required]    trigger.context["mapping"] = "<mapping_expression>"
+ *
+ *   A mapping expressions defines how to convert an Elasticsearch document into a Hawkular Event:
+ *
+ *   <mapping_expression> ::= <mapping> | <mapping> "," <mapping_expression>
+ *   <mapping> ::= <elasticsearch_field> [ "|" "'" <DEFAULT_VALUE> "'" ] ":" <hawkular_event_field>
+ *   <elasticsearch_field> ::= "index" | "id" | <SOURCE_FIELD>
+ *   <hawkular_event_field> ::= "id" | "ctime" | "dataSource" | "dataId" | "category" | "text" | "context" | "tags"
+ *
+ *   A minimum mapping for the "dataId" is required.
+ *   If a mapping is not present in an Elasticsearch document it will return an empty value.
+ *   It is possible to define a default value for cases when the Elasticsearch field is not present.
+ *   Special Elasticsearch metafields "_index" and "_id" are supported under "index" and "id" labels.
+ *
+ *   i.e.   trigger.context["mapping"] = "level|'INFO':category,@timestamp:ctime,message:text,hostname:dataId,index:tags"
+ *
+ * - [Optional]    trigger.context["interval"] = "[0-9]+[smh]"  (i.e. 30s, 2h, 10m)
+ *
+ *   Defines the periodic interval when a query will be performed against an Elasticsearch system.
+ *   If not value provided, default one is "2m" (two minutes).
+ *
+ *   i.e.   trigger.context["interval"] = "30s" will perform queries each 30 seconds fetching new documents generated
+ *          on the last 30 seconds, using the timestamp field provided in the Alerter tag.
+ *
+ * - [Optional]    trigger.context["timestamp_pattern"] = "<date and time pattern>"
+ *
+ *   Defines a new time pattern for the trigger.context["timestamp"]. It must follow supported formats of
+ *   {@link java.time.format.DateTimeFormatter}. If it is not present, it will expect default patterns:
+ *
+ *      "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"
+ *      "yyyy-MM-dd'T'HH:mm:ssZ"
+ *
+ * - [Optional]    trigger.context["index"] = "<elastic_search_index>"
+ *
+ *   Defines the index where the documents will be queried. If not index defined, query will search under all indexes
+ *   defined.
+ *
+ * - [Optional]    trigger.context["filter"] = "<elastic_search_query_filter>"
+ *
+ *   By default the Elasticsearch Alerter performs a range query over the timestamp field provided in the alerter tag.
+ *   This query accepts additional filter in Elasticsearch format. The final query should be built from:
+ *
+ *      {
+ *        "query":{
+ *          "constant_score":{
+ *              "filter":{
+ *                  "bool":{
+ *                      "must": [<range_query_on_timestamp>, <elastic_search_query_filter>]
+ *                  }
+ *              }
+ *          }
+ *        }
+ *      }
+ *
+ * - [Optional]    trigger.context["url"]
+ *
+ *   Elasticsearch url can be defined in several ways in the alerter.
+ *   If can be defined globally as system properties:
+ *
+ *      hawkular-alerts.elasticsearch-url
+ *
+ *   It can be defined globally from system env variables:
+ *
+ *      ELASTICSEARCH_URL
+ *
+ *   Or it can be overwritten per trigger using
+ *
+ *      trigger.context["url"]
+ *
+ *   Url can be a list of valid {@link org.apache.http.HttpHost} urls. By default it will point to
+ *
+ *      trigger.context["url"] = "http://localhost:9200"
+ *
+ *   i.e.
+ *
+ *      trigger.context["url"] = "http://host1:9200,http://host2:9200,http://host3:9200"
+ *
+ * </pre>
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Alerter(name = "elasticsearch")
+public class ElasticsearchAlerter implements AlerterPlugin {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(ElasticsearchAlerter.class);
+
+    private static final String ELASTICSEARCH_ALERTER = "hawkular-alerts.elasticsearch-alerter";
+    private static final String ELASTICSEARCH_ALERTER_ENV = "ELASTICSEARCH_ALERTER";
+    private static final String ELASTICSEARCH_ALERTER_DEFAULT = "true";
+    private boolean elasticSearchAlerter;
+
+    private static final String ELASTICSEARCH_URL="hawkular-alerts.elasticsearch-url";
+    private static final String ELASTICSEARCH_URL_ENV = "ELASTICSEARCH_URL";
+    private static final String ELASTICSEARCH_URL_DEFAULT = "http://localhost:9200";
+
+    private static final String ELASTICSEARCH_FORWARDED_FOR = "hawkular-alerts.elasticsearch-forwarded-for";
+    private static final String ELASTICSEARCH_FORWARDED_FOR_ENV = "ELASTICSEARCH_FORWARDED_FOR";
+    private static final String ELASTICSEARCH_FORWARDED_FOR_DEFAULT = "";
+
+    private static final String ELASTICSEARCH_TOKEN = "hawkular-alerts.elasticsearch-token";
+    private static final String ELASTICSEARCH_TOKEN_ENV = "ELASTICSEARCH_TOKEN";
+    private static final String ELASTICSEARCH_TOKEN_DEFAULT = "";
+
+    private static final String ELASTICSEARCH_PROXY_REMOTE_USER = "hawkular-alerts.elasticsearch-proxy-remote-user";
+    private static final String ELASTICSEARCH_PROXY_REMOTE_USER_ENV = "ELASTICSEARCH_PROXY_REMOTE_USER";
+    private static final String ELASTICSEARCH_PROXY_REMOTE_USER_DEFAULT = "";
+
+    private static final String ALERTER_NAME = "Elasticsearch";
+
+    private Map<TriggerKey, Trigger> activeTriggers = new ConcurrentHashMap<>();
+
+    private static final Integer THREAD_POOL_SIZE = 20;
+
+    private static final String INTERVAL = "interval";
+    private static final String INTERVAL_DEFAULT = "2m";
+    private static final String URL = "url";
+    private static final String FORWARDED_FOR = "forwarded-for";
+    private static final String PROXY_REMOTE_USER = "proxy-remote-user";
+    private static final String TOKEN = "token";
+
+    private ScheduledThreadPoolExecutor scheduledExecutor;
+    private Map<TriggerKey, ScheduledFuture<?>> queryFutures = new HashMap<>();
+
+    private Map<String, String> defaultProperties;
+
+    private DefinitionsService definitions;
+
+    private AlertsService alerts;
+
+    private ExecutorService executor;
+
+    public void init(DefinitionsService definitions, AlertsService alerts, ExecutorService executor) {
+        if (definitions == null || alerts == null || executor == null) {
+            throw new IllegalStateException("Elasticsearch Alerter cannot connect with Hawkular Alerting");
+        }
+        this.definitions = definitions;
+        this.alerts = alerts;
+        this.executor = executor;
+        elasticSearchAlerter = Boolean.parseBoolean(HawkularProperties.getProperty(ELASTICSEARCH_ALERTER,
+                ELASTICSEARCH_ALERTER_ENV, ELASTICSEARCH_ALERTER_DEFAULT));
+        defaultProperties = new HashMap();
+        defaultProperties.put(URL, HawkularProperties.getProperty(ELASTICSEARCH_URL, ELASTICSEARCH_URL_ENV,
+                ELASTICSEARCH_URL_DEFAULT));
+        defaultProperties.put(TOKEN, HawkularProperties.getProperty(ELASTICSEARCH_TOKEN, ELASTICSEARCH_TOKEN_ENV,
+                ELASTICSEARCH_TOKEN_DEFAULT));
+        defaultProperties.put(FORWARDED_FOR, HawkularProperties.getProperty(ELASTICSEARCH_FORWARDED_FOR,
+                ELASTICSEARCH_FORWARDED_FOR_ENV, ELASTICSEARCH_FORWARDED_FOR_DEFAULT));
+        defaultProperties.put(PROXY_REMOTE_USER, HawkularProperties.getProperty(ELASTICSEARCH_PROXY_REMOTE_USER,
+                ELASTICSEARCH_PROXY_REMOTE_USER_ENV, ELASTICSEARCH_PROXY_REMOTE_USER_DEFAULT));
+
+        if (elasticSearchAlerter) {
+            this.definitions.registerDistributedListener(events -> refresh(events));
+        }
+    }
+
+    public void stop() {
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdown();
+            scheduledExecutor = null;
+        }
+    }
+
+    private void refresh(Set<DistributedEvent> distEvents) {
+        log.debugf("Events received %s", distEvents);
+        executor.submit(() -> {
+            try {
+                for (DistributedEvent distEvent : distEvents) {
+                    TriggerKey triggerKey = new TriggerKey(distEvent.getTenantId(), distEvent.getTriggerId());
+                    switch (distEvent.getOperation()) {
+                        case REMOVE:
+                            activeTriggers.remove(triggerKey);
+                            break;
+                        case ADD:
+                            if (activeTriggers.containsKey(triggerKey)) {
+                                break;
+                            }
+                        case UPDATE:
+                            Trigger trigger = definitions.getTrigger(distEvent.getTenantId(), distEvent.getTriggerId());
+                            if (trigger != null && trigger.getTags().containsKey(ALERTER_NAME)) {
+                                if (!trigger.isLoadable()) {
+                                    activeTriggers.remove(triggerKey);
+                                    break;
+                                } else {
+                                    activeTriggers.put(triggerKey, trigger);
+                                }
+                            }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch Triggers for external conditions.", e);
+            }
+            update();
+        });
+    }
+
+    private synchronized void update() {
+        final Set<TriggerKey> existingKeys = queryFutures.keySet();
+        final Set<TriggerKey> activeKeys = activeTriggers.keySet();
+
+        Set<TriggerKey> newKeys = new HashSet<>();
+        Set<TriggerKey> canceledKeys = new HashSet<>();
+
+        Set<TriggerKey> updatedKeys = new HashSet<>(activeKeys);
+        updatedKeys.retainAll(activeKeys);
+
+        activeKeys.stream().filter(key -> !existingKeys.contains(key)).forEach(key -> newKeys.add(key));
+        existingKeys.stream().filter(key -> !activeKeys.contains(key)).forEach(key -> canceledKeys.add(key));
+
+        log.debugf("newKeys %s", newKeys);
+        log.debugf("updatedKeys %s", updatedKeys);
+        log.debugf("canceledKeys %s", canceledKeys);
+
+        canceledKeys.stream().forEach(key -> {
+            ScheduledFuture canceled = queryFutures.remove(key);
+            if (canceled != null) {
+                canceled.cancel(false);
+            }
+        });
+        updatedKeys.stream().forEach(key -> {
+            ScheduledFuture updated = queryFutures.remove(key);
+            if (updated != null) {
+                updated.cancel(false);
+            }
+        });
+
+        if (scheduledExecutor == null) {
+            scheduledExecutor = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
+        }
+
+        newKeys.addAll(updatedKeys);
+
+        for (TriggerKey key : newKeys) {
+            Trigger t = activeTriggers.get(key);
+            String interval = t.getContext().get(INTERVAL) == null ? INTERVAL_DEFAULT : t.getContext().get(INTERVAL);
+            queryFutures.put(key, scheduledExecutor
+                    .scheduleAtFixedRate(new ElasticsearchQuery(t, defaultProperties, alerts),0L,
+                            getIntervalValue(interval), getIntervalUnit(interval)));
+
+        }
+    }
+
+    public static int getIntervalValue(String interval) {
+        if (interval == null || interval.isEmpty()) {
+            interval = INTERVAL_DEFAULT;
+        }
+        try {
+            return new Integer(interval.substring(0, interval.length() - 1)).intValue();
+        } catch (Exception e) {
+            return new Integer(INTERVAL_DEFAULT.substring(0, interval.length() - 1)).intValue();
+        }
+    }
+
+    public static TimeUnit getIntervalUnit(String interval) {
+        if (interval == null || interval.isEmpty()) {
+            interval = INTERVAL_DEFAULT;
+        }
+        char unit = interval.charAt(interval.length() - 1);
+        switch (unit) {
+            case 'h':
+                return TimeUnit.HOURS;
+            case 's':
+                return TimeUnit.SECONDS;
+            case 'm':
+            default:
+                return TimeUnit.MINUTES;
+        }
+    }
+
+    private class TriggerKey {
+        private String tenantId;
+        private String triggerId;
+
+        public TriggerKey(String tenantId, String triggerId) {
+            this.tenantId = tenantId;
+            this.triggerId = triggerId;
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+
+        public String getTriggerId() {
+            return triggerId;
+        }
+
+        public void setTriggerId(String triggerId) {
+            this.triggerId = triggerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TriggerKey that = (TriggerKey) o;
+
+            if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+            return triggerId != null ? triggerId.equals(that.triggerId) : that.triggerId == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = tenantId != null ? tenantId.hashCode() : 0;
+            result = 31 * result + (triggerId != null ? triggerId.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchQuery.java
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchQuery.java
@@ -1,0 +1,552 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.elasticsearch;
+
+import static java.util.Collections.EMPTY_LIST;
+import static org.hawkular.alerter.elasticsearch.ElasticsearchAlerter.getIntervalUnit;
+import static org.hawkular.alerter.elasticsearch.ElasticsearchAlerter.getIntervalValue;
+import static org.hawkular.alerter.elasticsearch.ElasticsearchQuery.EventField.DATAID;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.hawkular.alerts.api.json.JsonUtil;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+/**
+ * This class performs a query into Elasticsearch system and parses results documents based on Trigger tags/context.
+ * @see {@link ElasticsearchAlerter}
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class ElasticsearchQuery implements Runnable {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(ElasticsearchQuery.class);
+
+    private static final int SIZE_DEFAULT = 10;
+
+    private static final String _ID = "_id";
+    private static final String _INDEX = "_index";
+    private static final String _SOURCE = "_source";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer";
+    private static final String ERROR = "error";
+    private static final String FILTER = "filter";
+    private static final String FORWARDED_FOR = "forwarded-for";
+    private static final String GET = "GET";
+    private static final String HITS = "hits";
+    private static final String ID = "id";
+    private static final String INDEX = "index";
+    private static final String INDEX_NOT_FOUND = "index_not_found_exception";
+    private static final String INTERVAL = "interval";
+    private static final String INTERVAL_DEFAULT = "2m";
+    private static final String MAPPING = "mapping";
+    private static final String PASS = "pass";
+    private static final String PREFERENCE = "preference";
+    private static final String PROXY_REMOTE_USER = "proxy-remote-user";
+    private static final String USER = "user";
+    private static final String TIMESTAMP = "timestamp";
+    private static final String TIMESTAMP_PATTERN = "timestamp_pattern";
+    private static final String TOKEN = "token";
+    private static final String TOTAL = "total";
+    private static final String TYPE = "type";
+    private static final String RESOURCE_ID = "resource.id";
+    private static final String SOURCE = "source";
+    private static final String URL = "url";
+    private static final String X_FORWARDED = "X-Forwarded-For";
+    private static final String X_PROXY_REMOTE_USER = "X-Proxy-Remote-User";
+
+    private static final DateTimeFormatter[] DEFAULT_DATE_FORMATS = {
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ")
+    };
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    /*
+        Event fields
+     */
+    enum EventField {
+        ID ("id"),
+        CTIME ("ctime"),
+        DATASOURCE ("dataSource"),
+        DATAID ("dataId"),
+        CATEGORY ("category"),
+        TEXT ("text"),
+        CONTEXT ("context"),
+        TAGS ("tags");
+
+        private final String name;
+
+        EventField(String name) {
+            this.name = name;
+        }
+
+        public boolean equalsName(String name) {
+            return this.name.equals(name);
+        }
+
+        public static EventField fromString(String name) {
+            for (EventField field : EventField.values()) {
+                if (field.equalsName(name)) {
+                    return field;
+                }
+            }
+            return null;
+        }
+
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    private Trigger trigger;
+    private Map<String, String> properties;
+    private AlertsService alerts;
+
+    private Map<String, EventField> mappings = new HashMap<>();
+
+    private RestClient client;
+
+    private Header[] headers = null;
+
+    public ElasticsearchQuery(Trigger trigger, Map<String, String> properties, AlertsService alerts) {
+        this.trigger = trigger;
+        this.properties = properties == null ? new HashMap<>() : new HashMap<>(properties);
+        this.alerts = alerts;
+    }
+
+    public void parseProperties() throws Exception {
+        if (trigger == null) {
+            throw new IllegalStateException("trigger must be not null");
+        }
+        checkContext(TIMESTAMP, true);
+        checkContext(MAPPING, true);
+        checkContext(INTERVAL, INTERVAL_DEFAULT);
+        checkContext(URL, false);
+        checkContext(INDEX, false);
+        checkContext(FILTER, false);
+        checkContext(TIMESTAMP_PATTERN, false);
+        checkContext(USER, false);
+        checkContext(PASS, false);
+        checkContext(TOKEN, false);
+    }
+
+    public void parseMap() throws Exception {
+        String rawMap = properties.get(MAPPING);
+        if (rawMap == null) {
+            throw new IllegalStateException("mapping must be not null");
+        }
+        String[] rawMappings = rawMap.split(",");
+        for (String rawMapping : rawMappings) {
+            String[] fields = rawMapping.trim().split(":");
+            if (fields.length == 2) {
+                EventField eventField = EventField.fromString(fields[1].trim());
+                if (eventField == null) {
+                    log.warnf("Skipping invalid mapping [%s]", rawMapping);
+                } else {
+                    mappings.put(fields[0].trim(), eventField);
+                }
+            } else {
+                log.warnf("Skipping invalid mapping [%s]", rawMapping);
+            }
+        }
+        if (!mappings.values().contains(DATAID)) {
+            throw new IllegalStateException("Mapping [" + rawMap + "] does not include dataId");
+        }
+    }
+
+    private void checkContext(String property, boolean required) {
+        checkMap(property, required, null);
+    }
+
+    private void checkContext(String property, String defaultValue) {
+        checkMap(property, true, defaultValue);
+    }
+
+    private void checkMap(String property, boolean required, String defaultValue) {
+        Map<String, String> map = trigger.getContext();
+        if (map.containsKey(property)) {
+            properties.put(property, map.get(property));
+        } else {
+            if (required && defaultValue == null) {
+                throw new IllegalStateException(property + " is not present and it has not a default value");
+            }
+            if (defaultValue != null) {
+                properties.put(property, defaultValue);
+            }
+        }
+    }
+
+    public void connect(String url) throws Exception {
+        String[] urls = url.split(",");
+        HttpHost[] hosts = new HttpHost[urls.length];
+        for (int i=0; i<urls.length; i++) {
+            hosts[i] = HttpHost.create(urls[0]);
+        }
+        client = RestClient.builder(hosts)
+                .setHttpClientConfigCallback(httpClientBuilder -> {
+                    httpClientBuilder.useSystemProperties();
+                    CredentialsProvider credentialsProvider = checkBasicCredentials();
+                    if (credentialsProvider != null) {
+                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    }
+                    return httpClientBuilder;
+                })
+                .build();
+        int nHeaders = 0;
+        String token = properties.get(TOKEN);
+        Header bearer = null;
+        if (!isEmpty(token)) {
+            bearer = new BasicHeader(AUTHORIZATION, BEARER + " " + token);
+            nHeaders++;
+        }
+        String forwarded = properties.get(FORWARDED_FOR);
+        Header xforwarded = null;
+        if (!isEmpty(forwarded)) {
+            xforwarded = new BasicHeader(X_FORWARDED, forwarded);
+            nHeaders++;
+        }
+        String proxyRemoteUser = properties.get(PROXY_REMOTE_USER);
+        Header xProxyRemoteUser = null;
+        if (!isEmpty(proxyRemoteUser)) {
+            xProxyRemoteUser = new BasicHeader(X_PROXY_REMOTE_USER, proxyRemoteUser);
+            nHeaders++;
+        }
+        if (nHeaders > 0) {
+            headers = new Header[nHeaders];
+            int i = 0;
+            if (bearer != null) {
+                headers[i] = bearer;
+                i++;
+            }
+            if (xforwarded != null) {
+                headers[i] = xforwarded;
+                i++;
+            }
+            if (xProxyRemoteUser != null) {
+                headers[i] = xProxyRemoteUser;
+            }
+        }
+    }
+
+    private CredentialsProvider checkBasicCredentials() {
+        String user = properties.get(USER);
+        String password = properties.get(PASS);
+        if (!isEmpty(user)){
+            if (!isEmpty(password)) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, password));
+                return credentialsProvider;
+            } else {
+                log.warnf("User [%s] without password ", user);
+            }
+        }
+        return null;
+    }
+
+    public List<Map<String, Object>> query(String filter, String indices) throws Exception {
+        if (filter == null || filter.isEmpty()) {
+            throw new IllegalArgumentException("filter must be not null");
+        }
+        List<Map<String, Object>> results = new ArrayList<>();
+        String json = rawQuery(filter);
+
+        List<String> index = indices == null ? EMPTY_LIST : new ArrayList<>(Arrays.asList(indices.split(",")));
+        Response response = null;
+        //  Using a loop in case results are greater than default results size
+        Map<String, String> params = new HashMap<>();
+        params.put(PREFERENCE, UUID.randomUUID().toString());
+        String jsonQuery = "{" +
+                "\"from\":0," +
+                "\"size\":" + SIZE_DEFAULT + "," +
+                "\"query\":" + json +
+                "}";
+        HttpEntity entity = new NStringEntity(jsonQuery, ContentType.APPLICATION_JSON);
+        boolean retry = false;
+        String endpoint = null;
+        do {
+            try {
+                endpoint = "/" + String.join(",", index) + "/_search";
+                response = headers == null ? client.performRequest(GET, endpoint, params, entity) :
+                        client.performRequest(GET, endpoint, params, entity, headers);
+                retry = false;
+            } catch (ResponseException e) {
+                log.warn(e.toString());
+                Map<String, Object> exception = JsonUtil.getMapper()
+                        .readValue(e.getResponse().getEntity().getContent(), Map.class);
+                Map<String, Object> error = (Map<String, Object>) exception.get(ERROR);
+                if (error != null) {
+                    String type = (String) error.get(TYPE);
+                    String badIndex = (String) error.get(RESOURCE_ID);
+                    if (type != null && type.equals(INDEX_NOT_FOUND)) {
+                        retry = true;
+                        index.remove(badIndex);
+                        if (index.isEmpty()) {
+                            return results;
+                        }
+                    }
+                }
+            }
+        } while(retry);
+        Map<String, Object> responseMap = JsonUtil.getMapper().readValue(response.getEntity().getContent(), Map.class);
+        Map<String, Object> allHits = (Map<String, Object>) responseMap.get(HITS);
+        List<Map<String, Object>> hits = (List<Map<String, Object>>) allHits.get(HITS);
+        results.addAll(hits);
+        long totalHits = new Long((Integer) allHits.get(TOTAL));
+        long currentHits = hits.size();
+        while (currentHits < totalHits) {
+            long pageSize = SIZE_DEFAULT;
+            if ((currentHits + SIZE_DEFAULT) > totalHits) {
+                pageSize = totalHits - currentHits;
+            }
+            jsonQuery = "{" +
+                    "\"from\":" + currentHits + "," +
+                    "\"size\":" + pageSize + "," +
+                    "\"query\":" + json +
+                    "}";
+            entity = new NStringEntity(jsonQuery, ContentType.APPLICATION_JSON);
+            response = headers == null ? client.performRequest(GET, endpoint, params, entity) :
+                    client.performRequest(GET, endpoint, params, entity, headers);
+            responseMap = JsonUtil.getMapper().readValue(response.getEntity().getContent(), Map.class);
+            allHits = (Map<String, Object>) responseMap.get(HITS);
+            hits = (List<Map<String, Object>>) allHits.get(HITS);
+            currentHits += hits.size();
+            log.debugf("currentHits [%s] totalHits [%s]", currentHits, totalHits);
+            results.addAll(hits);
+        }
+        log.debugf("Results %s", results.size());
+        return results;
+    }
+
+    public List<Event> parseEvents(List<Map<String, Object>> hits) {
+        List<Event> parsed = new ArrayList<>();
+        if (hits != null && !hits.isEmpty()) {
+            for (Map<String, Object> hit : hits) {
+                Event newEvent = new Event();
+                newEvent.getContext().put(SOURCE, JsonUtil.toJson(hit));
+                Map<String, Object> source = (Map<String, Object>) hit.get(_SOURCE);
+                for (Map.Entry<String, EventField> entry : mappings.entrySet()) {
+                    boolean isIndex = entry.getKey().equals(INDEX);
+                    boolean isId = entry.getKey().equals(ID);
+                    switch (entry.getValue()) {
+                        case ID:
+                            newEvent.setId(isId ? (String) hit.get(_ID) : getField(source, entry.getKey()));
+                            break;
+                        case CTIME:
+                            newEvent.setCtime(parseTimestamp(getField(source, entry.getKey())));
+                            break;
+                        case DATAID:
+                            newEvent.setDataId(isIndex ? (String) hit.get(_INDEX) : getField(source, entry.getKey()));
+                            break;
+                        case DATASOURCE:
+                            newEvent.setDataSource(getField(source, entry.getKey()));
+                            break;
+                        case CATEGORY:
+                            newEvent.setCategory(getField(source, entry.getKey()));
+                            break;
+                        case TEXT:
+                            newEvent.setText(getField(source, entry.getKey()));
+                            break;
+                        case CONTEXT:
+                            newEvent.getContext().put(entry.getKey(), getField(source, entry.getKey()));
+                            break;
+                        case TAGS:
+                            if (isIndex) {
+                                newEvent.getTags().put(INDEX, (String) hit.get(_INDEX));
+                            } else {
+                                newEvent.getTags().put(entry.getKey(), getField(source, entry.getKey()));
+                            }
+                            break;
+                    }
+                }
+                if (newEvent.getId() == null) {
+                    newEvent.setId(UUID.randomUUID().toString());
+                }
+                parsed.add(newEvent);
+            }
+        }
+        return parsed;
+    }
+
+    protected String getField(Map<String, Object> source, String name) {
+        if (source == null || name == null) {
+            return null;
+        }
+        if (name.charAt(0) == '\'' && name.charAt(name.length() - 1) == '\'') {
+            return name.substring(1, name.length() - 1);
+        }
+        String[] names = name.split("\\|");
+        String defaultValue = "";
+        if (names.length > 1) {
+            if (names[1].charAt(0) == '\'' && names[1].charAt(names[1].length() - 1) == '\'') {
+                defaultValue = names[1].substring(1, names[1].length() - 1);
+            }
+            name = names[0];
+        }
+        String[] fields = name.split("\\.");
+        for (int i=0; i < fields.length; i++) {
+            Object value = source.get(fields[i]);
+            if (value instanceof String) {
+                return (String) value;
+            }
+            if (value instanceof Map) {
+                source = (Map<String, Object>) value;
+            }
+        }
+        return defaultValue;
+    }
+
+    public long parseTimestamp(String timestamp) {
+        String definedPattern = properties.get(TIMESTAMP_PATTERN);
+        if (definedPattern != null) {
+            DateTimeFormatter formatter = null;
+            try {
+                formatter = DateTimeFormatter.ofPattern(definedPattern);
+                return ZonedDateTime.parse(timestamp, formatter).toInstant().toEpochMilli();
+            } catch (Exception e) {
+                log.debugf("Not able to parse [%s] with format [%s]", timestamp, formatter);
+            }
+        }
+        for (DateTimeFormatter formatter : DEFAULT_DATE_FORMATS) {
+            try {
+                return ZonedDateTime.parse(timestamp, formatter).toInstant().toEpochMilli();
+            } catch (Exception e) {
+                log.debugf("Not able to parse [%s] with format [%s]", timestamp, formatter);
+            }
+        }
+        try {
+            return new Long(timestamp).longValue();
+        } catch (Exception e) {
+            log.debugf("Not able to parse [%s] as plain timestamp", timestamp);
+        }
+        return System.currentTimeMillis();
+    }
+
+    public String formatTimestamp(Date date) {
+        String definedPattern = properties.get(TIMESTAMP_PATTERN);
+        if (definedPattern != null) {
+            DateTimeFormatter formatter = null;
+            try {
+                formatter = DateTimeFormatter.ofPattern(definedPattern);
+                return formatter.format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(date.getTime()), UTC));
+            } catch (Exception e) {
+                log.debugf("Not able to format [%s] with pattern [%s]", date, formatter);
+            }
+        }
+        return DEFAULT_DATE_FORMATS[0].format(ZonedDateTime.ofInstant(Instant.ofEpochMilli(date.getTime()), UTC));
+    }
+
+    private String rawQuery(String filter) {
+        return "{" +
+                    "\"constant_score\":{" +
+                        "\"filter\":{" +
+                            "\"bool\":{" +
+                                "\"must\":" +
+                                    filter +
+                            "}" +
+                        "}" +
+                    "}" +
+                "}";
+    }
+
+    private Date intervalDate() {
+        String interval = properties.get(INTERVAL);
+        int value = getIntervalValue(interval);
+        switch (getIntervalUnit(interval)) {
+            case HOURS:
+                value = value * 3600 * 1000;
+                break;
+            case MINUTES:
+                value = value * 60 * 1000;
+                break;
+            case SECONDS:
+                value = value * 1000;
+                break;
+        }
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(System.currentTimeMillis() - value);
+        return cal.getTime();
+    }
+
+    private String prepareQuery() {
+        String range = new StringBuilder("{\"range\":{\"").append(properties.get(TIMESTAMP))
+                .append("\":{\"gt\":\"").append(formatTimestamp(intervalDate())).append("\"}}}").toString();
+        String filter = properties.get(FILTER);
+        String filters;
+        if (filter != null) {
+            filters =new StringBuilder("[").append(filter).append(",").append(range).append("]").toString();
+        } else {
+            filters = new StringBuilder("[").append(range).append("]").toString();
+        }
+        return rawQuery(filters);
+    }
+
+    public void disconnect() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            parseProperties();
+            parseMap();
+            connect(properties.get(URL));
+            String preparedQuery = prepareQuery();
+            log.debugf("Fetching documents from Elasticsearch [%s] %s", preparedQuery, trigger.getContext());
+            List<Event> events = parseEvents(query(preparedQuery, (String) properties.get(INDEX)));
+            log.debugf("Found [%s]", events.size());
+            disconnect();
+            events.stream().forEach(e -> e.setTenantId(trigger.getTenantId()));
+            alerts.sendEvents(events);
+        } catch (Exception e) {
+            log.error("Error querying Elasticsearch.", e);
+        }
+    }
+
+    private boolean isEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/test/groovy/org/hawkular/alerter/elasticsearch/ElasticsearchITest.groovy
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/test/groovy/org/hawkular/alerter/elasticsearch/ElasticsearchITest.groovy
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.elasticsearch
+
+import static org.junit.Assert.assertTrue
+
+import java.text.SimpleDateFormat
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+class ElasticsearchITest {
+
+    def elasticsearch, hawkular, format, definitions, response
+
+    ElasticsearchITest() {
+        elasticsearch = new RESTClient(System.getProperty('elasticsearch.base-uri') ?: 'http://127.0.0.1:9200/', ContentType.JSON)
+        elasticsearch.handler.failure = { it }
+        hawkular = new RESTClient(System.getProperty('hawkular.base-uri') ?: 'http://centos:8080/hawkular/alerts/', ContentType.JSON)
+        hawkular.handler.failure = { it }
+        /*
+            Basic header is used only for hawkular-services distribution.
+            This header is ignored on standalone scenarios.
+
+            User: jdoe
+            Password: password
+            String encodedCredentials = Base64.getMimeEncoder()
+                .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+        */
+        hawkular.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+        hawkular.headers.put("Hawkular-Tenant", "my-organization")
+        format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
+        definitions = new File("src/test/resources/elasticsearch-trigger.json").text
+    }
+
+    /*
+        These tests are ignored as they need an external ElasticSearch instance.
+        Used for manual testing
+     */
+
+    @Ignore
+    @Test
+    void hawkularCreateTestDefinitions() {
+        response = hawkular.post(path: "import/all", body: definitions)
+        assertTrue(response.status < 300)
+    }
+
+    @Ignore
+    @Test
+    void hawkularDeleteTestDefinitions() {
+        hawkular.delete(path: "triggers/es-trigger")
+    }
+
+    @Ignore
+    @Test
+    void elasticsearchDeleteTestIndexes() {
+        elasticsearch.delete("alerts_full")
+        elasticsearch.delete("alerts_summary")
+    }
+
+    @Ignore
+    @Test
+    void elasticsearchSendOperationsLog() {
+        def index = ".operations.2017.02.21"
+        def type = "com.redhat.viaq.common"
+        def operations = "{\n" +
+                "          \"@timestamp\": \"${format.format(new Date())}\",\n" +
+                "          \"UNKNOWN1\": \"1\",\n" +
+                "          \"UNKNOWN2\": \"2\",\n" +
+                "          \"hostname\": \"localhost\",\n" +
+                "          \"message\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\",\n" +
+                "          \"pipeline_metadata\": {\n" +
+                "            \"collector\": {\n" +
+                "              \"inputname\": \"fluent-plugin-systemd\",\n" +
+                "              \"name\": \"fluentd openshift\",\n" +
+                "              \"received_at\": \"2017-02-21T16:26:28.348924+00:00\",\n" +
+                "              \"version\": \"0.12.29 1.4.0\"\n" +
+                "            }\n" +
+                "          },\n" +
+                "          \"systemd\": {\n" +
+                "            \"t\": {\n" +
+                "              \"BOOT_ID\": \"0937011437e44850b3cb5a615345b50f\",\n" +
+                "              \"COMM\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c\",\n" +
+                "              \"GID\": \"1000\",\n" +
+                "              \"HOSTNAME\": \"localhost\",\n" +
+                "              \"PID\": \"19698\",\n" +
+                "              \"SOURCE_REALTIME_TIMESTAMP\": \"1487694388348924\",\n" +
+                "              \"TRANSPORT\": \"stderr\",\n" +
+                "              \"UID\": \"1000\"\n" +
+                "            },\n" +
+                "            \"u\": {\n" +
+                "              \"SYSLOG_FACILITY\": \"1\",\n" +
+                "              \"SYSLOG_IDENTIFIER\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }"
+        println operations
+        response = elasticsearch.post(path: "${index}/${type}", body: operations)
+        assertTrue(response.status < 300)
+    }
+
+    @Ignore
+    @Test
+    void elasticsearchSendErrorProjectLog() {
+        def index = "project.this-is-project-01.namespaceid.2017.02.21"
+        def type = "com.redhat.viaq.common"
+        def level = "ERROR"
+        def project = "{\n" +
+                "          \"@timestamp\": \"${format.format(new Date())}\",\n" +
+                "          \"UNKNOWN1\": \"1\",\n" +
+                "          \"UNKNOWN2\": \"2\",\n" +
+                "          \"hostname\": \"localhost\",\n" +
+                "          \"kubernetes\": {\n" +
+                "            \"container_id\": \"4355a46b19d3\",\n" +
+                "            \"container_name\": \"this-is-container-01\",\n" +
+                "            \"host\": \"localhost\",\n" +
+                "            \"labels\": \"openshift_io:this is my label\",\n" +
+                "            \"namespace_id\": \"namespaceid\",\n" +
+                "            \"namespace_name\": \"this-is-project-01\",\n" +
+                "            \"pod_id\": \"870560fe-c22c-4f06-8ee4-c55399d3ed2f\",\n" +
+                "            \"pod_name\": \"this-is-pod-01\"\n" +
+                "          },\n" +
+                "          \"level\": \"${level}\",\n" +
+                "          \"message\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\",\n" +
+                "          \"pipeline_metadata\": {\n" +
+                "            \"collector\": {\n" +
+                "              \"inputname\": \"fluent-plugin-systemd\",\n" +
+                "              \"name\": \"fluentd openshift\",\n" +
+                "              \"received_at\": \"2017-02-21T16:26:28.356504+00:00\",\n" +
+                "              \"version\": \"0.12.29 1.4.0\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }"
+        println project
+        response = elasticsearch.post(path: "${index}/${type}", body: project)
+        assertTrue(response.status < 300)
+    }
+
+    @Ignore
+    @Test
+    void elasticsearchSendWarnProjectLog() {
+        def index = "project.this-is-project-01.namespaceid.2017.02.21"
+        def type = "com.redhat.viaq.common"
+        def level = "WARN"
+        def project = "{\n" +
+                "          \"@timestamp\": \"${format.format(new Date())}\",\n" +
+                "          \"UNKNOWN1\": \"1\",\n" +
+                "          \"UNKNOWN2\": \"2\",\n" +
+                "          \"hostname\": \"localhost\",\n" +
+                "          \"kubernetes\": {\n" +
+                "            \"container_id\": \"4355a46b19d3\",\n" +
+                "            \"container_name\": \"this-is-container-01\",\n" +
+                "            \"host\": \"localhost\",\n" +
+                "            \"labels\": \"openshift_io:this is my label\",\n" +
+                "            \"namespace_id\": \"namespaceid\",\n" +
+                "            \"namespace_name\": \"this-is-project-01\",\n" +
+                "            \"pod_id\": \"870560fe-c22c-4f06-8ee4-c55399d3ed2f\",\n" +
+                "            \"pod_name\": \"this-is-pod-01\"\n" +
+                "          },\n" +
+                "          \"level\": \"${level}\",\n" +
+                "          \"message\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\",\n" +
+                "          \"pipeline_metadata\": {\n" +
+                "            \"collector\": {\n" +
+                "              \"inputname\": \"fluent-plugin-systemd\",\n" +
+                "              \"name\": \"fluentd openshift\",\n" +
+                "              \"received_at\": \"2017-02-21T16:26:28.356504+00:00\",\n" +
+                "              \"version\": \"0.12.29 1.4.0\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }"
+        println project
+        response = elasticsearch.post(path: "${index}/${type}", body: project)
+        assertTrue(response.status < 300)
+    }
+
+    @Ignore
+    @Test
+    void elasticsearchSendInfoProjectLog() {
+        def index = "project.this-is-project-01.namespaceid.2017.02.21"
+        def type = "com.redhat.viaq.common"
+        def level = "INFO"
+        def project = "{\n" +
+                "          \"@timestamp\": \"${format.format(new Date())}\",\n" +
+                "          \"UNKNOWN1\": \"1\",\n" +
+                "          \"UNKNOWN2\": \"2\",\n" +
+                "          \"hostname\": \"localhost\",\n" +
+                "          \"kubernetes\": {\n" +
+                "            \"container_id\": \"4355a46b19d3\",\n" +
+                "            \"container_name\": \"this-is-container-01\",\n" +
+                "            \"host\": \"localhost\",\n" +
+                "            \"labels\": \"openshift_io:this is my label\",\n" +
+                "            \"namespace_id\": \"namespaceid\",\n" +
+                "            \"namespace_name\": \"this-is-project-01\",\n" +
+                "            \"pod_id\": \"870560fe-c22c-4f06-8ee4-c55399d3ed2f\",\n" +
+                "            \"pod_name\": \"this-is-pod-01\"\n" +
+                "          },\n" +
+                "          \"level\": \"${level}\",\n" +
+                "          \"message\": \"3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\",\n" +
+                "          \"pipeline_metadata\": {\n" +
+                "            \"collector\": {\n" +
+                "              \"inputname\": \"fluent-plugin-systemd\",\n" +
+                "              \"name\": \"fluentd openshift\",\n" +
+                "              \"received_at\": \"2017-02-21T16:26:28.356504+00:00\",\n" +
+                "              \"version\": \"0.12.29 1.4.0\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }"
+        println project
+        response = elasticsearch.post(path: "${index}/${type}", body: project)
+        assertTrue(response.status < 300)
+    }
+
+    @Ignore
+    @Test
+    void send100elasticsearchSendInfoProjectLog() {
+        for (int i=0; i<100; i++) {
+            elasticsearchSendInfoProjectLog();
+            Thread.sleep(5);
+        }
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/test/java/org/hawkular/alerter/elasticsearch/ElasticsearchQueryTest.java
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/test/java/org/hawkular/alerter/elasticsearch/ElasticsearchQueryTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class ElasticsearchQueryTest {
+
+    @Test
+    public void checkPropertiesAndMappings() throws Exception {
+        Trigger trigger = new Trigger();
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("host", "defaultHost");
+        properties.put("port", "defaultPort");
+
+        ElasticsearchQuery esQuery = new ElasticsearchQuery(trigger, properties, null);
+        try {
+            esQuery.parseProperties();
+            fail("Trigger has not mandatory tags/context properties");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("timestamp"));
+        }
+
+        trigger.getContext().put("timestamp", "@timestamp");
+        try {
+            esQuery.parseProperties();
+            fail("Trigger has not mandatory tags/context properties");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("mapping"));
+        }
+
+        try {
+            esQuery.parseMap();
+            fail("Trigger has not mandatory context properties");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("mapping"));
+        }
+
+        trigger.getContext().put("mapping", "@timestamp:ctime");
+        try {
+            esQuery.parseProperties();
+            esQuery.parseMap();
+            fail("EventCondition has not mandatory context properties");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("dataId"));
+        }
+
+        trigger.getContext().put("mapping", "@timestamp:ctime,index:dataId");
+        esQuery.parseProperties();
+        esQuery.parseMap();
+    }
+
+    @Test
+    public void checkConstantMapping() throws Exception {
+        ElasticsearchQuery esQuery = new ElasticsearchQuery(null, null, null);
+
+        Map<String, Object> source = new HashMap<>();
+        String value = esQuery.getField(source, "test");
+        assertTrue(value.isEmpty());
+
+        value = esQuery.getField(source, "'value'");
+        assertEquals("value", value);
+
+        value = esQuery.getField(source, "test|'value'");
+        assertEquals("value", value);
+
+        source.put("test", "newvalue");
+        value = esQuery.getField(source, "test|'value'");
+        assertEquals("newvalue", value);
+
+        Map<String, Object> test = new HashMap<>();
+        test.put("propA", "valueA");
+        test.put("propB", "valueB");
+        source.put("test", test);
+
+        value = esQuery.getField(source, "test|'value'");
+        assertEquals("value", value);
+
+        value = esQuery.getField(source, "|'value'");
+        assertEquals("value", value);
+
+        value = esQuery.getField(source, "test.propA|'value'");
+        assertEquals("valueA", value);
+
+        value = esQuery.getField(source, "test.propB|'value'");
+        assertEquals("valueB", value);
+    }
+
+    /*
+        -Djavax.net.ssl.trustStore=/tmp/truststore.jks
+        -Djavax.net.ssl.trustStorePassword=password
+        -Djavax.net.ssl.keyStore=/tmp/admin-key.jks
+        -Djavax.net.ssl.keyStorePassword=password
+        -Djavax.net.debug=ssl
+    */
+
+    @Ignore
+    @Test
+    public void querySecure() throws Exception {
+        System.setProperty("javax.net.ssl.trustStore", "/tmp/truststore.jks");
+        System.setProperty("javax.net.ssl.trustStorePassword", "password");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("token", "Q1KcScGJOgJUFadfOrEL4uX56lqnschT4jcsnoqBDFI");
+        properties.put("proxy-remote-user", "kibtest");
+        properties.put("forwarded-for", "127.0.0.1");
+
+        ElasticsearchQuery query = new ElasticsearchQuery(null, properties, null);
+        query.connect("https://logging-es:9200");
+        List<Map<String, Object>> results = query.query("[]", ".operations*");
+        System.out.println(results.size());
+        List<Event> events = query.parseEvents(results);
+        System.out.println(events.size());
+        query.disconnect();
+    }
+
+    @Ignore
+    @Test
+    public void validateMapping() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("mapping", "level:category,@timestamp:ctime,message:text,app:dataId,index:tags");
+
+        ElasticsearchQuery query = new ElasticsearchQuery(null, properties, null);
+        query.parseMap();
+        query.connect("http://localhost:9200");
+        List<Map<String, Object>> results = query.query("[]", "log");
+        List<Event> events = query.parseEvents(results);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ");
+        Calendar calendar = Calendar.getInstance();
+        for (int i=0; i<results.size(); i++) {
+            Map<String, Object> source = (Map<String,Object>)results.get(i).get("_source");
+            String timestamp = (String) source.get("@timestamp");
+            System.out.println(timestamp);
+            System.out.println(sdf.parse(timestamp).getTime());
+            Event event = events.get(i);
+            System.out.println(event.getCtime());
+            System.out.println(event.getContext());
+            System.out.println(sdf.format(new Date(event.getCtime())));
+            System.out.println("---");
+        }
+        query.disconnect();
+        System.out.println(results);
+        System.out.println(events);
+    }
+
+   @Ignore
+   @Test
+   public void directConnectionTest() throws Exception {
+        SSLSocketFactory sslsocketfactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        URL url = new URL("https://logging-es:9200/_search");
+        HttpsURLConnection conn = (HttpsURLConnection)url.openConnection();
+        conn.setSSLSocketFactory(sslsocketfactory);
+        InputStream inputstream = conn.getInputStream();
+        InputStreamReader inputstreamreader = new InputStreamReader(inputstream);
+        BufferedReader bufferedreader = new BufferedReader(inputstreamreader);
+
+        String string = null;
+        while ((string = bufferedreader.readLine()) != null) {
+            System.out.println("Received " + string);
+        }
+   }
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/elasticsearch-trigger.json
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/elasticsearch-trigger.json
@@ -1,0 +1,108 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "trigger-project",
+        "name": "Project Logging Trigger",
+        "description": "Alert on Project Logging (EFK infrastructure)",
+        "severity": "HIGH",
+        "enabled": true,
+        "tags": {
+          "Elasticsearch": "Demo ES instance"
+        },
+        "context": {
+          "timestamp": "@timestamp",
+          "interval": "30s",
+          "index": "project.logging*",
+          "mapping": "type|'Unknown':category,@timestamp:ctime,message:text,hostname:dataId,index:tags"
+        },
+        "actions":[
+          {
+            "actionPlugin": "elasticsearch",
+            "actionId": "write-full-alert"
+          },
+          {
+            "actionPlugin": "elasticsearch",
+            "actionId": "write-partial-alert"
+          },
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "EVENT",
+          "dataId": "192.168.122.198",
+          "expression": "category == 'response'"
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "trigger-operations",
+        "name": "Operations Trigger",
+        "description": "Alert on .operations data",
+        "severity": "HIGH",
+        "enabled": true,
+        "tags": {
+          "Elasticsearch": "Demo ES instance"
+        },
+        "context": {
+          "timestamp": "@timestamp",
+          "interval": "30s",
+          "index": ".operations*",
+          "mapping": "type|'Unknown':category,@timestamp:ctime,message:text,hostname:dataId,index:tags"
+        },
+        "actions":[
+          {
+            "actionPlugin": "elasticsearch",
+            "actionId": "write-full-alert"
+          },
+          {
+            "actionPlugin": "elasticsearch",
+            "actionId": "write-partial-alert"
+          },
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "EVENT",
+          "dataId": "centos",
+          "expression": "text starts '[system]'"
+        }
+      ]
+    }
+  ],
+  "actions":[
+    {
+      "actionPlugin": "elasticsearch",
+      "actionId": "write-full-alert",
+      "properties": {
+        "index": "alerts_full"
+      }
+    },
+    {
+      "actionPlugin": "elasticsearch",
+      "actionId": "write-partial-alert",
+      "properties": {
+        "index": "alerts_summary",
+        "timestamp.pattern": "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ",
+        "transform": "{\"tenantId\":\"tenant\",\"ctime\":\"timestamp\",\"text\":\"trigger\",\"context\":{\"interval\":\"fetch-interval\"},\"evalSets\":\"details\"}"
+      }
+    },
+    {
+      "actionPlugin": "email",
+      "actionId": "email-to-admins",
+      "properties": {
+        "mail.smtp.host": "192.168.1.16",
+        "to": "admins@hawkular.org"
+      }
+    }
+  ]
+}

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/log4j2.xml
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/mock-data.json
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/test/resources/mock-data.json
@@ -1,0 +1,3915 @@
+{
+  "_shards": {
+    "failed": 0,
+    "successful": 55,
+    "total": 55
+  },
+  "hits": {
+    "hits": [
+      {
+        "_id": "AVphfwzbogI4e30fG7t_",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:27.970659+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:27.970659+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694387970659",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694387970
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uJ",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:27.978732+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "8d019078-9b89-4dd9-883f-c814e568a79c",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:27.978732+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694387978
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uK",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:27.987468+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "89465df5-ebfe-48e7-817c-3b5726bf5838",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:27.987468+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694387987
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uL",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:27.996213+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "59817bdd-113f-41b6-8075-911dcd3c1dd6",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:27.996213+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694387996
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uM",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.005476+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "ec2e3260-4564-48a2-adeb-400d1b8675e4",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.005476+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388005
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uN",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.013720+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "e679bc20-3032-45f4-af26-21cb4268d6ca",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.013720+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388013
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uO",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.025530+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "b68345cb-2340-4010-9c22-6824fd8d20c9",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.025530+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388025
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uP",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.035165+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "638ff49d-97bf-403c-8684-230d1ec2f569",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.035165+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388035
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uQ",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.043719+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "e3f62b32-6405-4ea7-85e2-190b2e820e15",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.043719+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388043
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uR",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.052619+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "be99594b-0236-4497-ac58-6eac9fb9a609",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.052619+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388052
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uS",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.061501+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "43e6a531-d375-4764-992c-9f2786784fee",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-01 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.061501+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388061
+        ]
+      },
+      {
+        "_id": "AVphfwzbogI4e30fG7uA",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.068481+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.068481+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388068481",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388068
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uT",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.075881+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "d3c967dd-7259-4822-b8cb-0a626e7f4434",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.075881+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388075
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uU",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.084192+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "2223a0ca-f314-488e-a6da-f05564201792",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.084192+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388084
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uV",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.093009+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "a53e1cdf-3344-4c02-8c15-ee411ca19c40",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.093009+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388093
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uW",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.103110+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "68f1289e-b744-4939-b6ff-05707cf4b9df",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.103110+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388103
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uX",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.111399+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "6beed534-dab8-41db-b242-8c1dad3c6107",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.111399+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388111
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uY",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.120312+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "dc7bf8ef-b4bb-4f17-8034-36b5fa8639da",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.120312+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388120
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uZ",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.128555+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "93f4613f-5cb8-425e-86d5-3e7521514117",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.128555+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388128
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ua",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.137599+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "36bcc722-6d1c-4ed8-887a-d0ac3c80dbd8",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.137599+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388137
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ub",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.145638+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "e45990c5-54ed-47de-9e83-3dc7ed269428",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.145638+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388145
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uc",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.155941+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "47c338b5-ea16-42b2-8f18-765250078a67",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-02 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.155941+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388155
+        ]
+      },
+      {
+        "_id": "AVphfwzbogI4e30fG7uB",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.161113+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.161113+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388161113",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388161
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ud",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.169497+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "a27e3485-9bb9-453b-b92b-2abf7af48956",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.169497+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388169
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ue",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.177758+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "594f804e-45e5-454b-af13-9ece73db4149",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.177758+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388177
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uf",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.187052+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "827f0751-35aa-4011-b3ef-4461bc3e7aef",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.187052+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388187
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ug",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.195192+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "5891abce-ce72-49ec-8796-ff09e83031f1",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.195192+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388195
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uh",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.205046+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "72579a14-50ea-4b90-906f-46a6b53302c4",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.205046+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388205
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ui",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.213403+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "e16ba845-76f4-4988-a724-4a24fa00d32f",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.213403+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388213
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uj",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.223850+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "3f2a15fa-4447-4251-a6b2-c85c714375c1",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.223850+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388223
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uk",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.232445+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "07687d41-5c31-4084-b658-feb476b4875a",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.232445+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388232
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ul",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.240771+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "9e66e5f6-b6ad-41ec-844f-50986d5bb225",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.240771+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388240
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7um",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.251468+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "ffe979a1-d5dd-4b7e-a47f-fc2af0a0ba07",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-03 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.251468+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388251
+        ]
+      },
+      {
+        "_id": "AVphfwzbogI4e30fG7uC",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.256931+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.256931+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388256931",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388256
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7un",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.263999+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "3a6fe0d3-cfa6-4454-a05a-b4aff8273799",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.263999+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388263
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uo",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.272423+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "8674b0d8-1d37-4414-b6b4-7b7db9a1c62b",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.272423+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388272
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7up",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.281890+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "68c32d92-524a-4003-bb28-9b443ebd9b2e",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.281890+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388281
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uq",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.291358+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "90bf4b84-4f7d-45b1-98a1-d8c057dca73f",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.291358+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388291
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ur",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.299515+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "f928f436-5b6a-4324-86dc-74e2cf8d3548",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.299515+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388299
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7us",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.307818+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "1fa65f29-7add-4cb4-af1f-950ab3a6399c",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.307818+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388307
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ut",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.318319+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "a092784b-6416-4bef-b4ad-1a69d243322e",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.318319+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388318
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uu",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.326693+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "9ca2ba41-daa1-4f5f-b644-11538013a757",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.326693+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388326
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uv",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.335335+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "7d974a87-8142-4375-9774-c6856d61b40c",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.335335+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388335
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uw",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.343598+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "b74dff7a-e6a9-4c04-8cab-dc505f9cefd9",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-04 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.343598+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388343
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uD",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.348924+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.348924+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388348924",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388348
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7ux",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.356504+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "870560fe-c22c-4f06-8ee4-c55399d3ed2f",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.356504+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388356
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uy",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.364642+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "a600249f-f535-41a6-a3c9-73d37c65e758",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.364642+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388364
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7uz",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.374429+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "1522e0ed-b22d-4601-9cee-eaf15a41edd6",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.374429+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388374
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7u0",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.383563+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "efddd732-37b5-43fb-b7d2-b94c3bc1607f",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.383563+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388383
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7u1",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.392616+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "5f60b162-8414-459f-9e84-0d87519c3960",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.392616+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388392
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7u2",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.400859+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "8af5bd2c-8b56-4684-b507-26f15a615971",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.400859+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388400
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7u3",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.411030+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "b0b44288-70a1-4c6d-9376-966d53417fa7",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.411030+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388411
+        ]
+      },
+      {
+        "_id": "AVphfxDUogI4e30fG7u4",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.421367+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "128635b3-bab7-4af7-a0ea-a8004bbc8107",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.421367+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388421
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u5",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.429429+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "53d83734-b115-45a1-bc85-813143f38aa0",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.429429+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388429
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u6",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.439320+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "e3c0befb-6a0c-4b43-ade3-5c31b8c7fdcd",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-05 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.439320+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388439
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uE",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.444311+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.444311+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388444311",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388444
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u7",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.453143+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "f3ce5cd6-e7b7-4022-926d-3174d006575a",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.453143+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388453
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u8",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.461386+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "4ce349a9-378b-44a6-a3cb-c752f72637d5",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.461386+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388461
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u9",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.470142+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "f5143036-f331-4360-880e-83881884eac7",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.470142+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388470
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u-",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.478519+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "e564511a-6189-418e-b88f-cc46f3aea025",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.478519+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388478
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7u_",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.488323+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "0f5b6faf-4813-43d2-b4e6-fd82666ec2ee",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.488323+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388488
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vA",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.496591+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "91d420c5-29aa-42b3-9ac8-5e1a670e32a7",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.496591+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388496
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vB",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.505730+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "b7557eb7-ee34-4d00-b6a5-5b41e86ca156",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.505730+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388505
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vC",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.514139+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "d4d9a074-f0a7-4e75-bfe7-e9cc86fdc35c",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.514139+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388514
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vD",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.523478+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "fc34d792-6b12-4719-a9e4-21794cec4c64",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.523478+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388523
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vE",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.532106+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "3a17e648-a96c-4a86-ba64-e388aab00cce",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-06 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.532106+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388532
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uF",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.537836+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.537836+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388537836",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388537
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vF",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.544814+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "f56a31cc-e63c-4cb0-af53-bcb53335eef6",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.544814+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388544
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vG",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.553513+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "bbde2399-78f0-4752-8908-b5fe0f549cc3",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.553513+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388553
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vH",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.562325+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "b6b9ae0d-259a-4fc6-b98d-604c9f5083c9",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.562325+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388562
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vI",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.571655+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "14d74929-6a84-441f-9ce1-1b84267b3061",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.571655+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388571
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vJ",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.580381+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "d1eb1f62-63c9-4dd3-b0f3-acde51744b09",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.580381+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388580
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vK",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.589871+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "5749493f-80f2-49c9-93f3-d08c0143e662",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.589871+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388589
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vL",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.600348+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "5b681c20-3929-4ef7-9513-8ec2b39874a6",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.600348+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388600
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vM",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.609390+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "daabf7a6-895d-48cf-aa6d-1e064dece13a",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.609390+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388609
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vN",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.619249+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "1abc4ec6-ce38-47b2-877c-dc95520004ed",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.619249+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388619
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vO",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.628248+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "cda48dcc-10f6-43ce-b83e-6f93ef19d6f2",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-07 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.628248+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388628
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uG",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.634804+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.634804+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388634804",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388634
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vP",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.642318+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "032d7342-8857-45c7-a55d-09cb8644537d",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.642318+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388642
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vQ",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.650479+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "02c77084-57d5-4981-9a83-2b1f5e661c2a",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.650479+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388650
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vR",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.659427+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "d5ef4acf-35e7-42cd-90d6-033846a71594",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.659427+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388659
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vS",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.669073+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "706641d5-6ab4-48d4-b707-94768915fa81",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.669073+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388669
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vT",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.677494+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "e701391f-f909-43c8-8d55-c557a7940805",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.677494+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388677
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vU",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.686316+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "7822e5e5-6896-4f22-af21-16b72b3dbb48",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.686316+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388686
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vV",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.695123+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "8d22261d-4126-467d-bcea-9ee283353dfe",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.695123+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388695
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vW",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.704847+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "5c343d8f-d680-4111-9eb5-34fbe034e544",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.704847+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388704
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vX",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.712947+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "4964a30a-f293-4da7-90c4-405ed4a89630",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.712947+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388712
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vY",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.722272+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "01ac70fe-3ff1-407c-ba38-18f28aa2e801",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-08 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.722272+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388722
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uH",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.727138+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.727138+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388727138",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388727
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vZ",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.734874+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "67551f63-b31d-4588-a0e4-40e7ec7fb30c",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.734874+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388734
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7va",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.743287+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "3107d838-31e9-4f29-99a0-fd4d81ec1822",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.743287+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388743
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vb",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.753085+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "e7abecae-b53a-460b-9bb5-38c307d4b39b",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.753085+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388753
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vc",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.761441+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "c983c6c3-8130-4fc6-8a27-92d93b859876",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.761441+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388761
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vd",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.770346+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "b9660981-4bea-4ef1-94f1-a3b384cf2490",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.770346+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388770
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7ve",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.778359+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "da22b5d2-1bd8-46da-b66b-0fed45dd9238",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.778359+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388778
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vf",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.787871+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "0e2683b4-f210-49bc-89b2-5c25ea35c532",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.787871+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388787
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vg",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.796209+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "fda5d270-0ed1-463d-8aaa-9f9983912061",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.796209+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388796
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vh",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.805203+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "d111df45-81b9-407b-83d8-40ef29dd55aa",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.805203+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388805
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vi",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.814176+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "d8952e12-f327-48ca-9efe-8e61c5150ebf",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-09 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.814176+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388814
+        ]
+      },
+      {
+        "_id": "AVphfwzcogI4e30fG7uI",
+        "_index": ".operations.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.821287+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.821287+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          },
+          "systemd": {
+            "t": {
+              "BOOT_ID": "0937011437e44850b3cb5a615345b50f",
+              "COMM": "3240243d-9065-4ec2-983b-c0dd90d5d72c",
+              "GID": "1000",
+              "HOSTNAME": "localhost",
+              "PID": "19698",
+              "SOURCE_REALTIME_TIMESTAMP": "1487694388821287",
+              "TRANSPORT": "stderr",
+              "UID": "1000"
+            },
+            "u": {
+              "SYSLOG_FACILITY": "1",
+              "SYSLOG_IDENTIFIER": "3240243d-9065-4ec2-983b-c0dd90d5d72c"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388821
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vj",
+        "_index": "project.this-is-project-01.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.828433+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "4355a46b19d3",
+            "container_name": "this-is-container-01",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-01",
+            "pod_id": "9f53072a-cfd5-4af2-9eed-9e059bd18f8b",
+            "pod_name": "this-is-pod-01"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.828433+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388828
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vk",
+        "_index": "project.this-is-project-02.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.837670+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "53c234e5e847",
+            "container_name": "this-is-container-02",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-02",
+            "pod_id": "504102d8-0344-4407-b02e-6b7ecc4bd8a5",
+            "pod_name": "this-is-pod-02"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.837670+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388837
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vl",
+        "_index": "project.this-is-project-03.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.846918+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "1121cfccd591",
+            "container_name": "this-is-container-03",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-03",
+            "pod_id": "25a5ecf2-cf05-486c-86e0-de501188b3fe",
+            "pod_name": "this-is-pod-03"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.846918+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388846
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vm",
+        "_index": "project.this-is-project-04.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.857206+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "7de1555df0c2",
+            "container_name": "this-is-container-04",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-04",
+            "pod_id": "9dbc0336-55ac-48aa-8072-50377ebcd1b5",
+            "pod_name": "this-is-pod-04"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.857206+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388857
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vn",
+        "_index": "project.this-is-project-05.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.865499+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "f0b5c2c2211c",
+            "container_name": "this-is-container-05",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-05",
+            "pod_id": "bf4b5bb5-080b-41db-9813-9b809d591f54",
+            "pod_name": "this-is-pod-05"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.865499+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388865
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vo",
+        "_index": "project.this-is-project-06.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.873855+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "06e9d52c1720",
+            "container_name": "this-is-container-06",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-06",
+            "pod_id": "98783104-5f5c-4440-bfed-e5daa33ebc9d",
+            "pod_name": "this-is-pod-06"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.873855+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388873
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vp",
+        "_index": "project.this-is-project-07.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.883753+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "10159baf262b",
+            "container_name": "this-is-container-07",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-07",
+            "pod_id": "d0ec0566-2b3f-4151-a70d-43c9cfcdb4e4",
+            "pod_name": "this-is-pod-07"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.883753+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388883
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vq",
+        "_index": "project.this-is-project-08.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.892547+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "aa67a169b0bb",
+            "container_name": "this-is-container-08",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-08",
+            "pod_id": "445dbb9a-1b95-40a0-ac92-2dbf1ff8dbea",
+            "pod_name": "this-is-pod-08"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.892547+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388892
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vr",
+        "_index": "project.this-is-project-09.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.900824+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "2e6d31a5983a",
+            "container_name": "this-is-container-09",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-09",
+            "pod_id": "9b21ef8e-00b4-4adc-b43a-1fb4b542e1a1",
+            "pod_name": "this-is-pod-09"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.900824+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388900
+        ]
+      },
+      {
+        "_id": "AVphfxDVogI4e30fG7vs",
+        "_index": "project.this-is-project-10.namespaceid.2017.02.21",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2017-02-21T16:26:28.909996+00:00",
+          "UNKNOWN1": "1",
+          "UNKNOWN2": "2",
+          "hostname": "localhost",
+          "kubernetes": {
+            "container_id": "917df3320d77",
+            "container_name": "this-is-container-10",
+            "host": "localhost",
+            "labels": "openshift_io:this is my label",
+            "namespace_id": "namespaceid",
+            "namespace_name": "this-is-project-10",
+            "pod_id": "ae2c328f-fad0-4518-9eff-d734370f10df",
+            "pod_name": "this-is-pod-10"
+          },
+          "level": "3",
+          "message": "3240243d-9065-4ec2-983b-c0dd90d5d72c-10 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "pipeline_metadata": {
+            "collector": {
+              "inputname": "fluent-plugin-systemd",
+              "name": "fluentd openshift",
+              "received_at": "2017-02-21T16:26:28.909996+00:00",
+              "version": "0.12.29 1.4.0"
+            }
+          }
+        },
+        "_type": "com.redhat.viaq.common",
+        "sort": [
+          1487694388909
+        ]
+      }
+    ],
+    "max_score": null,
+    "total": 110
+  },
+  "timed_out": false,
+  "took": 11
+}

--- a/alerters/alerters-plugins/alerters-prometheus/pom.xml
+++ b/alerters/alerters-plugins/alerters-prometheus/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-alerters-plugins</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-prometheus</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerting: Alerter Prometheus Plugin</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${version.com.squareup.okhttp3}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-ws</artifactId>
+      <version>${version.com.squareup.okhttp3}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.commons</groupId>
+      <artifactId>hawkular-rest-api</artifactId>
+      <version>${version.org.hawkular.commons}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/BaseHttpClientGenerator.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/BaseHttpClientGenerator.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ws.WebSocketCall;
+
+/**
+ * Can be used to generate HTTP clients including those that require SSL. The Prometheus endpoint itself does not have
+ * any security but we may need to navigate through a reverse proxy and so we may need some of this security.  Without
+ * a reverse proxy just set useSSL to false.
+ *
+ * Note that if the configuration's sslContext is null, this object will use the configured keystorePath
+ * and keystorePassword to build one itself. If sslContext is provided (not-null) then the configuration's
+ * keystorePath and keystorePassword are ignored.
+ *
+ * Note that if the configuration says to NOT use SSL in the first place, the given SSL context (if any)
+ * as well as the configured keystorePath and keystorePassword will all be ignored since
+ * we are being told to not use SSL at all.
+ */
+public class BaseHttpClientGenerator {
+    private final MsgLogger log = MsgLogging.getMsgLogger(BaseHttpClientGenerator.class);
+
+    public static class Configuration {
+        public static class Builder {
+            private boolean useAuthorization;
+            private String username;
+            private String password;
+            private boolean useSSL;
+            private String keystorePath;
+            private String keystorePassword;
+            private SSLContext sslContext;
+            private X509TrustManager x509TrustManager;
+            private Optional<Integer> connectTimeoutSeconds = Optional.empty();
+            private Optional<Integer> readTimeoutSeconds = Optional.empty();
+
+            public Builder() {
+            }
+
+            public Configuration build() {
+                return new Configuration(useAuthorization, username, password, useSSL, keystorePath, keystorePassword,
+                        sslContext, x509TrustManager, connectTimeoutSeconds, readTimeoutSeconds);
+            }
+
+            public Builder useAuthorization(boolean b) {
+                this.useSSL = b;
+                return this;
+            }
+
+            public Builder username(String s) {
+                this.username = s;
+                return this;
+            }
+
+            public Builder password(String s) {
+                this.password = s;
+                return this;
+            }
+
+            public Builder useSsl(boolean b) {
+                this.useSSL = b;
+                return this;
+            }
+
+            public Builder keystorePath(String s) {
+                this.keystorePath = s;
+                return this;
+            }
+
+            public Builder keystorePassword(String s) {
+                this.keystorePassword = s;
+                return this;
+            }
+
+            public Builder sslContext(SSLContext s) {
+                this.sslContext = s;
+                return this;
+            }
+
+            public Builder x509TrustManager(X509TrustManager x509TrustManager) {
+                this.x509TrustManager = x509TrustManager;
+                return this;
+            }
+
+            public Builder connectTimeout(int connectTimeoutSeconds) {
+                this.connectTimeoutSeconds = Optional.of(connectTimeoutSeconds);
+                return this;
+            }
+
+            public Builder readTimeout(int readTimeoutSeconds) {
+                this.readTimeoutSeconds = Optional.of(readTimeoutSeconds);
+                return this;
+            }
+        }
+
+        private boolean useAuthorization;
+        private final String username;
+        private final String password;
+        private final boolean useSSL;
+        private final String keystorePath;
+        private final String keystorePassword;
+        private final SSLContext sslContext;
+        private final X509TrustManager x509TrustManager;
+        private final Optional<Integer> connectTimeoutSeconds;
+        private final Optional<Integer> readTimeoutSeconds;
+
+        private Configuration(boolean useAuthorization, String username, String password, boolean useSSL,
+                String keystorePath,
+                String keystorePassword, SSLContext sslContext, X509TrustManager x509TrustManager,
+                Optional<Integer> connectTimeoutSeconds,
+                Optional<Integer> readTimeoutSeconds) {
+            this.useAuthorization = useAuthorization;
+            this.username = username;
+            this.password = password;
+            this.useSSL = useSSL;
+            this.keystorePath = keystorePath;
+            this.keystorePassword = keystorePassword;
+            this.sslContext = sslContext;
+            this.x509TrustManager = x509TrustManager;
+            this.connectTimeoutSeconds = connectTimeoutSeconds;
+            this.readTimeoutSeconds = readTimeoutSeconds;
+        }
+
+        public boolean isUseAuthorization() {
+            return useAuthorization;
+        }
+
+        public void setUseAuthorization(boolean useAuthorization) {
+            this.useAuthorization = useAuthorization;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public boolean isUseSSL() {
+            return useSSL;
+        }
+
+        public String getKeystorePath() {
+            return keystorePath;
+        }
+
+        public String getKeystorePassword() {
+            return keystorePassword;
+        }
+
+        public SSLContext getSslContext() {
+            return sslContext;
+        }
+
+        public X509TrustManager getX509TrustManager() {
+            return x509TrustManager;
+        }
+
+        public Optional<Integer> getConnectTimeoutSeconds() {
+            return connectTimeoutSeconds;
+        }
+
+        public Optional<Integer> getReadTimeoutSeconds() {
+            return readTimeoutSeconds;
+        }
+    }
+
+    /** the configuration for our httpclient generator */
+    private final Configuration configuration;
+
+    /** The configured client singleton */
+    private final OkHttpClient httpClient;
+
+    public BaseHttpClientGenerator(Configuration configuration) {
+        this.configuration = configuration;
+
+        OkHttpClient.Builder httpClientBldr = new OkHttpClient.Builder();
+
+        /* set the timeouts explicitly only if they were set through the config */
+        configuration.getConnectTimeoutSeconds()
+                .ifPresent(timeout -> httpClientBldr.connectTimeout(timeout.intValue(), TimeUnit.SECONDS));
+        configuration.getReadTimeoutSeconds()
+                .ifPresent(timeout -> httpClientBldr.readTimeout(timeout.intValue(), TimeUnit.SECONDS));
+
+        if (this.configuration.isUseSSL()) {
+            SSLContext theSslContextToUse;
+            X509TrustManager theTrustManagerToUse = null;
+
+            if (this.configuration.getSslContext() == null) {
+                if (this.configuration.getKeystorePath() != null) {
+                    KeyStore keystore = loadKeystore(this.configuration.getKeystorePath(),
+                            this.configuration.getKeystorePassword());
+                    TrustManager[] trustManagers = buildTrustManagers(keystore);
+                    theSslContextToUse = buildSSLContext(keystore,
+                            this.configuration.getKeystorePassword(), trustManagers);
+
+                    for (TrustManager tm : trustManagers) {
+                        if (tm instanceof X509TrustManager) {
+                            theTrustManagerToUse = (X509TrustManager) tm;
+                            break;
+                        }
+                    }
+
+                } else {
+                    theSslContextToUse = null; // rely on the JVM default
+                }
+            } else {
+                theSslContextToUse = this.configuration.getSslContext();
+                theTrustManagerToUse = this.configuration.getX509TrustManager();
+            }
+
+            if (theSslContextToUse != null && theTrustManagerToUse != null) {
+                httpClientBldr.sslSocketFactory(theSslContextToUse.getSocketFactory(), theTrustManagerToUse);
+            } else if (theSslContextToUse != null) {
+                log.error("We have a SSLContext without a X509TrustManager.");
+            }
+
+            // does not perform any hostname verification when looking at the remote end's cert
+            /*
+            httpClient.setHostnameVerifier(new javax.net.ssl.HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    log.debugf("HTTP client is blindly approving cert for [%s]", hostname);
+                    return true;
+                }
+            });
+            */
+        }
+
+        this.httpClient = httpClientBldr.build();
+    }
+
+    /**
+     * @return the fully configured HTTP client
+     */
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    /**
+     * Creates a websocket that connects to the given URL.
+     *
+     * @param url where the websocket server is
+     * @param headers headers to pass in the connect request
+     * @return the websocket
+     */
+    public WebSocketCall createWebSocketCall(String url, Map<String, String> headers) {
+        String base64Credentials = buildBase64Credentials();
+
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", "Basic " + base64Credentials)
+                .addHeader("Accept", "application/json");
+
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                requestBuilder.addHeader(header.getKey(), header.getValue());
+            }
+        }
+
+        Request request = requestBuilder.build();
+        WebSocketCall wsc = WebSocketCall.create(getHttpClient(), request);
+        return wsc;
+    }
+
+    /**
+     * @return The configuration used to build the HTTP client.
+     */
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * For client requests that need to send a Basic authorization header, this builds the
+     * base-64 encoding of the username and password that is needed for that header.
+     *
+     * @return base-64 encoding of the "username:password" as required for Basic auth.
+     */
+    public String buildBase64Credentials() {
+        // see http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side
+        return base64Encode(this.configuration.getUsername() + ":" + this.configuration.getPassword());
+    }
+
+    private static String base64Encode(String plainTextString) {
+        String encoded = new String(Base64.getEncoder().encode(plainTextString.getBytes()));
+        return encoded;
+    }
+
+    private KeyStore loadKeystore(String keystorePath, String keystorePassword) {
+        try {
+            return readKeyStore(keystorePath, keystorePassword);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Cannot load keystore [%s]", keystorePath), e);
+        }
+    }
+
+    private SSLContext buildSSLContext(KeyStore keyStore, String keystorePassword, TrustManager[] trustManagers) {
+        try {
+
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory
+                    .getDefaultAlgorithm());
+            keyManagerFactory.init(keyStore, keystorePassword.toCharArray());
+            sslContext.init(keyManagerFactory.getKeyManagers(), trustManagers,
+                    new SecureRandom());
+            return sslContext;
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Cannot create SSL context from keystore"), e);
+        }
+    }
+
+    private TrustManager[] buildTrustManagers(KeyStore keyStore) {
+        try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(keyStore);
+            return trustManagerFactory.getTrustManagers();
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot build TrustManager", e);
+        }
+    }
+
+    private KeyStore readKeyStore(String keystorePath, String keystorePassword) throws Exception {
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+
+        // get user password and file input stream
+        char[] password = keystorePassword.toCharArray();
+        File file = new File(keystorePath);
+
+        log.infof("Using keystore %s", file.getAbsolutePath());
+
+        try (FileInputStream fis = new FileInputStream(file)) {
+            ks.load(fis, password);
+        }
+        return ks;
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/HttpClientBuilder.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/HttpClientBuilder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus;
+
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import okhttp3.RequestBody;
+
+/**
+ * Builds an HTTP client that can be used to talk to Prometheus.  The Prometheus endpoint itself does not have
+ * any security but we may need to navigate through a reverse proxy and so we may need some of this security.  Without
+ * a reverse proxy just set useAuthorization and useSSL to false. This builder has methods that you can use to build
+ * requests.
+ */
+public class HttpClientBuilder extends BaseHttpClientGenerator {
+    /**
+     * Creates the object that can be used to create a fully configured HTTP client.
+     * Note that if sslContext is null, this object will use the configured keystorePath
+     * and keystorePassword to build one itself. If sslContext is provided (not-null)
+     * then the configuration's keystorePath and keystorePassword are ignored.
+     *
+     * Note that if the configuration tells use to NOT use SSL in the first place,
+     * the given SSL context (if any) as well as the configured keystorePath and keystorePassword
+     * will all be ignored since we are being told to not use SSL.
+     *
+     * @param configuration configuration settings to determine things about the HTTP connections
+     *                      any built clients will be asked to make
+     * @param sslContext if not null, and if the configuration tells use to use SSL, this will
+     *                   be the SSL context to use.
+     */
+    public HttpClientBuilder(boolean useAuthorization, String username, String password, boolean useSSL,
+            SSLContext sslContext, X509TrustManager x509TrustManager, String keystorePath, String keystorePassword,
+            int connectTimeoutSeconds, int readTimeoutSeconds) {
+        super(new BaseHttpClientGenerator.Configuration.Builder()
+                .useAuthorization(useAuthorization)
+                .username(username)
+                .password(password)
+                .useSsl(useSSL)
+                .sslContext(sslContext)
+                .x509TrustManager(x509TrustManager)
+                .keystorePath(keystorePath)
+                .keystorePassword(keystorePassword)
+                .connectTimeout(connectTimeoutSeconds)
+                .readTimeout(readTimeoutSeconds)
+                .build());
+    }
+
+    public Request buildJsonGetRequest(String url, Map<String, String> headers) {
+        Builder requestBuilder = buildJsonBaseRequest(url, headers);
+
+        return requestBuilder.get().build();
+    }
+
+    public Request buildJsonDeleteRequest(String url, Map<String, String> headers) {
+        Builder requestBuilder = buildJsonBaseRequest(url, headers);
+
+        return requestBuilder.delete().build();
+    }
+
+    public Request buildJsonPostRequest(String url, Map<String, String> headers, String jsonPayload) {
+        Builder requestBuilder = buildJsonBaseRequest(url, headers);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"), jsonPayload);
+
+        return requestBuilder.post(body).build();
+    }
+
+    public Request buildJsonPutRequest(String url, Map<String, String> headers, String jsonPayload) {
+        Builder requestBuilder = buildJsonBaseRequest(url, headers);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json"), jsonPayload);
+
+        return requestBuilder.put(body).build();
+    }
+
+    private Builder buildJsonBaseRequest(String url, Map<String, String> headers) {
+        Builder requestBuilder = new Builder()
+                .url(url)
+                .addHeader("Accept", "application/json");
+
+        if (this.getConfiguration().isUseAuthorization()) {
+            // make sure we are authenticated. see http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side
+            String base64Credentials = buildBase64Credentials();
+            requestBuilder.addHeader("Authorization", "Basic " + base64Credentials);
+        }
+
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                requestBuilder.addHeader(header.getKey(), header.getValue());
+            }
+        }
+
+        return requestBuilder;
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/PrometheusAlerter.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/PrometheusAlerter.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.hawkular.alerts.alerters.api.Alerter;
+import org.hawkular.alerts.alerters.api.AlerterPlugin;
+import org.hawkular.alerts.api.model.condition.Condition;
+import org.hawkular.alerts.api.model.condition.ExternalCondition;
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.api.services.DistributedEvent;
+import org.hawkular.commons.properties.HawkularProperties;
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Manages the Prometheus evaluations and interacts with the Alerts system.  Sets up fixed rate thread
+ * jobs to back each ExternalCondition.</p>
+ * <pre>
+ * Defining a Trigger to be processed by the Prometheus External Alerter:
+ *   [Required]    trigger.tags["prometheus"] // the value is ignored
+ *   [Optional]    trigger.context["prometheus.frequency"] = "<seconds between queries to Prometheus, default = 120>"
+ *                 - note that the same frequency will apply to all Prometheus external conditions on the trigger
+ *
+ * Defining an ExternalCondition to be processed by the Prometheus External Alerter:
+ *   [Required]    the owning trigger must be defined as specified above.
+ *   [Required]    externalcondition.alerterId = "prometheus"
+ *   [Required]    externalcondition.expression = <BooleanExpression> | <ALERTSExpression>
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Alerter(name = "prometheus")
+public class PrometheusAlerter implements AlerterPlugin {
+    private final Logger log = Logger.getLogger(PrometheusAlerter.class);
+
+    private static final String PROMETHEUS_ALERTER = "hawkular-alerts.prometheus-alerter";
+    private static final String PROMETHEUS_ALERTER_ENV = "PROMETHEUS_ALERTER";
+    private static final String PROMETHEUS_ALERTER_DEFAULT = "false";  // do not turn on prom-alerter by default
+
+    private static final String PROMETHEUS_URL = "hawkular-alerts.prometheus-url";
+    private static final String PROMETHEUS_URL_ENV = "PROMETHEUS_URL";
+    private static final String PROMETHEUS_URL_DEFAULT = "http://localhost:9090";
+    private static final String URL = "url";
+
+    private static final String PROMETHEUS_THREAD_POOL_SIZE = "hawkular-alerts.prometheus-thread-pool-size";
+    private static final String PROMETHEUS_THREAD_POOL_SIZE_ENV = "PROMETHEUS_THREAD_POOL_SIZE";
+    private static final String PROMETHEUS_THREAD_POOL_SIZE_DEFAULT = "20";
+    private static final String THREAD_POOL_SIZE = "thread-pool-size";
+
+    private static final String FREQUENCY = "interval";
+    private static final String FREQUENCY_DEFAULT = "120";
+
+    private static final String ALERTER_ID = "prometheus";
+
+    private Map<TriggerKey, Trigger> activeTriggers = new ConcurrentHashMap<>();
+
+    ScheduledThreadPoolExecutor expressionExecutor;
+    Map<ExternalCondition, ScheduledFuture<?>> expressionFutures = new HashMap<>();
+
+    private boolean prometheusAlerter;
+    private Map<String, String> defaultProperties;
+    private DefinitionsService definitions;
+    private AlertsService alerts;
+
+    private ExecutorService executor;
+
+    public void init(DefinitionsService definitions, AlertsService alerts, ExecutorService executor) {
+        if (definitions == null || alerts == null || executor == null) {
+            throw new IllegalStateException("Prometheus Alerter cannot connect with Hawkular Alerting");
+        }
+        this.definitions = definitions;
+        this.alerts = alerts;
+        this.executor = executor;
+        prometheusAlerter = Boolean.parseBoolean(HawkularProperties.getProperty(PROMETHEUS_ALERTER,
+                PROMETHEUS_ALERTER_ENV, PROMETHEUS_ALERTER_DEFAULT));
+        defaultProperties = new HashMap<>();
+        defaultProperties.put(URL, HawkularProperties.getProperty(PROMETHEUS_URL, PROMETHEUS_URL_ENV,
+                PROMETHEUS_URL_DEFAULT));
+        defaultProperties.put(THREAD_POOL_SIZE,
+                HawkularProperties.getProperty(PROMETHEUS_THREAD_POOL_SIZE, PROMETHEUS_THREAD_POOL_SIZE_ENV,
+                        PROMETHEUS_THREAD_POOL_SIZE_DEFAULT));
+
+        if (prometheusAlerter) {
+            log.infof("Starting Hawkular Prometheus External Alerter");
+            definitions.registerDistributedListener(events -> refresh(events));
+        }
+    }
+
+    public void stop() {
+        log.infof("Stopping Hawkular Prometheus External Alerter");
+
+        if (null != expressionFutures) {
+            expressionFutures.values().forEach(f -> f.cancel(true));
+        }
+        if (null != expressionExecutor) {
+            expressionExecutor.shutdown();
+            expressionExecutor = null;
+        }
+    }
+
+    private void refresh(Set<DistributedEvent> distEvents) {
+        log.debugf("Events received %s", distEvents);
+        executor.submit(() -> {
+            try {
+                for (DistributedEvent distEvent : distEvents) {
+                    TriggerKey triggerKey = new TriggerKey(distEvent.getTenantId(), distEvent.getTriggerId());
+                    switch (distEvent.getOperation()) {
+                        case REMOVE:
+                            activeTriggers.remove(triggerKey);
+                            break;
+                        case ADD:
+                            if (activeTriggers.containsKey(triggerKey)) {
+                                break;
+                            }
+                        case UPDATE:
+                            Trigger trigger = definitions.getTrigger(distEvent.getTenantId(),
+                                    distEvent.getTriggerId());
+                            if (trigger != null && trigger.getTags().containsKey(ALERTER_ID)) {
+                                if (!trigger.isLoadable()) {
+                                    activeTriggers.remove(triggerKey);
+                                    break;
+                                } else {
+                                    activeTriggers.put(triggerKey, trigger);
+                                }
+                            }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch Triggers for external conditions.", e);
+            }
+
+            update();
+        });
+    }
+
+    private synchronized void update() {
+        log.debug("Refreshing External Prometheus Triggers!");
+        try {
+            if (expressionExecutor == null) {
+                expressionExecutor = new ScheduledThreadPoolExecutor(
+                        Integer.valueOf(defaultProperties.get(THREAD_POOL_SIZE)));
+            }
+
+            Set<ExternalCondition> activeConditions = new HashSet<>();
+            log.debugf("Found [%d] active External Prometheus Triggers!", activeTriggers.size());
+
+            // for each trigger look for Prometheus Conditions and start running them
+            Collection<Condition> conditions = null;
+            for (Trigger trigger : activeTriggers.values()) {
+                try {
+                    conditions = definitions.getTriggerConditions(trigger.getTenantId(), trigger.getId(), null);
+                    log.debugf("Checking [%s] Conditions for external Prometheus trigger [%s]", conditions.size(),
+                            trigger.getName());
+                } catch (Exception e) {
+                    log.error("Failed to fetch Conditions when scheduling prometheus conditions for " + trigger, e);
+                    continue;
+                }
+                for (Condition condition : conditions) {
+                    if (condition instanceof ExternalCondition) {
+                        ExternalCondition externalCondition = (ExternalCondition) condition;
+                        if (ALERTER_ID.equals(externalCondition.getAlerterId())) {
+                            log.debugf("Found Prometheus ExternalCondition %s", externalCondition);
+                            activeConditions.add(externalCondition);
+                            if (expressionFutures.containsKey(externalCondition)) {
+                                log.debugf("Skipping, already evaluating %s", externalCondition);
+
+                            } else {
+                                try {
+                                    // start the job. TODO: Do we need a delay for any reason?
+                                    log.debugf("Adding runner for %s", externalCondition);
+
+                                    ExpressionRunner runner = new ExpressionRunner(alerts, defaultProperties,
+                                            externalCondition);
+                                    String frequency = trigger.getContext().get(FREQUENCY) == null ? FREQUENCY_DEFAULT
+                                            : trigger.getContext().get(FREQUENCY);
+                                    expressionFutures.put(
+                                            externalCondition,
+                                            expressionExecutor.scheduleAtFixedRate(runner, 0L, Long.valueOf(frequency),
+                                                    TimeUnit.SECONDS));
+                                } catch (Exception e) {
+                                    log.error("Failed to schedule expression for Prometheus condition "
+                                            + externalCondition, e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // cancel obsolete expressions
+            Set<ExternalCondition> temp = new HashSet<>();
+            for (Map.Entry<ExternalCondition, ScheduledFuture<?>> me : expressionFutures.entrySet()) {
+                ExternalCondition ec = me.getKey();
+                if (!activeConditions.contains(ec)) {
+                    log.debugf("Canceling evaluation of obsolete External Prometheus Condition %s", ec);
+
+                    me.getValue().cancel(true);
+                    temp.add(ec);
+                }
+            }
+            expressionFutures.keySet().removeAll(temp);
+            temp.clear();
+
+        } catch (Exception e) {
+            log.error("Failed to fetch Triggers for scheduling Prometheus conditions.", e);
+        }
+    }
+
+    private static class ExpressionRunner implements Runnable {
+        private final Logger log = Logger.getLogger(PrometheusAlerter.ExpressionRunner.class);
+
+        private Map<String, String> properties;
+        private AlertsService alertsService;
+        private ExternalCondition externalCondition;
+
+        public ExpressionRunner(AlertsService alerts, Map<String, String> properties,
+                                ExternalCondition externalCondition) {
+            super();
+            this.alertsService = alerts;
+            this.externalCondition = externalCondition;
+            this.properties = properties;
+        }
+
+        @Override
+        public void run() {
+            try {
+                HttpClientBuilder restClient = new HttpClientBuilder(false, "ignored", "ignored", false, null, null,
+                        "ignored", "ignored", 15, 600);
+                StringBuffer url = new StringBuffer(properties.get(URL));
+                url.append("/api/v1/query?query=");
+                url.append(externalCondition.getExpression());
+                Request request = restClient.buildJsonGetRequest(url.toString(), null);
+                OkHttpClient httpClient = restClient.getHttpClient();
+                Response response = httpClient.newCall(request).execute();
+                if (response.code() >= 300) {
+                    log.warnf("Prometheus GET failed. Status=[%d], message=[%s], url=[%s]", response.code(),
+                            response.message(), url.toString());
+                } else {
+                    String bodyString = response.body().string();
+                    ObjectMapper mapper = new ObjectMapper();
+                    QueryResponse queryResponse = mapper.readValue(bodyString, QueryResponse.class);
+                    if (isValid(queryResponse, bodyString)) {
+                        evaluate(queryResponse.getData().getResult());
+                    }
+                    return;
+                }
+            } catch (Throwable t) {
+                if (log.isDebugEnabled()) {
+                    t.printStackTrace();
+                }
+                log.warnf("Failed data fetch for %s: %s", externalCondition.getExpression(), t.getMessage());
+            }
+        }
+
+        private boolean isValid(QueryResponse queryResponse, String bodyString) {
+            if (!"success".equals(queryResponse.getStatus())) {
+                log.warnf("Prometheus query did not return success, can not process external condition: [%s]",
+                        bodyString);
+                return false;
+            }
+            if (!"vector".equals(queryResponse.getData().getResultType())) {
+                log.warnf("resultType [%s] is not yet supported. Supported resultTyes are [vector]: [%s]",
+                        queryResponse.getData().getResultType(), bodyString);
+                return false;
+            }
+
+            return true;
+        }
+
+        private void evaluate(QueryResponse.Result[] result) throws Exception {
+            for (QueryResponse.Result r : result) {
+                // just send all of the time series labels as context for event
+                // TODO: Should these be tags or context?
+                Map<String, String> context = r.getMetric();
+
+                Event externalEvent = new Event(externalCondition.getTenantId(), UUID.randomUUID().toString(),
+                        System.currentTimeMillis(), externalCondition.getDataId(),
+                        ALERTER_ID, Arrays.toString(r.getValue()), context, null);
+                log.debugf("Sending External Condition Event to Alerting %s", externalEvent);
+                alertsService.sendEvents(Collections.singleton(externalEvent));
+            }
+        }
+    }
+
+    private class TriggerKey {
+        private String tenantId;
+        private String triggerId;
+
+        public TriggerKey(String tenantId, String triggerId) {
+            this.tenantId = tenantId;
+            this.triggerId = triggerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            TriggerKey that = (TriggerKey) o;
+
+            if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null)
+                return false;
+            return triggerId != null ? triggerId.equals(that.triggerId) : that.triggerId == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = tenantId != null ? tenantId.hashCode() : 0;
+            result = 31 * result + (triggerId != null ? triggerId.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/QueryResponse.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/QueryResponse.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author jshaughn
+ */
+public class QueryResponse {
+
+    @JsonInclude
+    String status;
+
+    @JsonInclude
+    Data data;
+
+    public QueryResponse() {
+        super();
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryResponse [status=" + status + ", data=" + data + "]";
+    }
+
+    public static class Data {
+        @JsonInclude
+        String resultType;
+
+        @JsonInclude
+        Result[] result;
+
+        public Data() {
+            super();
+        }
+
+        public String getResultType() {
+            return resultType;
+        }
+
+        public void setResultType(String resultType) {
+            this.resultType = resultType;
+        }
+
+        public Result[] getResult() {
+            return result;
+        }
+
+        public void setResult(Result[] result) {
+            this.result = result;
+        }
+
+        @Override
+        public String toString() {
+            return "Data [resultType=" + resultType + ", result=" + Arrays.toString(result) + "]";
+        }
+
+    }
+
+    public static class Result {
+        @JsonInclude
+        Map<String, String> metric;
+
+        @JsonInclude
+        Object[] value;
+
+        public Result() {
+            super();
+        }
+
+        public Map<String, String> getMetric() {
+            return metric;
+        }
+
+        public void setMetric(Map<String, String> metric) {
+            this.metric = metric;
+        }
+
+        public Object[] getValue() {
+            return value;
+        }
+
+        public void setValue(Object[] value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "MetricData [metric=" + metric + ", value=" + Arrays.toString(value) + "]";
+        }
+
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/Notification.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/Notification.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus.rest;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class Notification {
+
+    @JsonInclude
+    String receiver;
+
+    @JsonInclude
+    String status;
+
+    @JsonInclude
+    List<Alert> alerts;
+
+    @JsonInclude
+    Map<String, String> groupLabels;
+
+    @JsonInclude
+    Map<String, String> commonLabels;
+
+    @JsonInclude
+    Map<String, String> commonAnnotations;
+
+    @JsonInclude
+    String externalURL;
+
+    @JsonInclude
+    String version;
+
+    @JsonInclude
+    String groupKey;
+
+    public Notification() {
+    }
+
+    public String getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(String receiver) {
+        this.receiver = receiver;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public List<Alert> getAlerts() {
+        return alerts;
+    }
+
+    public void setAlerts(List<Alert> alerts) {
+        this.alerts = alerts;
+    }
+
+    public Map<String, String> getGroupLabels() {
+        return groupLabels;
+    }
+
+    public void setGroupLabels(Map<String, String> groupLabels) {
+        this.groupLabels = groupLabels;
+    }
+
+    public Map<String, String> getCommonLabels() {
+        return commonLabels;
+    }
+
+    public void setCommonLabels(Map<String, String> commonLabels) {
+        this.commonLabels = commonLabels;
+    }
+
+    public Map<String, String> getCommonAnnotations() {
+        return commonAnnotations;
+    }
+
+    public void setCommonAnnotations(Map<String, String> commonAnnotations) {
+        this.commonAnnotations = commonAnnotations;
+    }
+
+    public String getExternalURL() {
+        return externalURL;
+    }
+
+    public void setExternalURL(String externalURL) {
+        this.externalURL = externalURL;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getGroupKey() {
+        return groupKey;
+    }
+
+    public void setGroupKey(String groupKey) {
+        this.groupKey = groupKey;
+    }
+
+    @Override
+    public String toString() {
+        return "Notification [receiver=" + receiver + ", status=" + status + ", alerts=" + alerts + ", groupLabels="
+                + groupLabels + ", commonLabels=" + commonLabels + ", commonAnnotations=" + commonAnnotations
+                + ", externalURL=" + externalURL + ", version=" + version + ", groupKey=" + groupKey + "]";
+    }
+
+    public static class Alert {
+        @JsonInclude
+        String status;
+
+        @JsonInclude
+        Map<String, String> labels;
+
+        @JsonInclude
+        Map<String, String> annotations;
+
+        @JsonInclude
+        String startsAt;
+
+        @JsonInclude
+        String endsAt;
+
+        @JsonInclude
+        String generatorURL;
+
+        public Alert() {
+            super();
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Map<String, String> labels) {
+            this.labels = labels;
+        }
+
+        public Map<String, String> getAnnotations() {
+            return annotations;
+        }
+
+        public void setAnnotations(Map<String, String> annotations) {
+            this.annotations = annotations;
+        }
+
+        public String getStartsAt() {
+            return startsAt;
+        }
+
+        public void setStartsAt(String startsAt) {
+            this.startsAt = startsAt;
+        }
+
+        public String getEndsAt() {
+            return endsAt;
+        }
+
+        public void setEndsAt(String endsAt) {
+            this.endsAt = endsAt;
+        }
+
+        public String getGeneratorURL() {
+            return generatorURL;
+        }
+
+        public void setGeneratorURL(String generatorURL) {
+            this.generatorURL = generatorURL;
+        }
+
+        @Override
+        public String toString() {
+            return "Alert [status=" + status + ", labels=" + labels + ", annotations=" + annotations + ", startsAt="
+                    + startsAt + ", endsAt=" + endsAt + ", generatorURL=" + generatorURL + "]";
+        }
+
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/PrometheusApp.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/PrometheusApp.java
@@ -1,0 +1,33 @@
+package org.hawkular.alerter.prometheus.rest;
+
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+import org.hawkular.commons.properties.HawkularProperties;
+import org.hawkular.handlers.BaseApplication;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class PrometheusApp implements BaseApplication {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(PrometheusApp.class);
+    private static final String BASE_URL = "hawkular-alerts.base-url-alerter";
+    private static final String BASE_URL_DEFAULT = "/hawkular/alerter";
+
+    String baseUrl = HawkularProperties.getProperty(BASE_URL, BASE_URL_DEFAULT) + "/prometheus";
+
+    @Override
+    public void start() {
+        log.infof("Prometheus app started on [ %s ] ", baseUrl());
+    }
+
+    @Override
+    public void stop() {
+        log.infof("Prometheus app stopped", baseUrl());
+    }
+
+    @Override
+    public String baseUrl() {
+        return baseUrl;
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/PrometheusHandler.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/main/java/org/hawkular/alerter/prometheus/rest/PrometheusHandler.java
@@ -1,0 +1,91 @@
+package org.hawkular.alerter.prometheus.rest;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.hawkular.alerts.api.json.JsonUtil.fromJson;
+import static org.hawkular.alerts.api.json.JsonUtil.toJson;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.engine.StandaloneAlerts;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+import org.hawkular.handlers.RestEndpoint;
+import org.hawkular.handlers.RestHandler;
+
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@RestEndpoint(path = "/")
+public class PrometheusHandler implements RestHandler {
+    public final static String ACCEPT = "Accept";
+    public final static String CONTENT_TYPE = "Content-Type";
+    public final static String APPLICATION_JSON = "application/json";
+    private static final MsgLogger log = MsgLogging.getMsgLogger(PrometheusHandler.class);
+
+    AlertsService alerts;
+
+    public PrometheusHandler() {
+        alerts = StandaloneAlerts.getAlertsService();
+    }
+
+    @Override
+    public void initRoutes(String baseUrl, Router router) {
+        router.get(baseUrl + "/status").handler(this::status);
+        router.post(baseUrl + "/notification").handler(this::notification);
+    }
+
+    void status(RoutingContext routing) {
+        routing.vertx()
+                .executeBlocking(future -> future.complete("Status"),
+                        res -> response(routing, OK.code(), res.result()));
+    }
+
+    void notification(RoutingContext routing) {
+        routing.vertx()
+                .executeBlocking(future -> {
+                    String json = routing.getBodyAsString();
+                    Notification notification = fromJson(json, Notification.class);
+                    String tenantId = notification.getGroupLabels().getOrDefault("tenant", "prometheus");
+                    String dataId = notification.getGroupLabels().get("dataId");
+                    String category = "prometheus";
+                    String text = notification.getCommonAnnotations().get("description");
+                    text = null != text ? text : notification.getCommonAnnotations().get("summary");
+                    text = null != text ? text : notification.getGroupLabels().getOrDefault("alertname", "notification");
+                    Map<String, String> context = new HashMap<>();
+                    context.put("alertname", notification.getGroupLabels().getOrDefault("alertname", "unknown"));
+                    context.put("json", json);
+                    Event event = new Event(tenantId, UUID.randomUUID().toString(), dataId, category, text, context);
+                    log.debugf("Adding Prometheus Notification Event %s", event);
+                    try {
+                        alerts.addEvents(Collections.singleton(event));
+                        future.complete("Success");
+                    } catch (Exception e) {
+                        future.fail(e);
+                    }
+                }, res -> {
+                    if (res.succeeded()) {
+                        response(routing, OK.code(), res.result());
+                    } else {
+                        response(routing, BAD_REQUEST.code(), res.cause().getMessage());
+                    }
+                });
+    }
+
+    public static void response(RoutingContext routing, int code, Object o) {
+        routing.response()
+                .putHeader(ACCEPT, APPLICATION_JSON)
+                .putHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .setStatusCode(code)
+                .end(toJson(o));
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/groovy/org/hawkular/alerter/prometheus/PrometheusITest.groovy
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/groovy/org/hawkular/alerter/prometheus/PrometheusITest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+import java.text.SimpleDateFormat
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+class prometheusITest {
+
+    def prometheus, hawkular, format, response
+
+    prometheusITest() {
+        hawkular = new RESTClient(System.getProperty('hawkular.base-uri') ?: 'http://127.0.0.1:8080/hawkular/alerts/', ContentType.JSON)
+        hawkular.handler.failure = { it }
+        /*
+            Basic header is used only for hawkular-services distribution.
+            This header is ignored on standalone scenarios.
+
+            User: jdoe
+            Password: password
+            String encodedCredentials = Base64.getMimeEncoder()
+                .encodeToString("$testUser:$testPasword".getBytes("utf-8"))
+        */
+        hawkular.defaultRequestHeaders.Authorization = "Basic amRvZTpwYXNzd29yZA=="
+        hawkular.headers.put("Hawkular-Tenant", "test")
+    }
+
+    /*
+        These tests are ignored as they need an external prometheus instance.
+        Used for manual testing
+     */
+
+    @Ignore
+    @Test
+    void prometheusAlerterQueryTest() {
+        def start = String.valueOf(System.currentTimeMillis())
+        // load external trigger
+        def definitions = new File("src/test/resources/prometheus-query-trigger.json").text
+        response = hawkular.post(path: "import/all", body: definitions)
+        assertTrue(response.status < 300)
+
+        for ( int i=0; i < 60; ++i ) {
+            Thread.sleep(1000);
+
+            response = hawkular.get(path: "", query: [startTime:start,triggerIds:"prom-trigger"] )
+            /*
+                We should have only 1 alert
+             */
+            if ( response.status == 200 && response.data.size() == 1 ) {
+                break;
+            }
+            assertEquals(200, response.status)
+            System.out.println("NOTE!!!! May need to manually perform a get request on Prometheus to ge this to pass...")
+        }
+        assertEquals(200, response.status)
+        assertEquals(1, response.data.size())
+
+        response = hawkular.delete(path: "triggers/prom-trigger")
+        assertEquals(200, response.status)
+    }
+
+    @Ignore
+    @Test
+    void prometheusAlerterAlertTest() {
+        def start = String.valueOf(System.currentTimeMillis())
+        // load external trigger
+        def definitions = new File("src/test/resources/prometheus-alert-trigger.json").text
+        response = hawkular.post(path: "import/all", body: definitions)
+        assertTrue(response.status < 300)
+
+        // now manually make a get request on prometheus to get this to work...
+        for ( int i=0; i < 60; ++i ) {
+            Thread.sleep(1000);
+
+            response = hawkular.get(path: "", query: [startTime:start,triggerIds:"prom-alert-trigger"] )
+            /*
+                We should have only 1 alert
+             */
+            if ( response.status == 200 && response.data.size() == 1 ) {
+                break;
+            }
+            assertEquals(200, response.status)
+            System.out.println("NOTE!!!! Did you remember to configure prometheus to read the test rules file?")
+        }
+        assertEquals(200, response.status)
+        assertEquals(1, response.data.size())
+
+        response = hawkular.delete(path: "triggers/prom-alert-trigger")
+        assertEquals(200, response.status)
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/java/org/hawkular/alerter/prometheus/PrometheusQueryTest.java
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/java/org/hawkular/alerter/prometheus/PrometheusQueryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerter.prometheus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class PrometheusQueryTest {
+
+
+    @Ignore // Requires manually running Prom on localhost:9090
+    @Test
+    @SuppressWarnings("unchecked")
+    public void queryTest() throws Exception {
+
+        HttpClientBuilder restClient = new HttpClientBuilder(false, "ignored", "ignored", false, null, null,
+                "ignored", "ignored", 15, 600);
+        StringBuffer url = new StringBuffer("http://localhost:9090");
+        url.append("/api/v1/query?query=");
+        url.append("up");
+        Request request = restClient.buildJsonGetRequest(url.toString(), null);
+        OkHttpClient httpClient = restClient.getHttpClient();
+        Response response = httpClient.newCall(request).execute();
+        if (response.code() != 200) {
+            String msg = String.format("Prometheus GET failed. Status=[%d], message=[%s], url=[%s]", response.code(),
+                    response.message(), url.toString());
+            System.out.println(msg);
+            fail();
+        } else {
+            String bodyString = response.body().string();
+
+            ObjectMapper mapper = new ObjectMapper();
+            QueryResponse queryResponse = null;
+            try {
+                queryResponse = mapper.readValue(bodyString, QueryResponse.class);
+                assertEquals("success", queryResponse.getStatus());
+                QueryResponse.Data data = queryResponse.getData();
+                assertEquals("vector", data.getResultType());
+                QueryResponse.Result[] result = data.getResult();
+                assertEquals(1, result.length);
+                QueryResponse.Result r = result[0];
+                assertEquals("up", r.getMetric().get("__name__"));
+                assertEquals("prometheus", r.getMetric().get("job"));
+                assertEquals(2, r.getValue().length);
+                long tsMillis = Double.valueOf((double) r.getValue()[0] * 1000).longValue();
+                assertEquals(String.valueOf(r.getValue()[0]), String.valueOf(System.currentTimeMillis()).length(),
+                        String.valueOf(tsMillis).length());
+                assertEquals("1", r.getValue()[1]);
+
+            } catch (IOException e) {
+                String msg = String.format("Failed to Map prom response [%s]: %s", bodyString, e);
+                System.out.println(msg);
+                fail();
+            }
+        }
+    }
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/resources/log4j2.xml
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-alert-trigger.json
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-alert-trigger.json
@@ -1,0 +1,28 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "prom-alert-trigger",
+        "name": "Prometheus Alert Trigger",
+        "description": "Alert on any firing prometheus alert, check every 5 seconds. AutoDisable after 1 alert.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoDisable": true,
+        "tags": {
+          "prometheus": "Test"
+        },
+        "context": {
+          "prometheus.frequency": "5"
+        }
+      },
+      "conditions":[
+        {
+          "type": "EXTERNAL",
+          "alerterId": "prometheus",
+          "dataId": "prometheus-alert-test",
+          "expression": "ALERTS{job=\"prometheus\",alertname=\"InstanceUp\",alertstate=\"firing\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-alerts.rules
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-alerts.rules
@@ -1,0 +1,8 @@
+# The prometheus config.yml should be edited to point at this rules file for the manual itest to work
+ALERT InstanceUp
+  IF up == 1
+  ANNOTATIONS {
+    summary = "Instance {{ $labels.instance }} down",
+    description = "{{ $labels.instance }} of job {{ $labels.job }} is up!",
+  }
+

--- a/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-query-trigger.json
+++ b/alerters/alerters-plugins/alerters-prometheus/src/test/resources/prometheus-query-trigger.json
@@ -1,0 +1,28 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "prom-trigger",
+        "name": "Prometheus Trigger",
+        "description": "Alert on any prometheus http request with activity in the last 5 minutes, check every 5 seconds. AutoDisable after 1 alert.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoDisable": true,
+        "tags": {
+          "prometheus": "Test"
+        },
+        "context": {
+          "prometheus.frequency": "5"
+        }
+      },
+      "conditions":[
+        {
+          "type": "EXTERNAL",
+          "alerterId": "prometheus",
+          "dataId": "prometheus-test",
+          "expression": "rate(http_requests_total{handler=\"query\",job=\"prometheus\"}[5m])>0"
+        }
+      ]
+    }
+  ]
+}

--- a/alerters/alerters-plugins/pom.xml
+++ b/alerters/alerters-plugins/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>hawkular-alerts-alerters</artifactId>
+    <groupId>org.hawkular.alerts</groupId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-plugins</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Hawkular Alerting: Alerter Plugins</name>
+  <description>Parent module of all Alerter Plugins</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${version.org.apache.logging.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${version.org.apache.logging.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>alerters-elasticsearch</module>
+        <module>alerters-prometheus</module>
+      </modules>
+    </profile>
+  </profiles>
+</project>

--- a/alerters/pom.xml
+++ b/alerters/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Hawkular Alerting: Alerters parent</name>
+  <description>Parent module of all Alerters Artifacts</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <version>${version.junit}</version>
+    </dependency>
+
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>alerters-api</module>
+        <module>alerters-impl</module>
+        <module>alerters-plugins</module>
+      </modules>
+    </profile>
+  </profiles>
+
+</project>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -65,6 +65,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-elasticsearch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-prometheus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${version.org.apache.logging.log4j}</version>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -66,6 +66,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-elasticsearch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-prometheus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${version.org.apache.logging.log4j}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <version.com.fasterxml.jackson.core-elasticsearch>2.8.3</version.com.fasterxml.jackson.core-elasticsearch>
     <version.com.google.guava>19.0</version.com.google.guava>
     <version.com.icegreen>1.4.1</version.com.icegreen>
+    <version.com.squareup.okhttp3>3.4.2</version.com.squareup.okhttp3>
     <version.javaee.spec>7.0</version.javaee.spec>
     <version.javax.mail>1.4.7</version.javax.mail>
     <version.junit>4.12</version.junit>
@@ -101,7 +102,7 @@
     <version.org.drools>6.4.0.Final</version.org.drools>
     <version.org.elasticsearch.client>5.2.2</version.org.elasticsearch.client>
     <version.org.freemarker>2.3.23</version.org.freemarker>
-    <version.org.hawkular.commons>0.9.7.Final-SRC-revision-b76074c26ebad20064f2a0b8185c5f6b1a11b415</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.9.7.Final-SRC-revision-9b56e20d01327b330ad0ba893ee056a8a54f8766</version.org.hawkular.commons>
     <version.org.hibernate>5.7.0.Final</version.org.hibernate>
     <version.org.infinispan.wildfly>9.0.0.Final</version.org.infinispan.wildfly>
     <version.org.jboss.logging>3.3.1.Final</version.org.jboss.logging>
@@ -123,6 +124,7 @@
       </activation>
       <modules>
         <module>actions</module>
+        <module>alerters</module>
         <module>api</module>
         <module>commons</module>
         <module>engine</module>

--- a/rest-handlers/pom.xml
+++ b/rest-handlers/pom.xml
@@ -34,6 +34,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <version>${version.io.vertx}</version>

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/AlertingApp.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/AlertingApp.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.hawkular.alerts.actions.standalone.StandaloneActionPluginRegister;
+import org.hawkular.alerts.alerters.standalone.StandaloneAlerterPluginRegister;
 import org.hawkular.alerts.engine.StandaloneAlerts;
 import org.hawkular.alerts.handlers.util.AlertingThreadFactory;
 import org.hawkular.commons.log.MsgLogger;
@@ -32,6 +33,8 @@ public class AlertingApp implements BaseApplication {
         StandaloneAlerts.start();
         StandaloneActionPluginRegister.setExecutor(executor);
         StandaloneActionPluginRegister.start();
+        StandaloneAlerterPluginRegister.setExecutor(executor);
+        StandaloneAlerterPluginRegister.start();
         log.infof("Alerting app started on [ %s ] ", baseUrl());
     }
 


### PR DESCRIPTION
Consolidate Alerters around an API to make them easy to add.
Reusing same scheme for actions architecture which simplify the plugability.
Also porting elasticsearch and prometheus alerters into .next.