### PR TITLE
Unify helper isEmpty() in a single location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 # unshallow is needed by license-maven-plugin
 - git fetch origin --unshallow
 script:
-- ./mvnw -s .travis.maven.settings.xml verify -Pitest-ispn
+- ./mvnw -s .travis.maven.settings.xml verify -Pitest
 env:
   global:
   - secure: TQJ1pIBM6dGgCQj59OiYxmKI2Nk+0XIT9His/iBt4FGRXHQ4BqWZuMVbtiX0ngGJbyg6Ntq9mJwmioGNl3tyK3jY9eqD/pWg8XjA9YAn+UINSBS3ooPYgAwIjTuJp6o7x9xExLEKCdzyttFjQ0BG+AkNvIEVyjSTZq7ky/ngbP4=

--- a/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/StandaloneActionPluginRegister.java
+++ b/actions/actions-impl/src/main/java/org/hawkular/alerts/actions/standalone/StandaloneActionPluginRegister.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.standalone;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -69,7 +71,7 @@ public class StandaloneActionPluginRegister {
                 Set<String> properties = actionPluginListener.getProperties();
                 Map<String, String> defaultProperties = actionPluginListener.getDefaultProperties();
                 try {
-                    if (defaultProperties != null && !defaultProperties.isEmpty() ) {
+                    if (!isEmpty(defaultProperties)) {
                         definitions.addActionPlugin(actionPlugin, defaultProperties);
                     } else {
                         definitions.addActionPlugin(actionPlugin, properties);

--- a/actions/actions-plugins/actions-elasticsearch/src/main/java/org/hawkular/alerts/actions/elasticsearch/ElasticsearchPlugin.java
+++ b/actions/actions-plugins/actions-elasticsearch/src/main/java/org/hawkular/alerts/actions/elasticsearch/ElasticsearchPlugin.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.elasticsearch;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -365,9 +367,5 @@ public class ElasticsearchPlugin implements ActionPluginListener {
         } catch (Exception e) {
             log.error("Error sending ActionResponseMessage", e);
         }
-    }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
     }
 }

--- a/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
+++ b/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailPlugin.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -311,7 +313,7 @@ public class EmailPlugin implements ActionPluginListener {
         Message email = new EmailMimeMessage(mailSession);
 
         Map<String, String> props = msg.getAction().getProperties();
-        if (null == props || props.isEmpty()) {
+        if (isEmpty(props)) {
             log.warnf("Properties empty on plugin %s.", PLUGIN_NAME);
         }
         Event event = msg.getAction() != null ? msg.getAction().getEvent() : null;
@@ -349,14 +351,14 @@ public class EmailPlugin implements ActionPluginListener {
 
         String to = props.get(PROP_TO + "." + statusStr);
         to = to == null ? props.get(PROP_TO) : to;
-        if (to != null && !to.isEmpty()) {
+        if (!isEmpty(to)) {
             Address toAddress = new InternetAddress(to);
             email.addRecipient(Message.RecipientType.TO, toAddress);
         }
 
         String ccs = props.get(PROP_CC + "." + statusStr);
         ccs = ccs == null ? props.get(PROP_CC) : ccs;
-        if (ccs != null && !ccs.isEmpty()) {
+        if (!isEmpty(ccs)) {
             String[] multipleCc = ccs.split(",");
             for (String cc : multipleCc) {
                 Address toAddress = new InternetAddress(cc);
@@ -367,7 +369,7 @@ public class EmailPlugin implements ActionPluginListener {
         Map<String, String> emailProcessed = emailTemplate.processTemplate(msg);
 
         String subject = emailProcessed.get("emailSubject");
-        if (null != subject && !subject.isEmpty()) {
+        if (!isEmpty(subject)) {
             email.setSubject(subject);
         } else {
             log.debugf("Subject not found processing email on message: %s", msg);
@@ -388,9 +390,5 @@ public class EmailPlugin implements ActionPluginListener {
             email.setContent(multipart);
         }
         return email;
-    }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
     }
 }

--- a/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
+++ b/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/EmailTemplate.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -155,14 +157,14 @@ public class EmailTemplate {
          */
         StringWriter writerPlain = new StringWriter();
         StringWriter writerHtml = new StringWriter();
-        if (plain != null && !plain.isEmpty()) {
+        if (!isEmpty(plain)) {
             StringReader plainReader = new StringReader(plain);
             ftlTemplate = new Template("plainTemplate", plainReader, ftlCfg);
             ftlTemplate.process(pmDesc, writerPlain);
         }  else {
             ftlTemplatePlain.process(pmDesc, writerPlain);
         }
-        if (html != null && !html.isEmpty()) {
+        if (!isEmpty(html)) {
             StringReader htmlReader = new StringReader(html);
             ftlTemplate = new Template("htmlTemplate", htmlReader, ftlCfg);
             ftlTemplate.process(pmDesc, writerHtml);

--- a/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
+++ b/actions/actions-plugins/actions-email/src/main/java/org/hawkular/alerts/actions/email/PluginMessageDescription.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.email;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -235,8 +237,7 @@ public class PluginMessageDescription {
         }
         if (event != null && event.getTrigger() != null) {
             trigger = event.getTrigger();
-            if (trigger.getContext() != null &&
-                    !trigger.getContext().isEmpty() &&
+            if (!isEmpty(trigger.getContext()) &&
                     trigger.getContext().containsKey(CONTEXT_PROPERTY_RESOURCE_TYPE) &&
                     trigger.getContext().containsKey(CONTEXT_PROPERTY_RESOURCE_NAME)) {
                 triggerDescription = trigger.getContext().get(CONTEXT_PROPERTY_RESOURCE_TYPE) + " " +

--- a/actions/actions-plugins/actions-kafka/src/main/java/org/hawkular/alerts/actions/kafka/KafkaPlugin.java
+++ b/actions/actions-plugins/actions-kafka/src/main/java/org/hawkular/alerts/actions/kafka/KafkaPlugin.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.kafka;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -249,7 +251,4 @@ public class KafkaPlugin implements ActionPluginListener {
         }
     }
 
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
 }

--- a/actions/actions-plugins/actions-webhook/src/main/java/org/hawkular/alerts/actions/webhook/WebHookPlugin.java
+++ b/actions/actions-plugins/actions-webhook/src/main/java/org/hawkular/alerts/actions/webhook/WebHookPlugin.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.actions.webhook;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -164,9 +166,4 @@ public class WebHookPlugin implements ActionPluginListener {
             log.error("Error sending ActionResponseMessage", e);
         }
     }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
-
 }

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchAlerter.java
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchAlerter.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerter.elasticsearch;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -321,7 +323,7 @@ public class ElasticsearchAlerter implements AlerterPlugin {
     }
 
     public static int getIntervalValue(String interval) {
-        if (interval == null || interval.isEmpty()) {
+        if (isEmpty(interval)) {
             interval = INTERVAL_DEFAULT;
         }
         try {

--- a/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchQuery.java
+++ b/alerters/alerters-plugins/alerters-elasticsearch/src/main/java/org/hawkular/alerter/elasticsearch/ElasticsearchQuery.java
@@ -20,6 +20,7 @@ import static java.util.Collections.EMPTY_LIST;
 import static org.hawkular.alerter.elasticsearch.ElasticsearchAlerter.getIntervalUnit;
 import static org.hawkular.alerter.elasticsearch.ElasticsearchAlerter.getIntervalValue;
 import static org.hawkular.alerts.api.model.event.EventField.DATAID;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -508,9 +509,5 @@ public class ElasticsearchQuery implements Runnable {
         } catch (Exception e) {
             log.error("Error querying Elasticsearch.", e);
         }
-    }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
     }
 }

--- a/alerters/alerters-plugins/alerters-kafka/src/main/java/org/hawkular/alerter/kafka/KafkaQuery.java
+++ b/alerters/alerters-plugins/alerters-kafka/src/main/java/org/hawkular/alerter/kafka/KafkaQuery.java
@@ -17,6 +17,7 @@
 package org.hawkular.alerter.kafka;
 
 import static org.hawkular.alerts.api.model.event.EventField.DATAID;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -287,11 +288,4 @@ public class KafkaQuery implements Runnable {
         return System.currentTimeMillis();
     }
 
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
-
-    private boolean isEmpty(Map m) {
-        return m == null || m.isEmpty();
-    }
 }

--- a/api/src/main/java/org/hawkular/alerts/api/model/action/TimeConstraint.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/action/TimeConstraint.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.action;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -737,10 +739,6 @@ public class TimeConstraint implements Serializable {
         } catch (ParseException e) {
             throw new IllegalArgumentException("Bad format on startTime and/or endTime: " + e.getMessage());
         }
-    }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
     }
 
     @Override

--- a/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -211,7 +213,7 @@ public class EventCondition extends Condition {
         if (null == value) {
             return false;
         }
-        if (null == expression || expression.isEmpty()) {
+        if (isEmpty(expression)) {
             return true;
         }
         List<String> expressions = new ArrayList<>();
@@ -251,7 +253,7 @@ public class EventCondition extends Condition {
     private static final String GTE = ">=";
 
     private boolean processExpression(String expression, Event value) {
-        if (null == expression || expression.isEmpty() || null == value) {
+        if (isEmpty(expression) || null == value) {
             return false;
         }
         String[] tokens = expression.split(" ");
@@ -270,7 +272,7 @@ public class EventCondition extends Condition {
         String sConstantValue = null;
         Double dConstantValue = null;
 
-        if (eventField == null || eventField.isEmpty()) {
+        if (isEmpty(eventField)) {
             return false;
         }
         if (TENANT_ID.equals(eventField)) {

--- a/api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonCondition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/condition/NelsonCondition.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.condition;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -197,10 +199,6 @@ public class NelsonCondition extends Condition {
         }
 
         return false;
-    }
-
-    private boolean isEmpty(Collection<?> c) {
-        return null == c || c.isEmpty();
     }
 
     @Override

--- a/api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/dampening/Dampening.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.dampening;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -416,7 +418,7 @@ public class Dampening implements Serializable {
         if (null == match) {
             throw new IllegalArgumentException("Match can not be null");
         }
-        if (null == conditionEvalSet || isEmpty(conditionEvalSet)) {
+        if (isEmpty(conditionEvalSet)) {
             throw new IllegalArgumentException("ConditionEval Set can not be null or empty");
         }
 
@@ -553,10 +555,6 @@ public class Dampening implements Serializable {
         sb.append("-").append(triggerId);
         sb.append("-").append(triggerMode.name());
         this.dampeningId = sb.toString();
-    }
-
-    private boolean isEmpty(Collection<?> c) {
-        return null == c || c.isEmpty();
     }
 
     @Override

--- a/api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.data;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -224,10 +226,6 @@ public class Data implements Comparable<Data>, Serializable {
     public static Data forAvailability(String tenantId, String source, String id, long timestamp,
             AvailabilityType value, Map<String, String> context) {
         return new Data(tenantId, source, id, timestamp, value.name(), null, context);
-    }
-
-    private boolean isEmpty(String s) {
-        return null == s || s.trim().isEmpty();
     }
 
     public String getTenantId() {

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.event;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -527,10 +529,6 @@ public class Event implements Comparable<Event>, Serializable {
         } else if (!tenantId.equals(other.tenantId))
             return false;
         return true;
-    }
-
-    private static boolean isEmpty(String s) {
-        return null == s || s.trim().isEmpty();
     }
 
 }

--- a/api/src/main/java/org/hawkular/alerts/api/model/paging/ActionComparator.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/paging/ActionComparator.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.paging;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Comparator;
 
 import org.hawkular.alerts.api.model.action.Action;
@@ -44,7 +46,7 @@ public class ActionComparator implements Comparator<Action> {
         }
 
         public static Field getField(String text) {
-            if (text == null || text.isEmpty()) {
+            if (isEmpty(text)) {
                 return ALERT_ID;
             }
             for (Field f : values()) {

--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/FullTrigger.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/FullTrigger.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.trigger;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -141,14 +143,6 @@ public class FullTrigger implements Serializable {
                 }
             }
         }
-    }
-
-    private boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
-
-    private boolean isEmpty(Collection c) {
-        return c == null || c.isEmpty();
     }
 
     @Override

--- a/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/trigger/Trigger.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.model.trigger;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -252,7 +254,7 @@ public class Trigger implements Serializable {
     }
 
     public Trigger(String tenantId, String id, String name, Map<String, String> context, Map<String, String> tags) {
-        if (id == null || id.isEmpty()) {
+        if (isEmpty(id)) {
             throw new IllegalArgumentException("Trigger id must be non-empty");
         }
         this.tenantId = tenantId;
@@ -308,7 +310,7 @@ public class Trigger implements Serializable {
     }
 
     public void setName(String name) {
-        if (name == null || name.isEmpty()) {
+        if (isEmpty(name)) {
             throw new IllegalArgumentException("Trigger name must be non-empty.");
         }
         this.name = name;

--- a/api/src/main/java/org/hawkular/alerts/api/services/ActionsCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/ActionsCriteria.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.services;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 
 /**
@@ -164,19 +166,19 @@ public class ActionsCriteria {
     }
 
     public boolean hasActionIdCriteria() {
-        return null != actionId || (null != actionIds && !actionIds.isEmpty());
+        return !isEmpty(actionId) || !isEmpty(actionIds);
     }
 
     public boolean hasActionPluginCriteria() {
-        return null != actionPlugin || (null != actionPlugins && !actionPlugins.isEmpty());
+        return !isEmpty(actionPlugin) || !isEmpty(actionPlugins);
     }
 
     public boolean hasEventIdCriteria() {
-        return null != eventId || (null != eventIds && !eventIds.isEmpty());
+        return !isEmpty(eventId) || !isEmpty(eventIds);
     }
 
     public boolean hasResultCriteria() {
-        return null != result || (null != results && !results.isEmpty());
+        return !isEmpty(result) || !isEmpty(results);
     }
 
     public boolean hasStartCriteria() {

--- a/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/AlertsCriteria.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.services;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -293,22 +295,19 @@ public class AlertsCriteria {
     }
 
     public boolean hasAlertIdCriteria() {
-        return null != alertId
-                || (null != alertIds && !alertIds.isEmpty());
+        return !isEmpty(alertId) || !isEmpty(alertIds);
     }
 
     public boolean hasSeverityCriteria() {
-        return null != severity
-                || (null != severities && !severities.isEmpty());
+        return  null != severity || !isEmpty(severities);
     }
 
     public boolean hasStatusCriteria() {
-        return null != status
-                || (null != statusSet && !statusSet.isEmpty());
+        return null != status || !isEmpty(statusSet);
     }
 
     public boolean hasTagQueryCriteria() {
-        return (null != tagQuery && !isEmpty(tagQuery));
+        return !isEmpty(tagQuery);
     }
 
     public boolean hasCTimeCriteria() {
@@ -316,8 +315,7 @@ public class AlertsCriteria {
     }
 
     public boolean hasTriggerIdCriteria() {
-        return null != triggerId
-                || (null != triggerIds && !triggerIds.isEmpty());
+        return !isEmpty(triggerId) || !isEmpty(triggerIds);
     }
 
     public boolean hasResolvedTimeCriteria() {
@@ -366,10 +364,6 @@ public class AlertsCriteria {
                 ", tagQuery='" + tagQuery + '\'' +
                 ", thin=" + thin +
                 '}';
-    }
-
-    private static boolean isEmpty(String s) {
-        return s == null || s.trim().isEmpty();
     }
 
 }

--- a/api/src/main/java/org/hawkular/alerts/api/services/EventsCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/EventsCriteria.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.services;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -238,9 +240,5 @@ public class EventsCriteria {
                 ", criteriaNoQuerySize=" + criteriaNoQuerySize +
                 ", eventType='" + eventType + '\'' +
                 '}';
-    }
-
-    private static boolean isEmpty(String s) {
-        return s == null || s.trim().isEmpty();
     }
 }

--- a/api/src/main/java/org/hawkular/alerts/api/services/TriggersCriteria.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/TriggersCriteria.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.api.services;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,8 +81,7 @@ public class TriggersCriteria {
     }
 
     public boolean hasTriggerIdCriteria() {
-        return null != triggerId
-                || (null != triggerIds && !triggerIds.isEmpty());
+        return !isEmpty(triggerId) || !isEmpty(triggerIds);
     }
 
     public boolean hasCriteria() {

--- a/api/src/main/java/org/hawkular/alerts/api/util/Util.java
+++ b/api/src/main/java/org/hawkular/alerts/api/util/Util.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.api.util;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.hawkular.alerts.api.model.action.ActionDefinition;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * Unify some utility methods used in several components related to API model or generic validations
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class Util {
+
+    public static boolean isEmpty(String s) {
+        return null == s || s.trim().isEmpty();
+    }
+
+    public static boolean isEmpty(Collection c) {
+        return null == c || c.isEmpty();
+    }
+
+    public static boolean isEmpty(Map m) {
+        return m == null || m.isEmpty();
+    }
+
+    public static boolean isEmpty(String... strings) {
+        for (String s : strings) {
+            if (null == s || s.trim().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isEmpty(ActionDefinition a) {
+        return a == null || isEmpty(a.getActionPlugin()) || isEmpty(a.getActionId());
+    }
+
+    public static boolean isEmpty(Dampening dampening) {
+        return dampening == null || isEmpty(dampening.getTriggerId()) || isEmpty(dampening.getDampeningId());
+    }
+
+    public static boolean isEmpty(Trigger trigger) {
+        return trigger == null || isEmpty(trigger.getId());
+    }
+
+}

--- a/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/EventsAggregationExtension.java
+++ b/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/EventsAggregationExtension.java
@@ -17,6 +17,7 @@
 package org.hawkular.alerts.extensions;
 
 import static org.hawkular.alerts.api.services.DistributedEvent.*;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -222,9 +223,5 @@ public class EventsAggregationExtension implements EventExtension {
             executor.submit(() -> cep.processEvents(retained));
         }
         return filtered;
-    }
-
-    private boolean isEmpty(Collection c) {
-        return c == null || c.isEmpty();
     }
 }

--- a/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/Expression.java
+++ b/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/Expression.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.extensions;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -403,14 +405,6 @@ public class Expression {
             newStr = newStr.replaceAll(original, map + "[\"" + field + "\"]");
         }
         return newStr;
-    }
-
-    private static boolean isEmpty(String s) {
-        return null == s || s.trim().isEmpty();
-    }
-
-    private static boolean isEmpty(Collection c) {
-        return null == c || c.isEmpty();
     }
 
     @Override

--- a/engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/cache/PublishCacheManager.java
@@ -18,8 +18,8 @@ package org.hawkular.alerts.engine.cache;
 
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.TRIGGER_CONDITION_CHANGE;
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.TRIGGER_REMOVE;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -208,9 +208,5 @@ public class PublishCacheManager {
             publishCache.endBatch(false);
             return;
         }
-    }
-
-    private boolean isEmpty(Collection c) {
-        return c == null || c.isEmpty();
     }
 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.impl;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -243,7 +245,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
             log.errorDefinitionsService("Triggers", e.getMessage());
         }
 
-        if (triggers != null && !triggers.isEmpty()) {
+        if (!isEmpty(triggers)) {
 
             triggers.stream().filter(Trigger::isLoadable).forEach(t -> {
                 /*
@@ -859,9 +861,4 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
             });
         }
     }
-
-    private boolean isEmpty(String s) {
-        return null == s || s.trim().isEmpty();
-    }
-
 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.impl;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -180,16 +182,6 @@ public class DataDrivenGroupCacheManager {
 
         // otherwise, return the triggers that need a member for this source
         return triggersMap.get(key);
-    }
-
-    private boolean isEmpty(String... strings) {
-        for (String s : strings) {
-            if (null == s || s.trim().isEmpty()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static class CacheKey {

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManagerImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/IncomingDataManagerImpl.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.impl;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -234,10 +236,6 @@ public class IncomingDataManagerImpl implements IncomingDataManager {
                 }
             }
         }
-    }
-
-    private boolean isEmpty(String s) {
-        return null == s || s.isEmpty();
     }
 
     public static class IncomingData {

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/PartitionManagerImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/PartitionManagerImpl.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.impl;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +40,6 @@ import org.hawkular.alerts.engine.service.PartitionDataListener;
 import org.hawkular.alerts.engine.service.PartitionManager;
 import org.hawkular.alerts.engine.service.PartitionTriggerListener;
 import org.hawkular.alerts.log.AlertingLogger;
-import org.hawkular.commons.log.MsgLogger;
 import org.hawkular.commons.log.MsgLogging;
 import org.hawkular.commons.properties.HawkularProperties;
 import org.infinispan.Cache;
@@ -358,13 +359,13 @@ public class PartitionManagerImpl implements PartitionManager {
      * @return a new table of nodes
      */
     public Map<Integer, Integer> updateBuckets(Map<Integer, Integer> oldBuckets, List<Integer> members) {
-        if (members == null || members.isEmpty()) {
+        if (isEmpty(members)) {
             throw new IllegalArgumentException("newMembers must be not null");
         }
         /*
             Create a new map
          */
-        if (oldBuckets == null || oldBuckets.isEmpty()) {
+        if (isEmpty(oldBuckets)) {
             Map<Integer, Integer> newBuckets = new HashMap<>();
             for (int i = 0; i < members.size(); i++) {
                 newBuckets.put(i, members.get(i));
@@ -409,7 +410,7 @@ public class PartitionManagerImpl implements PartitionManager {
         if (entries == null) {
             throw new IllegalArgumentException("entries must be not null");
         }
-        if (buckets == null || buckets.isEmpty()) {
+        if (isEmpty(buckets)) {
             throw new IllegalArgumentException("entries must be not null");
         }
         HashFunction md5 = Hashing.md5();
@@ -432,7 +433,7 @@ public class PartitionManagerImpl implements PartitionManager {
         if (newEntry == null) {
             throw new IllegalArgumentException("newEntry must be not null");
         }
-        if (buckets == null || buckets.isEmpty()) {
+        if (isEmpty(buckets)) {
             throw new IllegalArgumentException("buckets must be not null");
         }
         HashFunction md5 = Hashing.md5();
@@ -486,7 +487,7 @@ public class PartitionManagerImpl implements PartitionManager {
         output.put("added", new HashMap<>());
         output.put("removed", new HashMap<>());
 
-        if (previous == null || previous.isEmpty()) {
+        if (isEmpty(previous)) {
             current.entrySet().stream().forEach(entry -> {
                 add(output.get("added"), entry.getKey());
             });

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnActionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnActionsServiceImpl.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.alerts.engine.impl.ispn;
 
-import static org.hawkular.alerts.engine.util.Utils.isEmpty;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImpl.java
@@ -16,17 +16,16 @@
  */
 package org.hawkular.alerts.engine.impl.ispn;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pk;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pkFromEventId;
 import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.EQ;
 import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.NEQ;
-import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.NOT;
 import static org.hawkular.alerts.engine.util.Utils.extractAlertIds;
 import static org.hawkular.alerts.engine.util.Utils.extractCategories;
 import static org.hawkular.alerts.engine.util.Utils.extractEventIds;
 import static org.hawkular.alerts.engine.util.Utils.extractStatus;
 import static org.hawkular.alerts.engine.util.Utils.extractTriggerIds;
-import static org.hawkular.alerts.engine.util.Utils.isEmpty;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
@@ -19,11 +19,11 @@ package org.hawkular.alerts.engine.impl.ispn;
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.ACTION_DEFINITION_CREATE;
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.ACTION_DEFINITION_REMOVE;
 import static org.hawkular.alerts.api.services.DefinitionsEvent.Type.ACTION_DEFINITION_UPDATE;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pk;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pkFromDampeningId;
 import static org.hawkular.alerts.engine.impl.ispn.IspnPk.pkFromTriggerId;
 import static org.hawkular.alerts.engine.util.Utils.checkTenantId;
-import static org.hawkular.alerts.engine.util.Utils.isEmpty;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/engine/src/main/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParser.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/tags/ExpressionTagQueryParser.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.alerts.engine.tags;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.AND;
 import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.NOT;
 import static org.hawkular.alerts.engine.tags.ExpressionTagQueryParser.ExpressionTagResolver.OR;
@@ -68,7 +69,7 @@ public class ExpressionTagQueryParser extends TagQueryBaseListener implements AN
         String IN = "in";
 
         static List<String> getTokens(String tagExpression) {
-            if (tagExpression == null || tagExpression.isEmpty()) {
+            if (isEmpty(tagExpression)) {
                 return null;
             }
             List<String> tokens = new ArrayList<>();
@@ -330,7 +331,7 @@ public class ExpressionTagQueryParser extends TagQueryBaseListener implements AN
             leftResult = resolver.resolve(left);
         }
         // Shorcutting the AND operator
-        if (isAnd && (leftResult == null || leftResult.isEmpty())) {
+        if (isAnd && isEmpty(leftResult)) {
             return leftResult;
         }
         Set<String> rightResult;

--- a/engine/src/main/java/org/hawkular/alerts/engine/util/ActionsValidator.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/util/ActionsValidator.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.util;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.event.Event;
 import org.hawkular.alerts.api.model.trigger.TriggerAction;
@@ -48,7 +50,7 @@ public class ActionsValidator {
         if (triggerAction == null || event == null) {
             return true;
         }
-        if ((triggerAction.getStates() == null || triggerAction.getStates().isEmpty())
+        if ((isEmpty(triggerAction.getStates()))
                 && triggerAction.getCalendar() == null) {
             return true;
         }

--- a/engine/src/main/java/org/hawkular/alerts/engine/util/Utils.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/util/Utils.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.alerts.engine.util;
 
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,30 +38,6 @@ import org.hawkular.alerts.api.services.EventsCriteria;
  * @author Lucas Ponce
  */
 public class Utils {
-
-    public static boolean isEmpty(String id) {
-        return id == null || id.trim().isEmpty();
-    }
-
-    public static boolean isEmpty(Map<String, String> map) {
-        return map == null || map.isEmpty();
-    }
-
-    public static boolean isEmpty(Collection<?> collection) {
-        return collection == null || collection.isEmpty();
-    }
-
-    public static boolean isEmpty(ActionDefinition a) {
-        return a == null || isEmpty(a.getActionPlugin()) || isEmpty(a.getActionId());
-    }
-
-    public static boolean isEmpty(Dampening dampening) {
-        return dampening == null || isEmpty(dampening.getTriggerId()) || isEmpty(dampening.getDampeningId());
-    }
-
-    public static boolean isEmpty(Trigger trigger) {
-        return trigger == null || isEmpty(trigger.getId());
-    }
 
     public static void checkTenantId(String tenantId, Object obj) {
         if (isEmpty(tenantId)) {

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -189,7 +189,7 @@
   <profiles>
 
     <profile>
-      <id>itest-ispn</id>
+      <id>itest</id>
 
       <build>
         <plugins>

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/ActionsHandler.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/ActionsHandler.java
@@ -1,6 +1,7 @@
 package org.hawkular.alerts.handlers;
 
 import static org.hawkular.alerts.api.json.JsonUtil.fromJson;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -94,13 +95,13 @@ public class ActionsHandler implements RestHandler {
                     if (actionDefinition == null) {
                         throw new ResponseUtil.BadRequestException("actionDefinition must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getActionPlugin())) {
+                    if (isEmpty(actionDefinition.getActionPlugin())) {
                         throw new ResponseUtil.BadRequestException("actionPlugin must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getActionId())) {
+                    if (isEmpty(actionDefinition.getActionId())) {
                         throw new ResponseUtil.BadRequestException("actionId must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getProperties())) {
+                    if (isEmpty(actionDefinition.getProperties())) {
                         throw new ResponseUtil.BadRequestException("properties must be not null");
                     }
                     actionDefinition.setTenantId(tenantId);
@@ -145,13 +146,13 @@ public class ActionsHandler implements RestHandler {
                     if (actionDefinition == null) {
                         throw new ResponseUtil.BadRequestException("actionDefinition must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getActionPlugin())) {
+                    if (isEmpty(actionDefinition.getActionPlugin())) {
                         throw new ResponseUtil.BadRequestException("actionPlugin must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getActionId())) {
+                    if (isEmpty(actionDefinition.getActionId())) {
                         throw new ResponseUtil.BadRequestException("actionId must be not null");
                     }
-                    if (ResponseUtil.isEmpty(actionDefinition.getProperties())) {
+                    if (isEmpty(actionDefinition.getProperties())) {
                         throw new ResponseUtil.BadRequestException("properties must be not null");
                     }
                     actionDefinition.setTenantId(tenantId);

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/AlertsHandler.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/AlertsHandler.java
@@ -3,7 +3,7 @@ package org.hawkular.alerts.handlers;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hawkular.alerts.api.json.JsonUtil.collectionFromJson;
 import static org.hawkular.alerts.api.json.JsonUtil.toJson;
-import static org.hawkular.alerts.handlers.util.ResponseUtil.isEmpty;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -140,7 +140,7 @@ public class AlertsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_TAGS) != null) {
                         tags = routing.request().params().get(PARAM_TAGS);
                     }
-                    if (ResponseUtil.isEmpty(alertIds) || ResponseUtil.isEmpty(tags)) {
+                    if (isEmpty(alertIds) || isEmpty(tags)) {
                         throw new ResponseUtil.BadRequestException("AlertIds and Tags required for adding tags");
                     }
                     try {
@@ -169,7 +169,7 @@ public class AlertsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_TAG_NAMES) != null) {
                         tagNames = routing.request().params().get(PARAM_TAG_NAMES);
                     }
-                    if (ResponseUtil.isEmpty(alertIds) || ResponseUtil.isEmpty(tagNames)) {
+                    if (isEmpty(alertIds) || isEmpty(tagNames)) {
                         throw new ResponseUtil.BadRequestException("AlertIds and Tags required for removing tags");
                     }
                     try {
@@ -202,7 +202,7 @@ public class AlertsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_ACK_NOTES) != null) {
                         ackNotes = routing.request().params().get(PARAM_ACK_NOTES);
                     }
-                    if (ResponseUtil.isEmpty(alertIds)) {
+                    if (isEmpty(alertIds)) {
                         throw new ResponseUtil.BadRequestException("AlertIds required for ack");
                     }
                     try {
@@ -263,7 +263,7 @@ public class AlertsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_RESOLVED_NOTES) != null) {
                         resolvedNotes = routing.request().params().get(PARAM_RESOLVED_NOTES);
                     }
-                    if (ResponseUtil.isEmpty(alertIds)) {
+                    if (isEmpty(alertIds)) {
                         throw new ResponseUtil.BadRequestException("AlertIds required for resolve");
                     }
                     try {
@@ -290,7 +290,7 @@ public class AlertsHandler implements RestHandler {
                         log.errorf("Error parsing Datums json: %s. Reason: %s", json, e.toString());
                         throw new ResponseUtil.BadRequestException(e.toString());
                     }
-                    if (ResponseUtil.isEmpty(datums)) {
+                    if (isEmpty(datums)) {
                         throw new ResponseUtil.BadRequestException("Data is empty");
                     }
                     try {
@@ -313,7 +313,7 @@ public class AlertsHandler implements RestHandler {
                     String ackBy = null;
                     String ackNotes = null;
                     String alertId = routing.request().getParam("alertId");
-                    if (ResponseUtil.isEmpty(alertId)) {
+                    if (isEmpty(alertId)) {
                         throw new ResponseUtil.BadRequestException("AlertId required for ack");
                     }
                     if (routing.request().params().get(PARAM_ACK_BY) != null) {
@@ -342,7 +342,7 @@ public class AlertsHandler implements RestHandler {
                     String user = null;
                     String text = null;
                     String alertId = routing.request().getParam("alertId");
-                    if (ResponseUtil.isEmpty(alertId)) {
+                    if (isEmpty(alertId)) {
                         throw new ResponseUtil.BadRequestException("AlertId required for adding notes");
                     }
                     if (routing.request().params().get(PARAM_USER) != null) {
@@ -432,7 +432,7 @@ public class AlertsHandler implements RestHandler {
             tagQuery = params.get(PARAM_TAG_QUERY);
         }
         String unifiedTagQuery;
-        if (!ResponseUtil.isEmpty(tags)) {
+        if (!isEmpty(tags)) {
             unifiedTagQuery = ResponseUtil.parseTagQuery(ResponseUtil.parseTags(tags));
         } else {
             unifiedTagQuery = tagQuery;

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/EventsHandler.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/EventsHandler.java
@@ -4,6 +4,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hawkular.alerts.api.json.JsonUtil.collectionFromJson;
 import static org.hawkular.alerts.api.json.JsonUtil.fromJson;
 import static org.hawkular.alerts.api.json.JsonUtil.toJson;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -82,10 +83,10 @@ public class EventsHandler implements RestHandler {
                     if (event == null) {
                         throw new ResponseUtil.BadRequestException("Event null.");
                     }
-                    if (ResponseUtil.isEmpty(event.getId())) {
+                    if (isEmpty(event.getId())) {
                         throw new ResponseUtil.BadRequestException("Event with id null.");
                     }
-                    if (ResponseUtil.isEmpty(event.getCategory())) {
+                    if (isEmpty(event.getCategory())) {
                         throw new ResponseUtil.BadRequestException("Event with category null.");
                     }
                     event.setTenantId(tenantId);
@@ -126,7 +127,7 @@ public class EventsHandler implements RestHandler {
                         log.errorf("Error parsing Event json: %s. Reason: %s", json, e.toString());
                         throw new ResponseUtil.BadRequestException(e.toString());
                     }
-                    if (ResponseUtil.isEmpty(events)) {
+                    if (isEmpty(events)) {
                         throw new ResponseUtil.BadRequestException("Events is empty");
                     }
                     try {
@@ -154,7 +155,7 @@ public class EventsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_TAGS) != null) {
                         tags = routing.request().params().get(PARAM_TAGS);
                     }
-                    if (ResponseUtil.isEmpty(eventIds) || ResponseUtil.isEmpty(tags)) {
+                    if (isEmpty(eventIds) || isEmpty(tags)) {
                         throw new ResponseUtil.BadRequestException("EventIds and Tags required for adding tags");
                     }
                     try {
@@ -183,7 +184,7 @@ public class EventsHandler implements RestHandler {
                     if (routing.request().params().get(PARAM_TAG_NAMES) != null) {
                         tagNames = routing.request().params().get(PARAM_TAG_NAMES);
                     }
-                    if (ResponseUtil.isEmpty(eventIds) || ResponseUtil.isEmpty(tagNames)) {
+                    if (isEmpty(eventIds) || isEmpty(tagNames)) {
                         throw new ResponseUtil.BadRequestException("EventIds and Tags required for removing tags");
                     }
                     try {
@@ -330,7 +331,7 @@ public class EventsHandler implements RestHandler {
             tagQuery = params.get(PARAM_TAG_QUERY);
         }
         String unifiedTagQuery;
-        if (!ResponseUtil.isEmpty(tags)) {
+        if (!isEmpty(tags)) {
             unifiedTagQuery = ResponseUtil.parseTagQuery(ResponseUtil.parseTags(tags));
         } else {
             unifiedTagQuery = tagQuery;

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/TriggersHandler.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/TriggersHandler.java
@@ -2,11 +2,11 @@ package org.hawkular.alerts.handlers;
 
 import static org.hawkular.alerts.api.json.JsonUtil.collectionFromJson;
 import static org.hawkular.alerts.api.json.JsonUtil.fromJson;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 import static org.hawkular.alerts.handlers.util.ResponseUtil.checkTags;
 import static org.hawkular.alerts.handlers.util.ResponseUtil.checkTenant;
 import static org.hawkular.alerts.handlers.util.ResponseUtil.extractPaging;
 import static org.hawkular.alerts.handlers.util.ResponseUtil.getCleanDampening;
-import static org.hawkular.alerts.handlers.util.ResponseUtil.isEmpty;
 import static org.hawkular.alerts.handlers.util.ResponseUtil.result;
 
 import java.util.Arrays;

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/util/ResponseUtil.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/util/ResponseUtil.java
@@ -5,6 +5,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERR
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hawkular.alerts.api.json.JsonUtil.toJson;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -188,18 +189,6 @@ public class ResponseUtil {
             }
         }
         return new Pager(page, perPage, ordering);
-    }
-
-    public static boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
-
-    public static boolean isEmpty(Collection c) {
-        return c == null || c.isEmpty();
-    }
-
-    public static boolean isEmpty(Map m) {
-        return m == null || m.isEmpty();
     }
 
     public static Map<String, String> parseTags(String tags) {


### PR DESCRIPTION
While developing plugins/alerters I realized we have copies of same methods spread across several classes.
Unify them to reduce some noise, probably other similar aux methods can follow same strategy.
Anyway, it's just a minor cleaning PR.