### PR TITLE
Add an Prometheus Alerter example

### DIFF
--- a/examples/elasticsearch/README.adoc
+++ b/examples/elasticsearch/README.adoc
@@ -64,7 +64,6 @@ Start the standalone server
     ./hawkular.sh
 ----
 
-
 [TIP]
 .Test Email server
 ==================

--- a/examples/prometheus/README.adoc
+++ b/examples/prometheus/README.adoc
@@ -1,0 +1,106 @@
+= Prometheus Integration
+
+Hawkular Alerting can integrate with Prometheus in two ways:
+
+- It can define an ExternalCondition that directly queries a Prometheus server.
+- It can be notified by Prometheus creating an Event in Hawkular Alerting.
+
+This mechanism allows to create Triggers in Hawkular Alerting with conditions defined from multiple sources.
+
+====
+The scripts used for this example are written in *bash* and tested on Linux platforms. +
+Those are pretty simple and can be translated a different environment easily.
+====
+
+== Install Prometheus and Hawkular Alerting
+
+=== 1) Install Prometheus
+
+Install Prometheus
+
+[source,shell]
+----
+  PS_HOME= # Directory to install Prometheus products
+  EXAMPLE_HOME= # Directory where this example is hosted
+  cd $PS_HOME
+  wget https://github.com/prometheus/prometheus/releases/download/v1.7.1/prometheus-1.7.1.linux-amd64.tar.gz
+  tar zxfv prometheus-1.7.1.linux-amd64.tar.gz
+  cd prometheus-1.7.1.linux-amd64
+
+  # Copy the rules for notification example
+  cp $EXAMPLE_HOME/prometheus-alerts.rules
+
+  # Edit prometheus.yml and add the prometheus-alerts.rules
+  #
+  # rule_files:
+  #   - "prometheus-alerts.rules"
+  #
+
+  ./prometheus
+----
+
+Install Prometheus AlertManager
+
+[source,shell]
+----
+  PS_HOME= # Directory to install Prometheus products
+  EXAMPLE_HOME= # Directory where this example is hosted
+  cd $PS_HOME
+  wget https://github.com/prometheus/alertmanager/releases/download/v0.7.1/alertmanager-0.7.1.linux-amd64.tar.gz
+  tar zxfv alertmanager-0.7.1.linux-amd64.tar.gz
+  cd alertmanager-0.7.1.linux-amd64.tar.gz
+
+  # Copy the notifier configuration to Hawkular Alerting
+  cp $EXAMPLE_HOME/alertmanager.yml .
+
+  ./alertmanager
+----
+
+=== 2) Install Hawkular Alerting
+
+Build a Hawkular Alerting standalone distribution
+
+[source,shell,subs="+attributes"]
+----
+    cd hawkular-alerts
+    mvn clean install -DskipTests
+----
+
+Start the standalone server
+
+[source,shell,subs="+attributes"]
+----
+    cd dist/target/hawkular-alerting*
+    ./hawkular.sh
+----
+
+[TIP]
+.Test Email server
+==================
+By default, Hawkular Alerting will send email notifications using a SMTP server on localhost:25, for demo purposes
+ a test smtp server can be used to validate the reception of the emails. +
+  +
+Hawkular Alerting has been tested using
+  https://nilhcem.github.io/FakeSMTP/[FakeSMTP]. +
+  +
+A GUI SMTP server can be set up with these steps:
+[source,shell,subs="+attributes"]
+----
+    git clone https://github.com/Nilhcem/FakeSMTP
+    cd FakeSMTP
+    mvn clean install -DskipTests
+    cd target
+    sudo java -jar fakeSMTP-*.jar
+----
+==================
+
+=== 3) Run the example: Create Trigger definitions
+
+Create Prometheus definitions
+
+[source,shell,subs="+attributes"]
+----
+    ./create-definitions.sh
+----
+
+Check out the Alerts generated on the link:http://localhost:8080/hawkular/alerts/ui[Hawkular Alerting UI].

--- a/examples/prometheus/alertmanager.yml
+++ b/examples/prometheus/alertmanager.yml
@@ -1,0 +1,14 @@
+global:
+
+route:
+  receiver: "hawkular-alerts"
+  group_by: ['alertname', 'tenant']
+  group_wait:      10s
+  group_interval:  1m
+  repeat_interval: 2m
+
+receivers:
+- name: "hawkular-alerts"
+  webhook_configs:
+  - url: 'http://localhost:8080/hawkular/alerter/prometheus/notification'
+    send_resolved: false

--- a/examples/prometheus/create-definitions.sh
+++ b/examples/prometheus/create-definitions.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+main() {
+    local url=$1
+    local tenant=$2
+    if [ "x$url" == "x" ]; then
+        url="http://localhost:8080"
+    fi
+    if [ "x$tenant" == "x" ]; then
+        tenant="my-organization"
+    fi
+    local response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -H "Hawkular-Tenant: $tenant" -XPOST "$url/hawkular/alerts/import/all" --data "@prometheus-triggers.json")
+    if [ "$response" -gt "300" ]; then
+        echo "Error importing definitions into hawkular"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/examples/prometheus/prometheus-alerts.rules
+++ b/examples/prometheus/prometheus-alerts.rules
@@ -1,0 +1,8 @@
+# The prometheus config.yml should be edited to point at this rules file for the manual itest to work
+ALERT InstanceUp
+  IF up == 1
+  ANNOTATIONS {
+    summary = "Instance {{ $labels.instance }} down",
+    description = "{{ $labels.instance }} of job {{ $labels.job }} is up!",
+  }
+

--- a/examples/prometheus/prometheus-triggers.json
+++ b/examples/prometheus/prometheus-triggers.json
@@ -1,0 +1,67 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "prom-trigger",
+        "name": "Prometheus Trigger",
+        "description": "Alert on any prometheus http request with activity in the last 5 minutes, check every 5 seconds. AutoDisable after 1 alert.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoDisable": true,
+        "tags": {
+          "prometheus": "Test"
+        }
+      },
+      "conditions":[
+        {
+          "type": "EXTERNAL",
+          "alerterId": "prometheus",
+          "dataId": "prometheus-test",
+          "expression": "rate(http_requests_total{handler=\"query\",job=\"prometheus\"}[5m])>0"
+        }
+      ],
+      "actions":[
+        {
+          "actionPlugin": "email",
+          "actionId": "email-to-admins"
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "prom-alert-trigger",
+        "name": "Prometheus Alert Trigger",
+        "description": "Alert on any firing prometheus alert, check every 5 seconds. AutoDisable after 1 alert.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoDisable": true,
+        "tags": {
+          "prometheus": "Test"
+        }
+      },
+      "conditions":[
+        {
+          "type": "EXTERNAL",
+          "alerterId": "prometheus",
+          "dataId": "prometheus-alert-test",
+          "expression": "ALERTS{job=\"prometheus\",alertname=\"InstanceUp\",alertstate=\"firing\"}"
+        }
+      ],
+      "actions":[
+        {
+          "actionPlugin": "email",
+          "actionId": "email-to-admins"
+        }
+      ]
+    }
+  ],
+  "actions":[
+    {
+      "actionPlugin": "email",
+      "actionId": "email-to-admins",
+      "properties": {
+        "to": "admins@hawkular.org"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add an example for the Prometheus Alerter.
It would be nice to have also a section in the docs like the Elasticsearch one.
An example of integration between P8S and ES would be great.
