### PR TITLE
HWKALERTS-270 TagQuery does not support empty spaces on regexp values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: false
+sudo: required
+dist: trusty
+
 language: java
 jdk:
 - oraclejdk8

--- a/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParser.java
+++ b/hawkular-alerts-engine/src/main/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParser.java
@@ -65,6 +65,10 @@ public class ExpressionTagQueryParser extends TagQueryBaseListener implements AN
         String EQ = "=";
         String NEQ = "!=";
         String IN = "in";
+        char SPACE = ' ';
+        char QUOTE = '\'';
+        char LEFT_BRACKET =  '[';
+        char RIGHT_BRACKET = ']';
 
         static List<String> getTokens(String tagExpression) {
             if (tagExpression == null || tagExpression.isEmpty()) {
@@ -72,22 +76,38 @@ public class ExpressionTagQueryParser extends TagQueryBaseListener implements AN
             }
             List<String> tokens = new ArrayList<>();
             StringBuilder token = new StringBuilder();
-            for (int i=0; i<tagExpression.length(); i++) {
-                char ch = tagExpression.charAt(i);
-                if (ch != ' ') {
+
+            int marker = 0;
+            boolean separatorChanged = false;
+            while (marker < tagExpression.length() && !separatorChanged) {
+                char ch = tagExpression.charAt(marker);
+                if (!separatorChanged && ch == QUOTE) {
+                    separatorChanged = true;
+                }
+                if (!separatorChanged && ch == LEFT_BRACKET) {
+                    separatorChanged = true;
+                }
+
+                if (ch != SPACE) {
                     token.append(ch);
                 }
+
                 if (token.toString().equals(NOT)) {
                     tokens.add(token.toString());
                     token = new StringBuilder();
-                } else if (ch == ' ') {
+                } else if (ch == SPACE) {
                     if (token.length() > 0) {
                         tokens.add(token.toString());
                     }
                     token = new StringBuilder();
                 }
+                marker++;
             }
-            tokens.add(token.toString());
+            if (separatorChanged) {
+                tokens.add(tagExpression.substring(marker - 1));
+            } else if (token.toString().length() > 0) {
+                tokens.add(token.toString());
+            }
             return tokens;
         }
 

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
@@ -2990,7 +2990,7 @@ public abstract class PersistenceTest {
         log.infof("Time for perf030GetAlerts = %s ms", time);
         assertTrue(time > 0);
         // This test averages around 4000ms on my box, so hopefully this is a reasonable fail time
-        assertTrue(time < 6000);
+        assertTrue(time < 10000);
     }
 
     private long perfGetEvents(int numEvents, int numGets, EventsCriteria criteria, int expected) throws Exception {

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
@@ -2140,7 +2140,7 @@ public abstract class PersistenceTest {
     }
 
     @Test
-    public void test131AlertTagQuery() throws Exception {
+    public void test0131AlertTagQuery() throws Exception {
         Trigger t = new Trigger("t131", "trigger 131");
 
         List<Alert> alerts = new ArrayList<>();
@@ -2587,7 +2587,7 @@ public abstract class PersistenceTest {
     }
 
     @Test
-    public void test141EventTagQuery() throws Exception {
+    public void test0141EventTagQuery() throws Exception {
         Trigger t = new Trigger("t141", "trigger 141");
 
         List<Event> events = new ArrayList<>();
@@ -2904,6 +2904,48 @@ public abstract class PersistenceTest {
         }
     }
 
+    @Test
+    public void test0142EventTagQuerySpecialChars() throws Exception {
+
+        EventsCriteria criteria = new EventsCriteria();
+
+        alertsService.deleteEvents("test0142", criteria);
+
+        Event e1 = new Event();
+        e1.setTenantId("test0142");
+        e1.setId("test_1");
+        e1.setCtime(1499452337498L);
+        e1.setCategory("test");
+        e1.setText("Avail-changed:[UP] WildFly Server");
+        e1.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~~");
+        e1.getContext().put("message", "Avail-changed:[UP] WildFly Server");
+        e1.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~~_Server Availability");
+
+        Event e2 = new Event();
+        e2.setTenantId("test0142");
+        e2.setId("test_2");
+        e2.setCtime(1499445265683L);
+        e2.setCategory("test");
+        e2.setText("Avail-changed:[DOWN] Deployment");
+        e2.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear");
+        e2.getContext().put("message", "Avail-changed:[DOWN] Deployment");
+        e2.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear_Deployment Status");
+
+        alertsService.persistEvents(Arrays.asList(e1, e2));
+
+        List<Event> events = alertsService.getEvents("test0142", criteria, null);
+
+        assertEquals(2, events.size());
+
+        String tagQuery = "test_tag = '/t;hawkular/f;my-agent/r;Local%20DMR~~_Server Availability'";
+
+        criteria.setCategory("test");
+        criteria.setTagQuery(tagQuery);
+
+        events = alertsService.getEvents("test0142", criteria, null);
+
+        assertEquals(1, events.size());
+    }
 
     // These tests would be nice in a separate class but I couldn't figure how to get multiple test classes
     // running together without hitting Cassandra life-cycle issues.

--- a/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParserTest.java
+++ b/hawkular-alerts-engine/src/test/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParserTest.java
@@ -167,4 +167,15 @@ public class ExpressionTagQueryParserTest {
         assertEquals("tagA.subA.subsubA = 'abc.abc.abc'", parser.parse(e3));
         assertEquals("[tagA.subA.subsubA, =, 'abc.abc.abc']", getTokens(parser.parse(e3)).toString());
     }
+
+    @Test
+    public void t08_checkSpacesInTagValues() throws Exception {
+        String e1 = "tagA = 'a b'";
+
+        assertEquals("[tagA, =, 'a b']", getTokens(parser.parse(e1)).toString());
+
+        String e2 = "tagA IN ['a b', 'c d'] ";
+
+        assertEquals("[tagA, in, ['a b','c d']]", getTokens(parser.parse(e2)).toString());
+    }
 }

--- a/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
+++ b/hawkular-alerts-rest-tests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
@@ -170,4 +170,41 @@ class EventsITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(0, resp.data.size())
     }
+
+    @Test
+    void testQueryEventsWithSpacesInValues() {
+        Event e1 = new Event();
+        e1.setId("test_1");
+        e1.setCtime(1499452337498L);
+        e1.setCategory("test");
+        e1.setText("Avail-changed:[UP] WildFly Server");
+        e1.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~~");
+        e1.getContext().put("message", "Avail-changed:[UP] WildFly Server");
+        e1.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~~_Server Availability");
+
+        def resp = client.post(path: "events", body: e1)
+        assertEquals(200, resp.status)
+        def event = resp.data
+        assertEquals("test_1", event.id)
+
+        Event e2 = new Event();
+        e2.setId("test_2");
+        e2.setCtime(1499445265683L);
+        e2.setCategory("test");
+        e2.setText("Avail-changed:[DOWN] Deployment");
+        e2.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear");
+        e2.getContext().put("message", "Avail-changed:[DOWN] Deployment");
+        e2.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear_Deployment Status");
+
+        resp = client.post(path: "events", body: e2)
+        assertEquals(200, resp.status)
+        event = resp.data
+        assertEquals("test_2", event.id)
+
+        def tagQuery = "test_tag = '/t;hawkular/f;my-agent/r;Local%20DMR~~_Server Availability'"
+
+        resp = client.get(path: "events", query: [tagQuery: tagQuery] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
 }


### PR DESCRIPTION
This is a fix to support spaces inside tagQuery regexp.
It was spotted by @josejulio for 1.6.x version.
It is first fixed in master but I can port this into the 1.6.x branch and prepare a release there if necessary.
There is a workaround (not using spaces), to I let @josejulio decide which approach works better for his needs.
