### PR TITLE
Fix broken pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
   <version>2.0.0.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-
   <name>Hawkular Alerting</name>
   <description>Alerting subsystem for Hawkular</description>
   <url>https://github.com/hawkular/hawkular-alerts</url>
@@ -136,7 +135,9 @@
     <profile>
       <id>default</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!dummy</name>
+        </property>
       </activation>
       <modules>
         <module>alerters</module>
@@ -170,7 +171,9 @@
     <profile>
       <id>actions</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!dummy</name>
+        </property>
       </activation>
       <modules>
         <module>actions</module>


### PR DESCRIPTION
- Multiple activeByDefault properties with other activation profiles disable the expected profiles

mvn clean install didn't work by default and Travis CI was working with an empty profile as it showed green results this escaped from previous review.

