### PR TITLE
POC : Make Standard Triggers natively work like DataDriven Triggers

### DIFF
--- a/actions/actions-api/src/test/java/org/hawkular/alerts/actions/api/model/JsonTest.java
+++ b/actions/actions-api/src/test/java/org/hawkular/alerts/actions/api/model/JsonTest.java
@@ -54,7 +54,7 @@ public class JsonTest {
     @BeforeClass
     public static void initTest() {
         Trigger trigger = new Trigger(TEST_TENANT, "trigger-test", "trigger-test");
-        Alert alert = new Alert(TEST_TENANT, trigger, null);
+        Alert alert = new Alert(TEST_TENANT, trigger, Data.SOURCE_NONE, null);
 
         AvailabilityCondition aCond = new AvailabilityCondition(TEST_TENANT, "trigger-test", "Default",
                 AvailabilityCondition.Operator.UP);

--- a/actions/actions-plugins/actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
+++ b/actions/actions-plugins/actions-file/src/test/java/org/hawkular/alerts/actions/file/FilePluginTest.java
@@ -110,7 +110,8 @@ public class FilePluginTest {
         /*
             Manual alert creation for threshold
          */
-        Alert rtAlertOpen = new Alert(rtTrigger.getTenantId(), rtTrigger, getEvalList(rtFiringCondition, rtBadData));
+        Alert rtAlertOpen = new Alert(rtTrigger.getTenantId(), rtTrigger, Data.SOURCE_NONE,
+                getEvalList(rtFiringCondition, rtBadData));
         rtAlertOpen.setDampening(rtFiringDampening);
         rtAlertOpen.setStatus(Alert.Status.OPEN);
 
@@ -125,7 +126,8 @@ public class FilePluginTest {
         openThresholdAction.setProperties(props);
         openThresholdMsg = new TestActionMessage(openThresholdAction);
 
-        Alert rtAlertAck = new Alert(rtTrigger.getTenantId(), rtTrigger, getEvalList(rtFiringCondition, rtBadData));
+        Alert rtAlertAck = new Alert(rtTrigger.getTenantId(), rtTrigger, Data.SOURCE_NONE,
+                getEvalList(rtFiringCondition, rtBadData));
         rtAlertAck.setDampening(rtFiringDampening);
         rtAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
         rtAlertAck.addNote("Test ACK user", "Test ACK notes");
@@ -140,7 +142,7 @@ public class FilePluginTest {
          */
         Data rtGoodData = Data.forNumeric(tenantId, rtDataId, System.currentTimeMillis() + 20000, 998d);
 
-        Alert rtAlertResolved = new Alert(rtTrigger.getTenantId(), rtTrigger,
+        Alert rtAlertResolved = new Alert(rtTrigger.getTenantId(), rtTrigger, Data.SOURCE_NONE,
                 getEvalList(rtFiringCondition, rtBadData));
         rtAlertResolved.setDampening(rtFiringDampening);
         rtAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);
@@ -172,7 +174,8 @@ public class FilePluginTest {
         /*
             Manual alert creation for availability
          */
-        Alert avAlertOpen = new Alert(avTrigger.getTenantId(), avTrigger, getEvalList(avFiringCondition, avBadData));
+        Alert avAlertOpen = new Alert(avTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
+                getEvalList(avFiringCondition, avBadData));
         avAlertOpen.setDampening(avFiringDampening);
         avAlertOpen.setStatus(Alert.Status.OPEN);
 
@@ -187,7 +190,8 @@ public class FilePluginTest {
         openAvailabilityAction.setProperties(props);
         openAvailMsg = new TestActionMessage(openAvailabilityAction);
 
-        Alert avAlertAck = new Alert(avTrigger.getTenantId(), avTrigger, getEvalList(avFiringCondition, avBadData));
+        Alert avAlertAck = new Alert(avTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
+                getEvalList(avFiringCondition, avBadData));
         avAlertAck.setDampening(avFiringDampening);
         avAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
         avAlertAck.addNote("Test ACK user", "Test ACK notes");
@@ -203,7 +207,7 @@ public class FilePluginTest {
         Data avGoodData = Data.forAvailability(tenantId, avDataId, System.currentTimeMillis() + 20000,
                 AvailabilityType.UP);
 
-        Alert avAlertResolved = new Alert(avTrigger.getTenantId(), avTrigger,
+        Alert avAlertResolved = new Alert(avTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
                 getEvalList(avFiringCondition, avBadData));
         avAlertResolved.setDampening(avFiringDampening);
         avAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);
@@ -246,7 +250,7 @@ public class FilePluginTest {
         List<Data> mixBadData = new ArrayList<>();
         mixBadData.add(rtBadData);
         mixBadData.add(avBadData);
-        Alert mixAlertOpen = new Alert(mixTrigger.getTenantId(), mixTrigger,
+        Alert mixAlertOpen = new Alert(mixTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
                getEvalList(mixConditions, mixBadData));
         mixAlertOpen.setDampening(mixFiringDampening);
         mixAlertOpen.setStatus(Alert.Status.OPEN);
@@ -262,7 +266,7 @@ public class FilePluginTest {
         openTwoCondAction.setProperties(props);
         openTwoCondMsg = new TestActionMessage(openTwoCondAction);
 
-        Alert mixAlertAck = new Alert(mixTrigger.getTenantId(), mixTrigger,
+        Alert mixAlertAck = new Alert(mixTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
                 getEvalList(mixConditions, mixBadData));
         mixAlertAck.setDampening(mixFiringDampening);
         mixAlertAck.addLifecycle(Alert.Status.ACKNOWLEDGED, "Test ACK user", System.currentTimeMillis() + 10000);
@@ -287,7 +291,7 @@ public class FilePluginTest {
         mixGoodData.add(rtGoodData);
         mixGoodData.add(avGoodData);
 
-        Alert mixAlertResolved = new Alert(mixTrigger.getTenantId(), mixTrigger,
+        Alert mixAlertResolved = new Alert(mixTrigger.getTenantId(), avTrigger, Data.SOURCE_NONE,
                 getEvalList(mixConditions, mixBadData));
         mixAlertResolved.setDampening(mixFiringDampening);
         mixAlertResolved.addLifecycle(Alert.Status.RESOLVED, "Test RESOLVED user", System.currentTimeMillis() + 20000);

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmGarbageCollectionData.java
@@ -105,7 +105,8 @@ public class JvmGarbageCollectionData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmHeapUsageData.java
@@ -110,7 +110,8 @@ public class JvmHeapUsageData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/JvmNonHeapUsageData.java
@@ -110,7 +110,8 @@ public class JvmNonHeapUsageData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/MultipleAllJvmData.java
@@ -211,7 +211,8 @@ public class MultipleAllJvmData extends CommonData {
 
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlAvailabilityData.java
@@ -101,7 +101,8 @@ public class UrlAvailabilityData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/UrlResponseTimeData.java
@@ -104,7 +104,8 @@ public class UrlResponseTimeData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebActiveSessionsData.java
@@ -111,7 +111,8 @@ public class WebActiveSessionsData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerCurrentThreadsData.java
@@ -111,7 +111,8 @@ public class WebContainerCurrentThreadsData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebContainerPendingRequestsData.java
@@ -111,7 +111,8 @@ public class WebContainerPendingRequestsData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebExpiredSessionsData.java
@@ -105,7 +105,8 @@ public class WebExpiredSessionsData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRejectedSessionsData.java
@@ -105,7 +105,8 @@ public class WebRejectedSessionsData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
+++ b/actions/actions-tests/src/main/java/org/hawkular/alerts/actions/tests/WebRequestsResponseTimeData.java
@@ -105,7 +105,8 @@ public class WebRequestsResponseTimeData extends CommonData {
         evalSet2.add(eval2);
         satisfyingEvals.add(evalSet2);
 
-        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, satisfyingEvals);
+        Alert openAlert = new Alert(trigger.getTenantId(), trigger, firingDampening, Data.SOURCE_NONE,
+                satisfyingEvals);
 
         return openAlert;
     }

--- a/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
@@ -396,8 +396,10 @@ public class EventCondition extends Condition {
 
     @Override
     public int hashCode() {
+        final int prime = 31;
         int result = super.hashCode();
-        result = 31 * result + (expression != null ? expression.hashCode() : 0);
+        result = prime * result + ((dataId == null) ? 0 : dataId.hashCode());
+        result = prime * result + ((expression == null) ? 0 : expression.hashCode());
         return result;
     }
 
@@ -408,4 +410,6 @@ public class EventCondition extends Condition {
                 ",expression='" + expression + '\'' +
                 '}';
     }
+
+
 }

--- a/api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/condition/ExternalCondition.java
@@ -25,11 +25,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * An <code>ExternalCondition</code> is used for condition evaluations performed outside of the Alerts engine.
- * The external engine will send <code>StringData</code> providing the data for which the external evaluation
- * <b>has already evaluated to <code>True</code></b>. The Alerts engine assumes a true evaluation for the data being
- * sent in from the external engine. In other words, every <code>ExternalConditionEvaluation</code> will have
+ * The external engine will send <code>Data</code> or an <code>Event</code> indicating an external evaluation
+ * <b>has already evaluated to <code>True</code></b>. The Alerting engine assumes a true evaluation for data received
+ * from the external engine. In other words, every <code>ExternalConditionEvaluation</code> will have
  * a true evaluation and therefore, for triggers with only a single external condition, and with default dampening,
- * an alert will be fired for each data submission.
+ * an alert will be fired for each submission.
  *
  * @author Jay Shaughnessy
  * @author Lucas Ponce
@@ -37,11 +37,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @DocModel(description = "An ExternalCondition is used for condition evaluations performed outside of the " +
         "Alerting engine. + \n" +
         " + \n" +
-        "The external engine will send StringData providing the data for which the external evaluation " +
+        "The external engine will send Data or an Event indicating an the external evaluation " +
         " + \n" +
         "has already evaluated to true. + \n" +
         " + \n" +
-        "The Alerting engine assumes a true evaluation for the data being sent in from the external engine. " +
+        "The Alerting engine assumes a true evaluation for data received from the external engine. " +
         "In other words, every <<ExternalConditionEval>> will have a true evaluation and therefore, for triggers with " +
         "only a single external condition, and with default dampening, an alert will be fired for each " +
         "data submission.")

--- a/api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/data/Data.java
@@ -382,8 +382,8 @@ public class Data implements Comparable<Data>, Serializable {
 
     @Override
     public String toString() {
-        return "Data [tenantId=" + tenantId + ", id=" + id + ", timestamp=" + timestamp + ", value=" + value
-                + ", context=" + context + "]";
+        return "Data [tenantId=" + tenantId + ", id=" + id + ", source=" + source + ", timestamp=" + timestamp
+                + ", value=" + value + ", context=" + context + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Alert.java
@@ -100,8 +100,8 @@ public class Alert extends Event {
     /**
      * Assumes default dampening.
      */
-    public Alert(String tenantId, Trigger trigger, List<Set<ConditionEval>> evalSets) {
-        this(tenantId, trigger, null, evalSets);
+    public Alert(String tenantId, Trigger trigger, String dataSource, List<Set<ConditionEval>> evalSets) {
+        this(tenantId, trigger, null, dataSource, evalSets);
     }
 
     public Alert(Alert alert) {
@@ -120,8 +120,9 @@ public class Alert extends Event {
         this.resolvedEvalSets = alert.getResolvedEvalSets();
     }
 
-    public Alert(String tenantId, Trigger trigger, Dampening dampening, List<Set<ConditionEval>> evalSets) {
-        super(tenantId, trigger, dampening, evalSets);
+    public Alert(String tenantId, Trigger trigger, Dampening dampening, String dataSource,
+            List<Set<ConditionEval>> evalSets) {
+        super(tenantId, trigger, dampening, dataSource, evalSets);
 
         this.status = Status.OPEN;
         this.severity = trigger.getSeverity();

--- a/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/event/Event.java
@@ -247,7 +247,8 @@ public class Event implements Comparable<Event>, Serializable {
      * @param alert the Non-Thin Alert, it must be fully defined.
      */
     public Event(Alert alert) {
-        this(alert.getTenantId(), alert.getTrigger(), alert.getDampening(), alert.getEvalSets());
+        this(alert.getTenantId(), alert.getTrigger(), alert.getDampening(), alert.getDataSource(),
+                alert.getEvalSets());
         this.eventType = alert.getEventType();
     }
 
@@ -272,7 +273,8 @@ public class Event implements Comparable<Event>, Serializable {
         this.tags = new HashMap<>(event.getTags());
     }
 
-    public Event(String tenantId, Trigger trigger, Dampening dampening, List<Set<ConditionEval>> evalSets) {
+    public Event(String tenantId, Trigger trigger, Dampening dampening, String dataSource,
+            List<Set<ConditionEval>> evalSets) {
         this.tenantId = tenantId;
         this.trigger = trigger;
         this.dampening = dampening;
@@ -281,7 +283,7 @@ public class Event implements Comparable<Event>, Serializable {
         this.ctime = System.currentTimeMillis();
 
         this.id = trigger.getId() + "-" + this.ctime + "-" + UUID.randomUUID();
-        this.dataSource = trigger.getSource();
+        this.dataSource = (null == dataSource) ? Data.SOURCE_NONE : dataSource;
         this.dataId = trigger.getId();
         this.context = trigger.getContext();
         if (!isEmpty(trigger.getEventCategory())) {

--- a/api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
+++ b/api/src/main/java/org/hawkular/alerts/api/services/AlertsService.java
@@ -67,7 +67,7 @@ public interface AlertsService {
      * Send events to the engine for alerts evaluation.
      * Persist the provided events.
      *
-     * @param events Set of unpersisted Events.
+     * @param events Set of persisted Events.
      * @throws Exception any problem
      */
     void addEvents(Collection<Event> events) throws Exception;
@@ -191,7 +191,7 @@ public interface AlertsService {
 
     /**
      * The alerts must already have been added. Set the alerts to RESOLVED status. The resolvedTime will be set to the
-     * system time.  If the call leaves the trigger with no unresolved alerts then:<br>
+     * system time.  If the call leaves the runtime trigger with no unresolved alerts then:<br>
      * - If the trigger has <code>autoEnable=true</code> it will be enabled, as needed.<br>
      * - If the trigger has <code>autoResolve=true</code> it will be set to firing mode, as needed.
      * @param tenantId Tenant where alerts are stored
@@ -201,8 +201,8 @@ public interface AlertsService {
      * @param resolvedEvalSets Optional. Typically the evalSets leading to an auto-resolved alert.
      * @throws Exception any problem
      */
-    void resolveAlerts(String tenantId, Collection<String> alertIds, String resolvedBy, String resolvedNotes,
-            List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
+    void resolveAlerts(String tenantId, Collection<String> alertIds, String resolvedBy,
+            String resolvedNotes, List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
 
     /**
      * Set unresolved alerts for the provided trigger to RESOLVED status. The resolvedTime will be set to the
@@ -211,13 +211,14 @@ public interface AlertsService {
      * - If the trigger has <code>autoResolve=true</code> it will be set to firing mode, as needed.
      * @param tenantId Tenant where alerts are stored
      * @param triggerId Tenant where alerts are stored
+     * @param source Limit to alerts with source, ignored if null
      * @param resolvedBy Optional. Typically the user resolving the alerts. "unknown" if not specified.
      * @param resolvedNotes Optional notes about the resolution. "none" if not specified.
      * @param resolvedEvalSets Optional. Typically the evalSets leading to an auto-resolved alert.
      * @throws Exception any problem
      */
-    void resolveAlertsForTrigger(String tenantId, String triggerId, String resolvedBy, String resolvedNotes,
-            List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
+    void resolveAlertsForTrigger(String tenantId, String triggerId, String source, String resolvedBy,
+            String resolvedNotes, List<Set<ConditionEval>> resolvedEvalSets) throws Exception;
 
     /**
      * Send data into the alerting system for evaluation.

--- a/api/src/test/java/org/hawkular/alerts/api/JsonTest.java
+++ b/api/src/test/java/org/hawkular/alerts/api/JsonTest.java
@@ -112,7 +112,7 @@ public class JsonTest {
     @Test
     public void jsonAlertTest() throws Exception {
         Trigger trigger = new Trigger(TEST_TENANT, "trigger-test", "trigger-test");
-        Alert alert = new Alert(TEST_TENANT, trigger, null);
+        Alert alert = new Alert(TEST_TENANT, trigger, Data.SOURCE_NONE, null);
 
         String output = objectMapper.writeValueAsString(alert);
 
@@ -1236,7 +1236,7 @@ public class JsonTest {
                 "\"severity\":\"HIGH\"}";
         Trigger trigger = objectMapper.readValue(str, Trigger.class);
 
-        assertEquals(Match.ANY, trigger.getMatch());
+        assertEquals(Match.ANY, trigger.getFiringMatch());
 
         assertTrue(trigger.getName().equals("test-name"));
         assertTrue(trigger.getDescription().equals("test-description"));

--- a/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/Expression.java
+++ b/engine-extensions/events-aggregation/src/main/java/org/hawkular/alerts/extensions/Expression.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.hawkular.alerts.api.model.condition.ExternalCondition;
+import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.FullTrigger;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 
@@ -154,7 +155,7 @@ public class Expression {
         alerterId = condition.getAlerterId();
         expression = condition.getExpression();
         tenantId = trigger.getTenantId();
-        source = trigger.getSource();
+        source = Data.SOURCE_NONE;
         dataId = condition.getDataId();
         drlWindow = "";
 

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/DataDrivenGroupCacheManager.java
@@ -123,7 +123,7 @@ public class DataDrivenGroupCacheManager {
                     Set<String> sources = new HashSet<>();
                     for (Trigger memberTrigger : definitions.getMemberTriggers(tenantId, groupTrigger.getId(),
                             false)) {
-                        sources.add(memberTrigger.getSource());
+                        // TODO: THIS CLASS GOES AWAY< I THINK sources.add(memberTrigger.getSource());
                     }
                     for (Condition c : definitions.getTriggerConditions(tenantId, groupTrigger.getId(), null)) {
                         CacheKey key = new CacheKey(tenantId, c.getDataId());

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImpl.java
@@ -335,7 +335,7 @@ public class IspnDefinitionsServiceImpl implements DefinitionsService {
             Trigger member = new Trigger(tenantId, memberId, group.getName());
 
             copyGroupTrigger(group, member, true);
-            member.setSource(source);
+            //member.setSource(source);
             // add source tag (not sure if we really need this)
             member.getTags().put("source", source);
 

--- a/engine/src/main/java/org/hawkular/alerts/engine/service/AlertsEngine.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/service/AlertsEngine.java
@@ -20,7 +20,9 @@ import java.util.TreeSet;
 
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Event;
+import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.engine.util.SourceTrigger;
 
 /**
  * Interface that allows to send data to the alerts engine and check resulting state. All methods are LockType.WRITE
@@ -37,10 +39,20 @@ public interface AlertsEngine {
     void clear();
 
     /**
-     * @param trigger the trigger for which the loaded version is requested.
-     * @return the Trigger with the current engine state, or null if the trigger is not found in the engine
+     * @param trigger root trigger of the SourceTrigger
+     * @param source source of the SourceTrigger
+     * @param enabled desired enablement or null to leave as is
+     * @param enabled desired mode or null to leave as is
+     * @return true if updated, false if no update performed
      */
-    Trigger getLoadedTrigger(Trigger trigger);
+    boolean updateSourceTrigger(Trigger trigger, String source, Boolean enabled, Mode mode);
+
+    /**
+     * @param trigger root trigger of the SourceTrigger
+     * @param source source of the SourceTrigger
+     * @return the SourceTrigger with the current engine state, or null if not found in the engine
+     */
+    SourceTrigger getSourceTrigger(Trigger trigger, String source);
 
     /**
      * Send data into the alerting system for evaluation. This method has LockType.READ.

--- a/engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/util/MissingState.java
@@ -18,7 +18,6 @@ package org.hawkular.alerts.engine.util;
 
 import org.hawkular.alerts.api.model.condition.MissingCondition;
 import org.hawkular.alerts.api.model.trigger.Mode;
-import org.hawkular.alerts.api.model.trigger.Trigger;
 
 /**
  * MissingConditions detect missing data or events within a defined time interval.  Each MissingCondition
@@ -39,17 +38,17 @@ public class MissingState {
     private long time;
 
     // Need to ensure the current trigger mode matches the condition's trigger mode
-    private Trigger trigger;
+    private SourceTrigger sourceTrigger;
 
     // Given the 1:1 relationship we use the [immutable] conditionId as the unique id for this as well.
     private String conditionId;
     private MissingCondition condition;
 
-    public MissingState(Trigger trigger, MissingCondition condition) {
-        this.trigger = trigger;
-        this.tenantId = trigger.getTenantId();
-        this.triggerId = trigger.getId();
-        this.source = trigger.getSource();
+    public MissingState(SourceTrigger sourceTrigger, MissingCondition condition) {
+        this.sourceTrigger = sourceTrigger;
+        this.tenantId = sourceTrigger.getTenantId();
+        this.triggerId = sourceTrigger.getId();
+        this.source = sourceTrigger.getSource();
 
         this.condition = condition;
         this.conditionId = condition.getConditionId();
@@ -97,8 +96,8 @@ public class MissingState {
         this.time = time;
     }
 
-    public Trigger getTrigger() {
-        return trigger;
+    public SourceTrigger getSourceTrigger() {
+        return sourceTrigger;
     }
 
     public MissingCondition getCondition() {

--- a/engine/src/main/java/org/hawkular/alerts/engine/util/SourceDampening.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/util/SourceDampening.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.util;
+
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.alerts.api.model.condition.ConditionEval;
+import org.hawkular.alerts.api.model.dampening.Dampening;
+import org.hawkular.alerts.api.model.dampening.Dampening.Type;
+import org.hawkular.alerts.api.model.trigger.Match;
+import org.hawkular.alerts.api.model.trigger.Mode;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class SourceDampening {
+
+    /** The tenant of the root Trigger */
+    private String tenantId;
+
+    /** The id of the root Trigger */
+    private String triggerId;
+
+    /** The data source being applied to the root trigger. */
+    private String source;
+
+    /** The root dampening mode */
+    private Mode triggerMode;
+
+    /** The root dampening type */
+    private Type type;
+
+    /** The root Dampening */
+    private transient Dampening dampening;
+
+    private transient int numTrueEvals;
+
+    private transient int numEvals;
+
+    private transient long trueEvalsStartTime;
+
+    // This Map<conditionSetIndex,ConditionEval> holds the most recent eval for each member of the condition set
+    private transient Map<Integer, ConditionEval> currentEvals = new HashMap<>(5);
+
+    private transient boolean satisfied;
+
+    private transient List<Set<ConditionEval>> satisfyingEvals = new ArrayList<Set<ConditionEval>>();
+
+    public SourceDampening(String source, Dampening dampening) {
+        super();
+        this.tenantId = dampening.getTenantId();
+        this.triggerId = dampening.getTriggerId();
+        this.source = source;
+        this.triggerMode = dampening.getTriggerMode();
+        this.type = dampening.getType();
+        this.dampening = dampening;
+
+        reset();
+    }
+
+    public void reset() {
+        this.numTrueEvals = 0;
+        this.numEvals = 0;
+        this.trueEvalsStartTime = 0L;
+        this.satisfied = false;
+        this.satisfyingEvals.clear();
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getTriggerId() {
+        return triggerId;
+    }
+
+    public void setTriggerId(String triggerId) {
+        this.triggerId = triggerId;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public Mode getTriggerMode() {
+        return triggerMode;
+    }
+
+    public void setTriggerMode(Mode triggerMode) {
+        this.triggerMode = triggerMode;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Dampening getDampening() {
+        return dampening;
+    }
+
+    public void setDampening(Dampening dampening) {
+        this.dampening = dampening;
+    }
+
+    public void setSatisfied(boolean satisfied) {
+        this.satisfied = satisfied;
+    }
+
+    public void setSatisfyingEvals(List<Set<ConditionEval>> satisfyingEvals) {
+        this.satisfyingEvals = satisfyingEvals;
+    }
+
+    public int getNumTrueEvals() {
+        return numTrueEvals;
+    }
+
+    public void setNumTrueEvals(int numTrueEvals) {
+        this.numTrueEvals = numTrueEvals;
+    }
+
+    public long getTrueEvalsStartTime() {
+        return trueEvalsStartTime;
+    }
+
+    public void setTrueEvalsStartTime(long trueEvalsStartTime) {
+        this.trueEvalsStartTime = trueEvalsStartTime;
+    }
+
+    public int getNumEvals() {
+        return numEvals;
+    }
+
+    public void setNumEvals(int numEvals) {
+        this.numEvals = numEvals;
+    }
+
+    public Map<Integer, ConditionEval> getCurrentEvals() {
+        return currentEvals;
+    }
+
+    public boolean isSatisfied() {
+        return satisfied;
+    }
+
+    /**
+     * @return a safe, but not deep, copy of the satisfying evals List
+     */
+    public List<Set<ConditionEval>> getSatisfyingEvals() {
+        return new ArrayList<Set<ConditionEval>>(satisfyingEvals);
+    }
+
+    public void addSatisfyingEvals(Set<ConditionEval> satisfyingEvals) {
+        this.satisfyingEvals.add(satisfyingEvals);
+    }
+
+    public void addSatisfyingEvals(ConditionEval... satisfyingEvals) {
+        this.satisfyingEvals.add(new HashSet<ConditionEval>(Arrays.asList(satisfyingEvals)));
+    }
+
+    public void perform(Match match, Set<ConditionEval> conditionEvalSet) {
+        if (null == match) {
+            throw new IllegalArgumentException("Match can not be null");
+        }
+        if (null == conditionEvalSet || isEmpty(conditionEvalSet)) {
+            throw new IllegalArgumentException("ConditionEval Set can not be null or empty");
+        }
+
+        // The currentEvals map holds the most recent eval for each condition in the condition set.
+        conditionEvalSet.stream()
+                .forEach(conditionEval -> currentEvals.put(conditionEval.getConditionSetIndex(), conditionEval));
+
+        // The conditionEvals for the same trigger will all have the same condition set size, so just use the first
+        int conditionSetSize = conditionEvalSet.iterator().next().getConditionSetSize();
+        boolean trueEval = false;
+        switch (match) {
+            case ALL:
+                // Don't perform a dampening eval until we have a conditionEval for each member of the ConditionSet.
+                if (currentEvals.size() < conditionSetSize) {
+                    return;
+                }
+                // Otherwise, all condition evals must be true for the condition set eval to be true
+                trueEval = true;
+                for (ConditionEval ce : currentEvals.values()) {
+                    if (!ce.isMatch()) {
+                        trueEval = false;
+                        break;
+                    }
+                }
+                break;
+            case ANY:
+                // we only need one true condition eval for the condition set eval to be true
+                trueEval = false;
+                for (ConditionEval ce : currentEvals.values()) {
+                    if (ce.isMatch()) {
+                        trueEval = true;
+                        break;
+                    }
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected Match type: " + match.name());
+        }
+
+        // If we had previously started our time and now have exceeded our time limit then we must start over
+        long now = System.currentTimeMillis();
+        if (dampening.getType() == Type.RELAXED_TIME && trueEvalsStartTime != 0L) {
+            if ((now - trueEvalsStartTime) > dampening.getEvalTimeSetting()) {
+                reset();
+            }
+        }
+
+        numEvals += 1;
+        if (trueEval) {
+            numTrueEvals += 1;
+            addSatisfyingEvals(new HashSet<>(currentEvals.values()));
+
+            switch (dampening.getType()) {
+                case STRICT:
+                case RELAXED_COUNT:
+                    if (numTrueEvals == dampening.getEvalTrueSetting()) {
+                        satisfied = true;
+                    }
+                    break;
+
+                case RELAXED_TIME:
+                    if (trueEvalsStartTime == 0L) {
+                        trueEvalsStartTime = now;
+                    }
+                    if ((numTrueEvals == dampening.getEvalTrueSetting())
+                            && ((now - trueEvalsStartTime) < dampening.getEvalTimeSetting())) {
+                        satisfied = true;
+                    }
+                    break;
+                case STRICT_TIME:
+                case STRICT_TIMEOUT:
+                    if (trueEvalsStartTime == 0L) {
+                        trueEvalsStartTime = now;
+
+                    } else if ((now - trueEvalsStartTime) >= dampening.getEvalTimeSetting()) {
+                        satisfied = true;
+                    }
+                    break;
+            }
+        } else {
+            switch (dampening.getType()) {
+                case STRICT:
+                case STRICT_TIME:
+                case STRICT_TIMEOUT:
+                    reset();
+                    break;
+                case RELAXED_COUNT:
+                    int numNeeded = dampening.getEvalTrueSetting() - numTrueEvals;
+                    int chancesLeft = dampening.getEvalTotalSetting() - numEvals;
+                    if (numNeeded > chancesLeft) {
+                        reset();
+                    }
+                    break;
+                case RELAXED_TIME:
+                    break;
+            }
+        }
+    }
+
+    public String log() {
+        StringBuilder sb = new StringBuilder(
+                "[" + triggerId + ", triggerMode=" + triggerMode.name() + ", source=" + source + ", numTrueEvals="
+                        + numTrueEvals + ", numEvals=" + numEvals + ", trueEvalsStartTime=" + trueEvalsStartTime
+                        + ", satisfied=" + satisfied);
+        if (satisfied) {
+            for (Set<ConditionEval> ces : satisfyingEvals) {
+                sb.append("\n\t[");
+                String space = "";
+                for (ConditionEval ce : ces) {
+                    sb.append(space);
+                    sb.append("[");
+                    sb.append(ce.getDisplayString());
+                    sb.append("]");
+                    space = " ";
+                }
+                sb.append("]");
+
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((source == null) ? 0 : source.hashCode());
+        result = prime * result + ((tenantId == null) ? 0 : tenantId.hashCode());
+        result = prime * result + ((triggerId == null) ? 0 : triggerId.hashCode());
+        result = prime * result + ((triggerMode == null) ? 0 : triggerMode.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SourceDampening other = (SourceDampening) obj;
+        if (source == null) {
+            if (other.source != null)
+                return false;
+        } else if (!source.equals(other.source))
+            return false;
+        if (tenantId == null) {
+            if (other.tenantId != null)
+                return false;
+        } else if (!tenantId.equals(other.tenantId))
+            return false;
+        if (triggerId == null) {
+            if (other.triggerId != null)
+                return false;
+        } else if (!triggerId.equals(other.triggerId))
+            return false;
+        if (triggerMode != other.triggerMode)
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "SourceDampening [tenantId=" + tenantId + ", triggerId=" + triggerId
+                + ", source=" + source + ", triggerMode=" + triggerMode.name() + ", type=" + type.name()
+                + ", numTrueEvals=" + numTrueEvals + ", numEvals=" + numEvals
+                + ", trueEvalsStartTime=" + trueEvalsStartTime + ", currentEvals=" + currentEvals + ", satisfied="
+                + satisfied + "]";
+    }
+
+}

--- a/engine/src/main/java/org/hawkular/alerts/engine/util/SourceTrigger.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/util/SourceTrigger.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.alerts.engine.util;
+
+import org.hawkular.alerts.api.model.trigger.Match;
+import org.hawkular.alerts.api.model.trigger.Mode;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class SourceTrigger {
+
+    /** The tenant of the root Trigger */
+    private String tenantId;
+
+    /** The id of the root Trigger */
+    private String id;
+
+    /** The data source being applied to the root trigger. */
+    private String source;
+
+    /** The root Trigger */
+    private transient Trigger trigger;
+
+    /** Used internally by the rules engine. Indicates current mode of a trigger: FIRING or AUTORESOLVE. */
+    private transient Mode mode;
+
+    /** Used internally by the rules engine. Indicates current match of a trigger: ALL or ANY. */
+    private transient Match match;
+
+    /** Used internally by the rules engine. Indicated whether this SourceTrigger is enabled or disabled. */
+    private transient boolean enabled;
+
+    public SourceTrigger(Trigger trigger, String source) {
+        super();
+        this.tenantId = trigger.getTenantId();
+        this.id = trigger.getId();
+        this.source = source;
+        this.trigger = trigger;
+        this.mode = Mode.FIRING;
+        this.match = trigger.getFiringMatch();
+        this.enabled = true;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public Trigger getTrigger() {
+        return trigger;
+    }
+
+    public void setTrigger(Trigger trigger) {
+        this.trigger = trigger;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public Match getMatch() {
+        return match;
+    }
+
+    public void setMatch(Match match) {
+        this.match = match;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((source == null) ? 0 : source.hashCode());
+        result = prime * result + ((tenantId == null) ? 0 : tenantId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SourceTrigger other = (SourceTrigger) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (source == null) {
+            if (other.source != null)
+                return false;
+        } else if (!source.equals(other.source))
+            return false;
+        if (tenantId == null) {
+            if (other.tenantId != null)
+                return false;
+        } else if (!tenantId.equals(other.tenantId))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "SourceTrigger [tenantId=" + tenantId + ", id=" + id + ", source=" + source + ", mode=" + mode
+                + ", match=" + match + "]";
+    }
+
+}

--- a/engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -54,6 +54,8 @@ import org.hawkular.alerts.engine.util.CompareData;
 import org.hawkular.alerts.engine.util.MissingState;
 import org.hawkular.alerts.engine.util.NelsonData;
 import org.hawkular.alerts.engine.util.RateData;
+import org.hawkular.alerts.engine.util.SourceDampening;
+import org.hawkular.alerts.engine.util.SourceTrigger;
 import org.hawkular.commons.log.MsgLogger;
 
 import java.util.ArrayList;
@@ -68,8 +70,66 @@ global ActionsService actions;
 global List alerts;
 global List events;
 global Set pendingTimeouts;
-global Map autoResolvedTriggers;
-global Set disabledTriggers;
+global Map autoResolvedSourceTriggers;
+global Set disabledSourceTriggers;
+global Set missingStates;
+
+////// SOURCE TRIGGER HANDLING
+//
+// Each Trigger can be the root of several SourceTrigger instances. Each SourceTrigger handles a different data
+// "source". We can then track dampening, mode and matchType individually for each SourceTrigger.  Not every
+// source may be valid for the trigger.  If valid create a SourceTrigger, otherwise retract the Data to stop
+// processing.
+
+rule AddSourceTriggerViaData
+    when
+        $t : Trigger( $tenantId : tenantId, $tid : id )
+        $c : Condition ( tenantId == $tenantId, triggerId == $tid, $did : dataId )
+        $d : Data( tenantId == $tenantId, id == $did, $source : source )
+        not  SourceTrigger( tenantId == $tenantId, id == $tid, source == $source )
+    then
+        if ( $t.isValidSource($source) ) {
+          SourceTrigger st = new SourceTrigger($t, $source);
+          if (log != null && log.isDebugEnabled()) {
+            log.debugf("Adding %s for %s", st, $d);
+          }
+          insert( st );
+        } else {
+          retract( $d );
+        }
+end
+
+rule AddSourceTriggerViaEvent
+    when
+        $t : Trigger( $tenantId : tenantId, $tid : id )
+        $c : Condition ( tenantId == $tenantId, triggerId == $tid, $did : dataId )
+        $e : Event( tenantId == $tenantId, dataId == $did, $source : dataSource )
+        not  SourceTrigger( tenantId == $tenantId, id == $tid, source == $source )
+    then
+        if ( $t.isValidSource($source) ) {
+          SourceTrigger st = new SourceTrigger($t, $source);
+          if (log != null && log.isDebugEnabled()) {
+            log.debugf("Adding %s for %s", st, $e);
+          }
+          insert( st );
+        } else {
+          retract( $e );
+        }
+end
+
+rule AddMissingState
+    when
+        $st : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $source : source )
+        $c  : MissingCondition( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode )
+        not   MissingState( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, source == $source )
+    then
+        MissingState ms = new MissingState($st, $c);
+        if (log != null && log.isDebugEnabled()) {
+          log.debugf("Adding %s", ms);
+        }
+        missingStates.add(ms);
+        insert( ms );
+end
 
 ////// CONDITION MATCHING
 //
@@ -89,7 +149,7 @@ global Set disabledTriggers;
 
 rule Threshold
     when 
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : ThresholdCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
@@ -102,7 +162,7 @@ end
 
 rule ThresholdRange
     when 
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : ThresholdRangeCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
@@ -124,7 +184,7 @@ end
 // across engine firings.
 rule ProvideCompareData1
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : CompareCondition( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $d1id : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $d1id )
         not  CompareData( data.tenantId == $tenantId, data.source == $tsource, data.id == $d1id )
@@ -138,7 +198,7 @@ end
 
 rule ProvideCompareData2
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : CompareCondition( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $d2id : data2Id )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $d2id )
         not  CompareData( data.tenantId == $tenantId, data.source == $tsource, data.id == $d2id )
@@ -168,7 +228,7 @@ end
 
 rule Compare
     when 
-        $t   : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t   : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c   : CompareCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode,
                                   $d1id : dataId, $d2id : data2Id )
         $cd1 : CompareData( data.tenantId == $tenantId, data.source == $tsource, data.id == $d1id )
@@ -183,7 +243,7 @@ end
 
 rule Availability
     when 
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : AvailabilityCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
@@ -196,7 +256,7 @@ end
 
 rule String
     when 
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : StringCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
@@ -209,7 +269,7 @@ end
 
 rule ExternalData
     when 
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : ExternalCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
     then
@@ -222,7 +282,7 @@ end
 
 rule ExternalEvent
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : ExternalCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId  )
         $d : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did )
     then
@@ -235,7 +295,7 @@ end
 
 rule Event
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : EventCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did )
     then
@@ -252,7 +312,7 @@ end
 // when the next datum for dataId arrives in working memory.
 rule ProvideInitialRateData
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c : RateCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d : Data( tenantId == $tenantId, source == $tsource, id == $did )
         not  RateData( data.tenantId == $tenantId, data.source == $tsource, data.id == $did )
@@ -267,7 +327,7 @@ end
 // Given previous and current data for a given dataId, perform a RateCondition evaluation.
 rule Rate
     when
-        $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t  : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c  : RateCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId )
         $d  : Data( tenantId == $tenantId, source == $tsource, id == $did, $dt : timestamp )
         $rd : RateData( data.tenantId == $tenantId, data.source == $tsource, data.id == $did, data.timestamp < $dt )
@@ -300,7 +360,7 @@ end
 // Given current data and a NelsonData for a given dataId, perform a NelsonCondition evaluation.
 rule Nelson
     when
-        $t  : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source )
+        $t  : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $tsource : source, enabled == true )
         $c  : NelsonCondition ( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, $did : dataId,
                                 $cid : conditionId )
         $d  : Data( tenantId == $tenantId, source == $tsource, id == $did )
@@ -471,23 +531,37 @@ end
 
 // Dampening update rules
 
-rule ProvideDefaultDampening
+rule ProvideDefaultSourceDampening
     when
-        $t : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode )
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $source : source, enabled == true )
         not Dampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode )
+        not SourceDampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, source == $source )
     then
         if (log != null && log.isDebugEnabled()) {
-            log.debugf("Adding default %s dampening for trigger! %s", $tmode, $t.getId());
+            log.debugf("Adding default %s SourceDampening for SourceTrigger %s", $tmode, $t);
         }
-        Dampening d = Dampening.forStrict( $tenantId, $tid, $tmode, 1 );
-        insert( d );
+        SourceDampening sd = new SourceDampening($source, Dampening.forStrict( $tenantId, $tid, $tmode, 1 ));
+        insert( sd );
+end
+
+rule ProvideSourceDampening
+    when
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $source : source, enabled == true )
+        $d : Dampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode )
+        not SourceDampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, source == $source )
+    then
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Adding %s SourceDampening for SourceTrigger %s", $tmode, $t);
+        }
+        SourceDampening sd = new SourceDampening($source, $d);
+        insert( sd );
 end
 
 // Group all of the ConditionEvals for a trigger (1 or more) as a Set, and update the trigger's dampening
 rule DampenTrigger
     when
-        $t   : Trigger( $tenantId : tenantId, $tid : id, $tmode : mode )
-        $d   : Dampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, satisfied == false )
+        $t   : SourceTrigger( $tenantId : tenantId, $tid : id, $tmode : mode, $source : source, enabled == true )
+        $d   : SourceDampening( tenantId == $tenantId, triggerId == $tid, triggerMode == $tmode, source == $source, satisfied == false )
         not    Data( )
         not    Event( )
         $ces : Set( size > 0 )
@@ -516,7 +590,7 @@ end
 // timeouts when the dampening is reset.
 rule DampeningTimeoutAdd
     when
-        $d   : Dampening( type == Type.STRICT_TIMEOUT, numTrueEvals == 1, satisfied == false )
+        $d   : SourceDampening( type == Type.STRICT_TIMEOUT, numTrueEvals == 1, satisfied == false )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debugf( "DampeningTimeoutAdd %s", $d );
@@ -528,7 +602,7 @@ end
 //       it is fairly lightweight. 
 rule DampeningTimeoutRemove
     when
-        $d   : Dampening( type == Type.STRICT_TIMEOUT, numTrueEvals == 0, satisfied == false )
+        $d   : SourceDampening( type == Type.STRICT_TIMEOUT, numTrueEvals == 0, satisfied == false )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debugf( "DampeningTimeoutRemove %s", $d );
@@ -542,31 +616,31 @@ end
 
 // If a Trigger's FIRE mode Dampening is satisfied, then the Trigger fires and generates an Alert.  The Trigger's
 // FIRE mode Dampening fact is then reset and updated in working memory, ready to again track evals for the Trigger.
-// If the Trigger has safety mode enabled then we toggle the Trigger to SAFETY mode and it can not fire again
-// until the safety mode Dampening is satisfied and the Trigger returns to FIRE mode.
+// If the Trigger has autoresolve enabled then we toggle the Trigger to AUTORESOLVE mode and it can not fire again
+// until the AURTORESOLVE is satisfied and the Trigger returns to FIRING mode.
 rule AlertOnSatisfiedDampening
     when
-        $t  : Trigger( mode == Mode.FIRING, $tenantId : tenantId, $tid : id )
-        $d  : Dampening( triggerMode == Mode.FIRING, tenantId == $tenantId, triggerId == $tid, satisfied == true )
+        $t  : SourceTrigger( mode == Mode.FIRING, $tenantId : tenantId, $tid : id, $source : source, enabled == true )
+        $d  : SourceDampening( triggerMode == Mode.FIRING, tenantId == $tenantId, triggerId == $tid, source == $source, satisfied == true )
     then
         Event newEvent;
 
         // Only some triggers generate an alert
-        if ($t.getEventType() == EventType.ALERT) {
+        if ($t.getTrigger().getEventType() == EventType.ALERT) {
             if (log != null && log.isDebugEnabled()) {
                 log.debugf("Alert! Dampening Satisfied! %s", $d.log());
             }
 
-            newEvent = new Alert( $t.getTenantId(), $t, $d, $d.getSatisfyingEvals() );
+            newEvent = new Alert( $t.getTenantId(), $t.getTrigger(), $d.getDampening(), $source, $d.getSatisfyingEvals() );
             // Adding an Alert will implicitly add the related Event
             alerts.add((Alert)newEvent);
 
         } else {
-            if (log != null && log.isDebugEnabled() && $t.getEventType() == EventType.EVENT) {
+            if (log != null && log.isDebugEnabled() && $t.getTrigger().getEventType() == EventType.EVENT) {
                 log.debugf("Event! Dampening Satisfied! %s", $d.log());
             }
 
-            newEvent = new Event( $t.getTenantId(), $t, $d, $d.getSatisfyingEvals() );
+            newEvent = new Event( $t.getTenantId(), $t.getTrigger(), $d.getDampening(), $source, $d.getSatisfyingEvals() );
             events.add(newEvent);
         }
 
@@ -574,53 +648,48 @@ rule AlertOnSatisfiedDampening
         insert( newEvent );
 
         if (actions != null) {
-            actions.send($t, newEvent);
+            actions.send($t.getTrigger(), newEvent);
         }
 
         retract( $d );
         $d.reset();
         insert( $d );
 
-        if ($t.isAutoResolve()) {
+        if ($t.getTrigger().isAutoResolve()) {
             log.debugf("Setting Trigger to AutoResolve Mode! %s", $t);
             modify($t) {
                setMode(Mode.AUTORESOLVE)
             }
-        } else if ($t.isAutoDisable()) {
-            if (log != null && log.isDebugEnabled()) {
-                log.debugf("Setting Trigger Disabled! %s", $t);
+        } else if ($t.getTrigger().isAutoDisable()) {
+            log.debugf("Setting Trigger Disabled! %s", $t);
+            modify($t) {
+               setEnabled(false)
             }
-
-            // the autoDisable trigger handling will result in a trigger reload, so we can just retract the
-            // current definition. And given that it will be disabled, it actually will not get loaded.
-            disabledTriggers.add( $t );
-
-            retract( $t );
-
+            disabledSourceTriggers.add($t);
         } else {
-            if (log != null && log.isDebugEnabled()) {
-                log.debugf("Trigger remains in Firing mode, AutoDisable and AutoResolve not set. %s", $t);
-            }
+           log.debugf("Trigger remains in Firing mode, AutoDisable and AutoResolve not set. %s", $t);
         }
 end
 
 
 rule SetFiringModeOnSatisfiedDampening
     when
-        $t  : Trigger( mode == Mode.AUTORESOLVE, $tenantId : tenantId, $tid : id )
-        $d  : Dampening( triggerMode == Mode.AUTORESOLVE, tenantId == $tenantId, triggerId == $tid, satisfied == true )
+        $t  : SourceTrigger( mode == Mode.AUTORESOLVE, $tenantId : tenantId, $tid : id, $source : source, enabled == true )
+        $d  : SourceDampening( triggerMode == Mode.AUTORESOLVE, tenantId == $tenantId, triggerId == $tid, source == $source, satisfied == true )
     then
         if (log != null && log.isDebugEnabled()) {
             log.debugf("SetFiringModeOnSatisfiedDampening! %s", $d.log());
         }
 
-        // the autoResolved trigger handling will result in a trigger reload, so we can just retract the
-        // current definition. We set it to FIRING mode but that is mainly a cosmetic change and affects
-        // only the Trigger instance placed into autoResolvedTriggers.
-        $t.setMode(Mode.FIRING);
-        autoResolvedTriggers.put( $t, $d.getSatisfyingEvals() );
+        modify($t) {
+           setMode(Mode.FIRING)
+        }
 
-        retract( $t );
+        autoResolvedSourceTriggers.put( $t, $d.getSatisfyingEvals() );
+
+        retract( $d );
+        $d.reset();
+        insert( $d );
 end
 
 
@@ -629,6 +698,30 @@ end
 // If a trigger is retracted these rules will ensure all associated facts are removed. This only assures
 // a clean working memory if the trigger is retracted while rules are firing. If a Trigger fact is removed via
 // the API while the rule-base is not firing, then these rules don't fire and manual cleanup may be necessary.
+
+rule retractOrphanSourceTrigger
+    when
+        $t : SourceTrigger( $tenantId : tenantId, $tid : id )
+        not  Trigger( tenantId == $tenantId, id == $tid )
+    then
+        retract( $t )
+
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Retract SourceTrigger with no Trigger. %s", $t);
+        }
+end
+
+rule retractOrphanSourceDampening
+    when
+        $d : SourceDampening( $tenantId : tenantId, $tid : triggerId, $source : source )
+        not  SourceTrigger( tenantId == $tenantId, id == $tid, source == $source )
+    then
+        retract( $d )
+
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Retract SourceDampening with no SourceTrigger. %s", $d);
+        }
+end
 
 rule retractOrphanDampening
     when

--- a/engine/src/test/java/org/hawkular/alerts/engine/PerfRulesEngineTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/PerfRulesEngineTest.java
@@ -27,13 +27,13 @@ import org.hawkular.alerts.api.model.condition.CompareCondition;
 import org.hawkular.alerts.api.model.condition.StringCondition;
 import org.hawkular.alerts.api.model.condition.ThresholdCondition;
 import org.hawkular.alerts.api.model.condition.ThresholdRangeCondition;
-import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.AvailabilityType;
 import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.alerts.engine.impl.DroolsRulesEngineImpl;
 import org.hawkular.alerts.engine.service.RulesEngine;
+import org.hawkular.alerts.engine.util.SourceDampening;
 import org.hawkular.commons.log.MsgLogger;
 import org.hawkular.commons.log.MsgLogging;
 import org.junit.After;
@@ -58,7 +58,7 @@ public class PerfRulesEngineTest {
 
     RulesEngine rulesEngine = new DroolsRulesEngineImpl();
     List<Alert> alerts = new ArrayList<>();
-    Set<Dampening> pendingTimeouts = new HashSet<>();
+    Set<SourceDampening> pendingTimeouts = new HashSet<>();
     TreeSet<Data> datums = new TreeSet<Data>();
 
     @Before

--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnAlertsServiceImplTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hawkular.alerts.api.model.Severity;
+import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.event.Event;
 import org.hawkular.alerts.api.services.AlertsCriteria;
@@ -575,7 +575,8 @@ public class IspnAlertsServiceImplTest extends IspnBaseServiceImplTest {
         int numAlerts = 5;
         createTestAlerts(numTenants, numTriggers, numAlerts);
 
-        alerts.resolveAlertsForTrigger("tenant0", "trigger0", "test", "RESOLVED from resolveAlert() test", null);
+        alerts.resolveAlertsForTrigger("tenant0", "trigger0", Data.SOURCE_NONE, "test",
+                "RESOLVED from resolveAlert() test", null);
 
         AlertsCriteria criteria = new AlertsCriteria();
         criteria.setStatus(Alert.Status.RESOLVED);

--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnBaseServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnBaseServiceImplTest.java
@@ -155,7 +155,7 @@ public abstract class IspnBaseServiceImplTest {
                     evalSet.add(eval);
                     List<Set<ConditionEval>> evals = new ArrayList<>();
                     evals.add(evalSet);
-                    Alert alertX = new Alert(tenantId, triggerX, evals);
+                    Alert alertX = new Alert(tenantId, triggerX, Data.SOURCE_NONE, evals);
                     // Hack to set up the right ctime for tests
                     alertX.setCtime(alert + 1);
                     alertX.getCurrentLifecycle().setStime(alert + 1);

--- a/itests/src/test/groovy/org/hawkular/alerts/rest/EventsLifecycleITest.groovy
+++ b/itests/src/test/groovy/org/hawkular/alerts/rest/EventsLifecycleITest.groovy
@@ -386,8 +386,20 @@ class EventsLifecycleITest extends AbstractITestBase {
         resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t04",enabled:true])
         assertEquals(200, resp.status)
 
-        // Wait for 7 seconds to fire the missing events
-        Thread.sleep(7000);
+        // Send in initial event to initiate MissingState checking, then send no more to cause a violation.
+        String jsonEventTest04Id = UUID.randomUUID().toString();
+        String jsonEventTest04 = "[{" +
+                "\"id\":\"" + jsonEventTest04Id + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"Test04\"," +
+                "\"dataId\":\"event-data-id-t04\"," +
+                "\"text\":\"Test04 text\"" +
+                "}]";
+        resp = client.post(path: "events/data", body: jsonEventTest04);
+        assertEquals(200, resp.status)
+
+        // Wait for 8 seconds to fire the missing events
+        Thread.sleep(8000);
 
         resp = client.get(path: "events", query: [startTime:start,triggerIds:"test-events-t04"] )
         assertEquals(200, resp.status)
@@ -428,8 +440,7 @@ class EventsLifecycleITest extends AbstractITestBase {
         resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t05",enabled:true])
         assertEquals(200, resp.status)
 
-        Thread.sleep(2000);
-
+        // Send in initial event to initiate MissingState checking
         String jsonEventTest05Id = UUID.randomUUID().toString();
         String jsonEventTest05 = "[{" +
                 "\"id\":\"" + jsonEventTest05Id + "\"," +
@@ -438,10 +449,10 @@ class EventsLifecycleITest extends AbstractITestBase {
                 "\"dataId\":\"event-data-id-t05\"," +
                 "\"text\":\"Test05 text\"" +
                 "}]";
-
         resp = client.post(path: "events/data", body: jsonEventTest05);
         assertEquals(200, resp.status)
 
+        // send another after 2s, should not cause a violation
         Thread.sleep(2000);
 
         jsonEventTest05Id = UUID.randomUUID().toString();
@@ -452,10 +463,10 @@ class EventsLifecycleITest extends AbstractITestBase {
                 "\"dataId\":\"event-data-id-t05\"," +
                 "\"text\":\"Test05 text\"" +
                 "}]";
-
         resp = client.post(path: "events/data", body: jsonEventTest05);
         assertEquals(200, resp.status)
 
+        // send another after 2s, should not cause a violation
         Thread.sleep(2000);
 
         jsonEventTest05Id = UUID.randomUUID().toString();
@@ -466,7 +477,20 @@ class EventsLifecycleITest extends AbstractITestBase {
                 "\"dataId\":\"event-data-id-t05\"," +
                 "\"text\":\"Test05 text\"" +
                 "}]";
+        resp = client.post(path: "events/data", body: jsonEventTest05);
+        assertEquals(200, resp.status)
 
+        // send another after 2s, should not cause a violation
+        Thread.sleep(2000);
+
+        jsonEventTest05Id = UUID.randomUUID().toString();
+        jsonEventTest05 = "[{" +
+                "\"id\":\"" + jsonEventTest05Id + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"Test05\"," +
+                "\"dataId\":\"event-data-id-t05\"," +
+                "\"text\":\"Test05 text\"" +
+                "}]";
         resp = client.post(path: "events/data", body: jsonEventTest05);
         assertEquals(200, resp.status)
 

--- a/itests/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
+++ b/itests/src/test/java/org/hawkular/alerts/engine/PersistenceTest.java
@@ -980,7 +980,7 @@ public abstract class PersistenceTest {
         evalSet.add(eval);
         List<Set<ConditionEval>> evals = new ArrayList<>();
         evals.add(evalSet);
-        Alert alert = new Alert(TENANT, t, evals);
+        Alert alert = new Alert(TENANT, t, Data.SOURCE_NONE, evals);
         alert.addTag("test.subtest.subname", "value.subvalue");
         List<Alert> alerts = new ArrayList<>();
         alerts.add(alert);
@@ -1136,7 +1136,7 @@ public abstract class PersistenceTest {
             evalSet.add(eval);
             List<Set<ConditionEval>> evals = new ArrayList<>();
             evals.add(evalSet);
-            Alert alert = new Alert(TENANT, t, evals);
+            Alert alert = new Alert(TENANT, t, Data.SOURCE_NONE, evals);
             int iAlert = i % 3;
             switch (iAlert) {
                 case 2:
@@ -1408,7 +1408,7 @@ public abstract class PersistenceTest {
         evalSet.add(eval);
         List<Set<ConditionEval>> evals = new ArrayList<>();
         evals.add(evalSet);
-        Event event = new Event(TENANT, t, null, evals);
+        Event event = new Event(TENANT, t, null, Data.SOURCE_NONE, evals);
         List<Event> events = new ArrayList<>();
         events.add(event);
 
@@ -1547,7 +1547,7 @@ public abstract class PersistenceTest {
             evalSet.add(eval);
             List<Set<ConditionEval>> evals = new ArrayList<>();
             evals.add(evalSet);
-            Event event = new Event(TENANT, t, null, evals);
+            Event event = new Event(TENANT, t, null, Data.SOURCE_NONE, evals);
             int iEvent = i % 3;
             switch (iEvent) {
                 case 2:
@@ -2052,7 +2052,7 @@ public abstract class PersistenceTest {
     @Test
     public void test0120BasicNotesOnAlert() throws Exception {
         Trigger t = new Trigger("non-existence-trigger", "non-existence-trigger");
-        Alert testAlert = new Alert(TENANT, t, null);
+        Alert testAlert = new Alert(TENANT, t, Data.SOURCE_NONE, null);
 
         alertsService.addAlerts(Collections.singletonList(testAlert));
 
@@ -2080,7 +2080,7 @@ public abstract class PersistenceTest {
         t.addTag("TriggerTag1Name", "TriggerTag1Value");
         t.addTag("TriggerTag2Name", "TriggerTag2Value");
 
-        Alert testAlert = new Alert(TENANT, t, null);
+        Alert testAlert = new Alert(TENANT, t, Data.SOURCE_NONE, null);
 
         alertsService.addAlerts(Collections.singletonList(testAlert));
 
@@ -2208,7 +2208,7 @@ public abstract class PersistenceTest {
 
         List<Alert> alerts = new ArrayList<>();
         for (int i=0; i<10; i++) {
-            alerts.add(new Alert(TENANT, t, null));
+            alerts.add(new Alert(TENANT, t, Data.SOURCE_NONE, null));
         }
 
         alertsService.addAlerts(alerts);
@@ -2527,7 +2527,7 @@ public abstract class PersistenceTest {
         t.addTag("TriggerTag1Name", "TriggerTag1Value");
         t.addTag("TriggerTag2Name", "TriggerTag2Value");
 
-        Event testEvent = new Event(TENANT, t, null, null);
+        Event testEvent = new Event(TENANT, t, null, Data.SOURCE_NONE, null);
 
         alertsService.persistEvents(Collections.singletonList(testEvent));
 
@@ -2655,7 +2655,7 @@ public abstract class PersistenceTest {
 
         List<Event> events = new ArrayList<>();
         for (int i=0; i<10; i++) {
-            events.add(new Event(new Alert(TENANT, t, null)));
+            events.add(new Event(new Alert(TENANT, t, Data.SOURCE_NONE, null)));
         }
 
         alertsService.persistEvents(events);
@@ -3092,7 +3092,7 @@ public abstract class PersistenceTest {
         for (int i = 1; i <= numAlerts; ++i) {
             t.setSeverity(Severity.values()[i % Severity.values().length]);
             Alert.Status status = Alert.Status.values()[i % Alert.Status.values().length];
-            Alert a = new Alert(TENANT, t, null);
+            Alert a = new Alert(TENANT, t, Data.SOURCE_NONE, null);
             a.setCtime(i);
             if (status != Alert.Status.OPEN) {
                 a.addLifecycle(status, "test", i);
@@ -3138,7 +3138,7 @@ public abstract class PersistenceTest {
             Trigger t = new Trigger(tenantId, "test0300GetAlertsMultipleTenants");
             Collection<Alert> alerts = new ArrayList<>(numAlerts);
             for (int i = 0; i < numAlerts; ++i) {
-                Alert a = new Alert(tenantId, t, null);
+                Alert a = new Alert(tenantId, t, Data.SOURCE_NONE, null);
                 a.setCtime(i);
                 alerts.add(a);
             }


### PR DESCRIPTION
Do Not Merge until reviewed and dicussed.  PR opened for review and to keep in sync with master. 

I spent a few days investigating this somewhat major change to trigger semantics. In short it merges the data-driven group trigger feature into standard triggers. Put another way, it lets a single trigger handle data/events from N sources. The big difference is that it does it without using a backing group trigger. It's not totally seamless, there are some behavioral differences but I think the benefits justify the changes.

Here is a diagram of the approach:

![native data-driven triggers](https://user-images.githubusercontent.com/2104052/29837699-e1dd0f2c-8cc6-11e7-97cd-8f8850e5195d.png)
