### PR TITLE
Add default values for match/mode when Trigger is loaded from Ispn

### DIFF
--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -283,8 +283,8 @@ public class Trigger implements Serializable {
         this.source = trigger.getSource();
         this.severity = trigger.getSeverity();
 
-        this.match = trigger.getMatch();
-        this.mode = trigger.getMode();
+        this.mode = trigger.getMode() != null ? trigger.getMode() : Mode.FIRING;
+        this.match = trigger.getMode() == Mode.FIRING ?  trigger.getFiringMatch() : trigger.getAutoResolveMatch();
     }
 
     public Trigger(String tenantId, String id, String name, Map<String, String> context, Map<String, String> tags) {


### PR DESCRIPTION
This fixes a bad bug on the engine.
When server is shutdown and restarted, transient fields are not serialized (which is intended), but in the Trigger(Trigger) constructor some missing default values where carried over the engine, throwing a non expected NPE.