### PR TITLE
Gnocchi Alerter

### DIFF
--- a/alerters/alerters-plugins/alerters-gnocchi/pom.xml
+++ b/alerters/alerters-plugins/alerters-gnocchi/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.alerts</groupId>
+    <artifactId>hawkular-alerts-alerters-plugins</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hawkular-alerts-alerters-gnocchi</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular Alerting: Alerter Gnocchi Plugin</name>
+
+  <dependencies>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <version>${version.junit}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiAlerter.java
+++ b/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiAlerter.java
@@ -184,6 +184,17 @@ import org.hawkular.commons.properties.HawkularProperties;
  *
  *   The aggregated metric will be used as Data.dataId field in Hawkular Alerting to be referred in conditions.
  *
+ * - [Optional]     trigger.context["metric.granularity"] = "<Gnocchi metric granularity>"
+ *
+ *   The alerter can define the granularity of the metrics defined.
+ *   If not present granularity is set to 300.
+ *
+ *   i.e.
+ *
+ *      trigger.context["metric.granularity"] = "1"
+ *
+ *   Granularity defined will be annotated in the context of Hawkular Data.
+ *
  * </pre>
  *
  * @author Jay Shaughnessy

--- a/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiAlerter.java
+++ b/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiAlerter.java
@@ -1,0 +1,380 @@
+package org.hawkular.alerter.gnocchi;
+
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.hawkular.alerts.alerters.api.Alerter;
+import org.hawkular.alerts.alerters.api.AlerterPlugin;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.model.trigger.TriggerKey;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.alerts.api.services.DistributedEvent;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+import org.hawkular.commons.properties.HawkularProperties;
+
+/**
+ * This is the main class of the GnocchiAlerter Alerter.
+ *
+ * The Gnocchi Alerter will listen for triggers tagged with "Gnocchi" tag. The Alerter will schedule a
+ * periodic query to an Gnocchi system with the info provided from the tagged trigger context. The Alerter
+ * will convert Gnocchi metric measures into Hawkular Alerting data and send them into the Alerting engine.
+ *
+ * The Gnocchi Alerter uses the following conventions for trigger tags and context:
+ *
+ * <pre>
+ *
+ * - [Required]    trigger.tags["Gnocchi"] = "<value reserved for future uses>"
+ *
+ *   An "Gnocchi" tag is required for the alerter to detect this trigger will query to an Gnocchi system.
+ *   Value is not necessary, it can be used as a description, it is reserved for future uses.
+ *
+ *   i.e.   trigger.tags["Gnocchi"] = ""                              // Empty value is valid
+ *          trigger.tags["Gnocchi"] = "OpenStack Development System"  // It can be used as description
+ *
+ * - [Optional]    trigger.context["interval"] = "[0-9]+[smh]"  (i.e. 30s, 2h, 10m)
+ *
+ *   Defines the periodic interval when a query will be performed against an Gnocchi system.
+ *   If not value provided, default one is "2m" (two minutes).
+ *
+ *   i.e.   trigger.context["interval"] = "30s" will perform queries each 30 seconds fetching new data generated
+ *          on the last 30 seconds.
+ *
+ * - [Optional]    trigger.context["url"] = "<Gnocchi server url>"
+ *
+ *   Gnocchi url can be defined in several ways in the alerter.
+ *   If can be defined globally as system properties:
+ *
+ *      hawkular-alerts.gnocchi-url
+ *
+ *   It can be defined globally from system env variables:
+ *
+ *      GNOCCHI_URL
+ *
+ *   Or it can be overwritten per trigger using
+ *
+ *      trigger.context["url"]
+ *
+ *   By default it will point to
+ *
+ *      trigger.context["url"] = "http://localhost:8041"
+ *
+ * - [Optional]    trigger.context["user"] = "<Gnocchi server user>"
+ *
+ *   Gnocchi user can be defined in several ways in the alerter.
+ *   If can be defined globally as system properties:
+ *
+ *      hawkular-alerts.gnocchi-user
+ *
+ *   It can be defined globally from system env variables:
+ *
+ *      GNOCCHI_USER
+ *
+ *   Or it can be overwritten per trigger using
+ *
+ *      trigger.context["user"]
+ *
+ *   By default it will point to
+ *
+ *      trigger.context["user"] = "admin"
+ *
+ * - [Optional]    trigger.context["password"] = "Gnocchi server password>"
+ *
+ *   Gnocchi password can be defined in several ways in the alerter.
+ *   If can be defined globally as system properties:
+ *
+ *      hawkular-alerts.gnocchi-password
+ *
+ *   It can be defined globally from system env variables:
+ *
+ *      GNOCCHI_PASSWORD
+ *
+ *   Or it can be overwritten per trigger using
+ *
+ *      trigger.context["password"]
+ *
+ *   By default it will point to
+ *
+ *      trigger.context["password"] = "admin"
+ *
+ * - [Optional]    trigger.context["metric.ids"] = "<list of Gnocchi metric ids to fetch>"
+ *
+ *   The alerter fetches for Gnocchi metrics to use them into the alerting engine.
+ *   Metrics can be defined in several ways, first one is using Gnocchi metric ids.
+ *
+ *   i.e.
+ *
+ *      trigger.context["metric.ids"] = "0062038b-af87-4f5c-b250-72c986037fa2,01320e1e-0aeb-4e17-9402-d2450b2e0024"
+ *
+ *   The metric id will be used as Data.dataId field in Hawkular Alerting to be referred in conditions.
+ *
+ *   If "metric.ids" property is present, the alerter will ignore other ways to define Gnocchi metrics to fetch.
+ *
+ * - [Optional]    trigger.context["metric.names"] = "<list of Gnocchi metric names to fetch>"
+ *
+ *   If "metric.ids" is not present the alerter will use the "metric.names" property.
+ *   A list of metrics names will be used to fetch Gnocchi metrics.
+ *
+ *   i.e.
+ *
+ *      trigger.context["metric.names"] = "cpu-0@cpu-user-0,cpu-1@cpu-user-0,cpu-2@cpu-user-0"
+ *
+ *   The metric name will be used as Data.dataId field in Hawkular Alerting to be referred in conditions.
+ *   Metric names are not unique in Gnocchi, so user should be aware that the alerter will use first match with the
+ *   metric name defined, on the contrary, metric names are more clear to use in trigger definitions rather than
+ *   metric ids (based on UUID formats).
+ *
+ *  In priorities, "metric.names" will be used if not "metric.ids" property is defined, other ways to define Gnocchi
+ *  metrics will be ingored.
+ *
+ * - [Optional]    trigger.context["metric.names.regexp"] = "<regular expression>"
+ *
+ *   If "metric.ids" or "metric.names" are not defined, the alerter will use "metric.names.regexp" property.
+ *   A regular expression will be used to match metric names.
+ *
+ *   i.e.
+ *
+ *      trigger.context["metric.names.regexp"] = "cpu-.@cpu.*"
+ *
+ *   The metric name will be used as Data.dataId field in Hawkular Alerting to be referred in conditions.
+ *   Metric names are not unique in Gnocchi, so user should be aware that the alerter will use first match with the
+ *   metric name defined, on the contrary, metric names are more clear to use in trigger definitions rather than
+ *   metric ids (based on UUID formats).
+ *
+ * - [Optional]    trigger.context["metric.resource.query"] = "<a Gnocchi search resource query>"
+ *
+ *   By default, the alerter will search metrics from all resources.
+ *   It is possible to define a Gnocchi query to limit the metric search to a particular set of resources.
+ *
+ *   i.e.
+ *
+ *      trigger.context["metric.resource.query"] = "{\"like\":{\"type\":\"c%\"}}"
+ *
+ *   This parameter will search metrics only (by ids, names or regexp, as described below) on resources which type starts with "c".
+ *
+ *   For more details about format and supported Gnocchi queries
+ *
+ *      http://gnocchi.xyz/stable_3.0/rest.html#searching-for-resources
+ *
+ * - [Optional]     trigger.context["metric.aggregation"] = "<aggregated_metric_name>=<aggregated_function>(<list_of_metric_names>|<regexp>);..."
+ *
+ *   A powerful feature of Gnocchi is to work with aggregated metrics.
+ *   The alerter can define an aggregated metric name and the expression to calculate it.
+ *
+ *   i.e.
+ *
+ *      Aggregated metrics can be defined explicitly from a list of metric names:
+ *
+ *      trigger.context["metric.aggregation"] = "cpu-user=mean(cpu-0@cpu-user-0,cpu-1@cpu-user-0);cpu-nice=mean(cpu-0@cpu-nice-0,cpu-1@cpu-nice-0)"
+ *
+ *      or they can be defined using regular expressions:
+ *
+ *      trigger.context["metric.aggregation"] = "cpu-user=mean(cpu-.@cpu-user-.*);cpu-nice=mean(cpu-.@cpu-nice-.*)"
+ *
+ *   The aggregated metric will be used as Data.dataId field in Hawkular Alerting to be referred in conditions.
+ *
+ * </pre>
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@Alerter(name = "gnocchi")
+public class GnocchiAlerter implements AlerterPlugin {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(GnocchiAlerter.class);
+
+    public static final String GNOCCHI_ALERTER = "hawkular-alerts.gnocchi-alerter";
+    public static final String GNOCCHI_ALERTER_ENV = "GNOCCHI_ALERTER";
+    public static final String GNOCCHI_ALERTER_DEFAULT = "true";
+    public boolean gnocchiAlerter;
+
+    public static final String GNOCCHI_URL = "hawkular-alerts.gnocchi-url";
+    public static final String GNOCCHI_URL_ENV = "GNOCCHI_URL";
+    public static final String GNOCCHI_URL_DEFAULT = "http://localhost:8041";
+
+    public static final String GNOCCHI_USER = "hawkular-alerts.gnocchi-user";
+    public static final String GNOCCHI_USER_ENV = "GNOCCHI_USER";
+    public static final String GNOCCHI_USER_DEFAULT = "admin";
+
+    public static final String GNOCCHI_PASSWORD ="hawkular-alerts.gnocchi-password";
+    public static final String GNOCCHI_PASSWORD_ENV = "GNOCCHI_PASSWORD";
+    public static final String GNOCCHI_PASSWORD_DEFAULT = "admin";
+
+    public static final String INTERVAL = "interval";
+    public static final String INTERVAL_DEFAULT = "2m";
+    public static final String URL = "url";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
+
+    private static final String ALERTER_NAME = "Gnocchi";
+
+    private Map<TriggerKey, Trigger> activeTriggers = new ConcurrentHashMap<>();
+
+    private static final Integer THREAD_POOL_SIZE = 20;
+
+
+    private ScheduledThreadPoolExecutor scheduledExecutor;
+    private Map<TriggerKey, ScheduledFuture<?>> queryFutures = new HashMap<>();
+
+    private Map<String, String> defaultProperties;
+
+    private DefinitionsService definitions;
+
+    private AlertsService alerts;
+
+    private ExecutorService executor;
+
+    @Override
+    public void init(DefinitionsService definitions, AlertsService alerts, ExecutorService executor) {
+        if (definitions == null || alerts == null || executor == null) {
+            throw new IllegalStateException("Gnocchi Alerter cannot connect with Hawkular Alerting");
+        }
+        this.definitions = definitions;
+        this.alerts = alerts;
+        this.executor = executor;
+        gnocchiAlerter = Boolean.parseBoolean(HawkularProperties.getProperty(GNOCCHI_ALERTER, GNOCCHI_ALERTER_ENV, GNOCCHI_ALERTER_DEFAULT));
+        defaultProperties = new HashMap();
+        defaultProperties.put(URL, HawkularProperties.getProperty(GNOCCHI_URL, GNOCCHI_URL_ENV, GNOCCHI_URL_DEFAULT));
+        defaultProperties.put(USER, HawkularProperties.getProperty(GNOCCHI_USER, GNOCCHI_USER_ENV, GNOCCHI_USER_DEFAULT));
+        defaultProperties.put(PASSWORD, HawkularProperties.getProperty(GNOCCHI_PASSWORD, GNOCCHI_PASSWORD_ENV, GNOCCHI_PASSWORD_DEFAULT));
+
+        if (gnocchiAlerter) {
+            this.definitions.registerDistributedListener(events -> refresh(events));
+            initialRefresh();
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdown();
+            scheduledExecutor = null;
+        }
+    }
+
+    private void refresh(Set<DistributedEvent> distEvents) {
+        log.debugf("Events received %s", distEvents);
+        executor.submit(() -> {
+            try {
+                for (DistributedEvent distEvent : distEvents) {
+                    TriggerKey triggerKey = new TriggerKey(distEvent.getTenantId(), distEvent.getTriggerId());
+                    switch (distEvent.getOperation()) {
+                        case REMOVE:
+                            activeTriggers.remove(triggerKey);
+                            break;
+                        case ADD:
+                            if (activeTriggers.containsKey(triggerKey)) {
+                                break;
+                            }
+                        case UPDATE:
+                            Trigger trigger = definitions.getTrigger(distEvent.getTenantId(), distEvent.getTriggerId());
+                            if (trigger != null && trigger.getTags().containsKey(ALERTER_NAME)) {
+                                if (!trigger.isLoadable()) {
+                                    activeTriggers.remove(triggerKey);
+                                    break;
+                                } else {
+                                    activeTriggers.put(triggerKey, trigger);
+                                }
+                            }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch Triggers for external conditions.", e);
+            }
+            update();
+        });
+    }
+
+    private void initialRefresh() {
+        try {
+            Collection<Trigger> triggers = definitions.getAllTriggersByTag(ALERTER_NAME, "*");
+            triggers.stream().forEach(trigger -> activeTriggers.put(new TriggerKey(trigger.getTenantId(), trigger.getId()), trigger));
+            update();
+        } catch (Exception e) {
+            log.error("Failed to fetch Triggers for external conditions.", e);
+        }
+    }
+
+    private synchronized void update() {
+        final Set<TriggerKey> existingKeys = queryFutures.keySet();
+        final Set<TriggerKey> activeKeys = activeTriggers.keySet();
+
+        Set<TriggerKey> newKeys = new HashSet<>();
+        Set<TriggerKey> canceledKeys = new HashSet<>();
+
+        Set<TriggerKey> updatedKeys = new HashSet<>(activeKeys);
+        updatedKeys.retainAll(activeKeys);
+
+        activeKeys.stream().filter(key -> !existingKeys.contains(key)).forEach(key -> newKeys.add(key));
+        existingKeys.stream().filter(key -> !activeKeys.contains(key)).forEach(key -> canceledKeys.add(key));
+
+        log.debugf("newKeys %s", newKeys);
+        log.debugf("updatedKeys %s", updatedKeys);
+        log.debugf("canceledKeys %s", canceledKeys);
+
+        canceledKeys.stream().forEach(key -> {
+            ScheduledFuture canceled = queryFutures.remove(key);
+            if (canceled != null) {
+                canceled.cancel(false);
+            }
+        });
+        updatedKeys.stream().forEach(key -> {
+            ScheduledFuture updated = queryFutures.remove(key);
+            if (updated != null) {
+                updated.cancel(false);
+            }
+        });
+
+        if (scheduledExecutor == null) {
+            scheduledExecutor = new ScheduledThreadPoolExecutor(THREAD_POOL_SIZE);
+        }
+
+        newKeys.addAll(updatedKeys);
+
+        for (TriggerKey key : newKeys) {
+            Trigger t = activeTriggers.get(key);
+            String interval = t.getContext().get(INTERVAL) == null ? INTERVAL_DEFAULT : t.getContext().get(INTERVAL);
+            queryFutures.put(key, scheduledExecutor
+                .scheduleAtFixedRate(new GnocchiQuery(t, defaultProperties, alerts), 0L,
+                        getIntervalValue(interval), getIntervalUnit(interval)));
+        }
+    }
+
+    public static int getIntervalValue(String interval) {
+        if (isEmpty(interval)) {
+            interval = INTERVAL_DEFAULT;
+        }
+        try {
+            return new Integer(interval.substring(0, interval.length() - 1)).intValue();
+        } catch (Exception e) {
+            return new Integer(INTERVAL_DEFAULT.substring(0, interval.length() - 1)).intValue();
+        }
+    }
+
+    public static TimeUnit getIntervalUnit(String interval) {
+        if (interval == null || interval.isEmpty()) {
+            interval = INTERVAL_DEFAULT;
+        }
+        char unit = interval.charAt(interval.length() - 1);
+        switch (unit) {
+            case 'h':
+                return TimeUnit.HOURS;
+            case 's':
+                return TimeUnit.SECONDS;
+            case 'm':
+            default:
+                return TimeUnit.MINUTES;
+        }
+    }
+
+}

--- a/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiQuery.java
+++ b/alerters/alerters-plugins/alerters-gnocchi/src/main/java/org/hawkular/alerter/gnocchi/GnocchiQuery.java
@@ -1,0 +1,391 @@
+package org.hawkular.alerter.gnocchi;
+
+import static org.hawkular.alerter.gnocchi.GnocchiAlerter.GNOCCHI_USER;
+import static org.hawkular.alerter.gnocchi.GnocchiAlerter.INTERVAL;
+import static org.hawkular.alerter.gnocchi.GnocchiAlerter.INTERVAL_DEFAULT;
+import static org.hawkular.alerter.gnocchi.GnocchiAlerter.getIntervalUnit;
+import static org.hawkular.alerter.gnocchi.GnocchiAlerter.getIntervalValue;
+import static org.hawkular.alerts.api.util.Util.isEmpty;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+
+import org.hawkular.alerts.api.json.JsonUtil;
+import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.alerts.api.services.AlertsService;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class GnocchiQuery implements Runnable {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(GnocchiQuery.class);
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String ACCEPT = "Accept";
+    private static final String APPLICATION_JSON = "application/json";
+    private static final String GET = "GET";
+    private static final String POST = "POST";
+
+    private static final String METRIC_IDS = "metric.ids";
+    private static final String METRIC_NAMES = "metric.names";
+    private static final String METRIC_NAMES_REGEXP = "metric.names.regexp";
+    private static final String METRIC_RESOURCE_QUERY = "metric.resource.query";
+    private static final String METRIC_AGGREGATION = "metric.aggregation";
+
+    private Trigger trigger;
+    private Map<String, String> properties;
+    private AlertsService alerts;
+
+    private String baseUrl;
+    private String basicAuth;
+    private String metricIds;
+    private String metricNames;
+    private String metricNamesRegexp;
+    private String metricResourceQuery;
+    private String metricAggregation;
+    private String interval;
+
+    private Map<String, String> nameIdMetrics = new HashMap<>();
+    private Map<String, List<String>> aggregatedMetrics = new HashMap<>();
+    private Map<String, String> queries = new HashMap<>();
+    private ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    public GnocchiQuery(Trigger trigger, Map<String, String> properties, AlertsService alerts) {
+        this.trigger = trigger;
+        this.properties = properties == null ? new HashMap<>() : new HashMap<>(properties);
+        this.alerts = alerts;
+        String user = null;
+        String password = null;
+        if (trigger != null) {
+            baseUrl = trigger.getContext().get(GnocchiAlerter.URL);
+            user = trigger.getContext().get(GnocchiAlerter.USER);
+            password = trigger.getContext().get(GnocchiAlerter.PASSWORD);
+            metricIds = trigger.getContext().get(METRIC_IDS);
+            metricNames = trigger.getContext().get(METRIC_NAMES);
+            metricNamesRegexp = trigger.getContext().get(METRIC_NAMES_REGEXP);
+            metricResourceQuery = trigger.getContext().get(METRIC_RESOURCE_QUERY);
+            metricAggregation = trigger.getContext().get(METRIC_AGGREGATION);
+            interval = trigger.getContext().get(INTERVAL) == null ? INTERVAL_DEFAULT : trigger.getContext().get(INTERVAL);
+        }
+        if (isEmpty(baseUrl)) {
+            baseUrl = this.properties.getOrDefault(GnocchiAlerter.URL, GnocchiAlerter.GNOCCHI_URL_DEFAULT);
+        }
+        if (isEmpty(user)) {
+            user = this.properties.getOrDefault(GnocchiAlerter.USER, GnocchiAlerter.GNOCCHI_USER_DEFAULT);
+        }
+        if (isEmpty(password)) {
+            password = this.properties.getOrDefault(GnocchiAlerter.PASSWORD, GnocchiAlerter.GNOCCHI_PASSWORD_DEFAULT);
+        }
+        basicAuth = new StringBuilder("Basic ")
+                .append(new String(Base64.getEncoder().encode(new StringBuilder()
+                        .append(user)
+                        .append(":")
+                        .append(password)
+                        .toString()
+                        .getBytes())))
+                .toString();
+        searchMetrics();
+        processMetricAggregation();
+        buildGnocchiQueries();
+    }
+
+    public void searchMetrics() {
+        // Case 1, fixed list of metric ids, so, no need to query names or anything
+        if (!isEmpty(metricIds)) {
+            String[] gnocchiIds = metricIds.split(",");
+            for (int i = 0; i < gnocchiIds.length; i++) {
+                nameIdMetrics.put(gnocchiIds[i].trim(), gnocchiIds[i].trim());
+            }
+            log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+            return;
+        }
+
+        // Case 2, fixed list of metric names, a query to get gnocchi ids is necessary
+        if (!isEmpty(metricNames) && isEmpty(metricResourceQuery)) {
+            String[] splitMetricNames = metricNames.split(",");
+            List<String> gnocchiNames = new ArrayList<>();
+            for (int i = 0; i < splitMetricNames.length; i++) {
+                gnocchiNames.add(splitMetricNames[i].trim());
+            }
+            List rawAllMetrics = getAllMetrics();
+            for (int i = 0; i < rawAllMetrics.size(); i++) {
+                Map<String, String> metric = (Map<String, String>) rawAllMetrics.get(i);
+                if (gnocchiNames.contains(metric.get("name"))) {
+                    nameIdMetrics.put(metric.get("name"), metric.get("id"));
+                }
+            }
+            log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+            return;
+        }
+
+        // Case 3, regexp defined for metrics names
+        if (!isEmpty(metricNamesRegexp) && isEmpty(metricResourceQuery)) {
+            Pattern pattern = Pattern.compile(metricNamesRegexp);
+            List rawAllMetrics = getAllMetrics();
+            for (int i = 0; i < rawAllMetrics.size(); i++) {
+                Map<String, String> metric = (Map<String, String>) rawAllMetrics.get(i);
+                if (pattern.matcher(metric.get("name")).matches()) {
+                    nameIdMetrics.put(metric.get("name"), metric.get("id"));
+                }
+            }
+            log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+            return;
+        }
+
+        // Case 4, a resource query is defined, so metrics are filtered by this query
+        if (!isEmpty(metricResourceQuery)) {
+            List rawResourceMetrics = getResourceMetrics();
+            // Case 4.1 there is a metricNames list defined
+            if (!isEmpty(metricNames)) {
+                String[] splitMetricNames = metricNames.split(",");
+                List<String> gnocchiNames = new ArrayList<>();
+                for (int i = 0; i < splitMetricNames.length; i++) {
+                    gnocchiNames.add(splitMetricNames[i].trim());
+                }
+                for (int i = 0; i < rawResourceMetrics.size(); i++) {
+                    Map<String, String> metric = (Map<String, String>) rawResourceMetrics.get(i);
+                    if (gnocchiNames.contains(metric.get("name"))) {
+                        nameIdMetrics.put(metric.get("name"), metric.get("id"));
+                    }
+                }
+                log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+                return;
+            }
+            // Case 4.2 there is a regexp defined
+            if (!isEmpty(metricNamesRegexp)) {
+                Pattern pattern = Pattern.compile(metricNamesRegexp);
+                for (int i = 0; i < rawResourceMetrics.size(); i++) {
+                    Map<String, String> metric = (Map<String, String>) rawResourceMetrics.get(i);
+                    if (pattern.matcher(metric.get("name")).matches()) {
+                        nameIdMetrics.put(metric.get("name"), metric.get("id"));
+                    }
+                }
+                log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+                return;
+            }
+            // Case 4.3 include all metrics found for this resource
+            for (int i = 0; i < rawResourceMetrics.size(); i++) {
+                Map<String, String> metric = (Map<String, String>) rawResourceMetrics.get(i);
+                nameIdMetrics.put(metric.get("name"), metric.get("id"));
+            }
+            log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+            return;
+        }
+
+        // Case 5, nothing defined, then all metrics are fetched, not ideal but it will save configuration steps on trigger
+        List rawAllMetrics = getAllMetrics();
+        for (int i = 0; i < rawAllMetrics.size(); i++) {
+            Map<String, String> metric = (Map<String, String>) rawAllMetrics.get(i);
+            nameIdMetrics.put(metric.get("name"), metric.get("id"));
+        }
+        log.debugf("Gnocchi Metrics configured %s", nameIdMetrics);
+        return;
+    }
+
+    /*
+        <aggregated_metric_name>=<aggregated_function>(<list_of_metric_names>|<regexp>);
+     */
+    public void processMetricAggregation() {
+        if (!isEmpty(metricAggregation)) {
+            String[] aggregations = metricAggregation.split(";");
+            for (int i = 0; i < aggregations.length; i++) {
+                String definition = aggregations[i].trim();
+                int index0 = definition.indexOf("=");
+                int index1 = definition.indexOf("(");
+                int index2 = definition.indexOf(")");
+                String aggregatedName = definition.substring(0, index0);
+                String operation = definition.substring(index0 + 1, index1);
+                String parameters = definition.substring(index1 + 1, index2);
+                List<String> metricNames = new ArrayList<>();
+                metricNames.add(operation);
+                // Case a list of metricNames
+                if (parameters.contains(",")) {
+                    String[] listMetricNames = parameters.split(",");
+                    for (int j = 0; j < listMetricNames.length; j++) {
+                        metricNames.add(listMetricNames[j].trim());
+                    }
+                } else {
+                    Pattern pattern = Pattern.compile(parameters);
+                    for (String metricName : nameIdMetrics.keySet()) {
+                        if (pattern.matcher(metricName).matches()) {
+                            metricNames.add(metricName);
+                        }
+                    }
+                }
+                aggregatedMetrics.put(aggregatedName, metricNames);
+            }
+            log.debugf("Gnocchi Aggregated Metrics from %s -> %s", metricAggregation, aggregatedMetrics);
+        }
+    }
+
+    public void buildGnocchiQueries() {
+        if (!aggregatedMetrics.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : aggregatedMetrics.entrySet()) {
+                List<String> aggregatedInfo = entry.getValue();
+                StringBuilder url = new StringBuilder(baseUrl)
+                        .append("/v1/aggregation/metric?aggregation=")
+                        .append(aggregatedInfo.get(0))
+                        .append("&");
+                for (int i = 1; i < aggregatedInfo.size(); i++) {
+                    if (nameIdMetrics.containsKey(aggregatedInfo.get(i))) {
+                        url.append("metric=")
+                                .append(nameIdMetrics.get(aggregatedInfo.get(i)))
+                                .append("&");
+                    }
+                }
+                queries.put(entry.getKey(), url.toString());
+            }
+        } else if (!nameIdMetrics.isEmpty()) {
+            for (Map.Entry<String, String> entry : nameIdMetrics.entrySet()) {
+                StringBuilder url = new StringBuilder(baseUrl)
+                        .append("/v1/metric/")
+                        .append(entry.getValue())
+                        .append("/measures?");
+                queries.put(entry.getKey(), url.toString());
+            }
+        }
+    }
+
+    private List<Map<String, String>> getAllMetrics() {
+        String allMetricsUrl = baseUrl + "/v1/metric";
+        try {
+            URL url = new URL(allMetricsUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty(AUTHORIZATION, basicAuth);
+            conn.setRequestMethod(GET);
+            conn.setDoInput(true);
+            List rawAllMetrics = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+            conn.disconnect();
+            log.debugf("Gnocchi Metrics found %s", rawAllMetrics);
+            return (List<Map<String, String>>) rawAllMetrics;
+        } catch (IOException e) {
+            log.errorf(e,"Error querying Gnocchi metrics %s", allMetricsUrl);
+        }
+        return Collections.EMPTY_LIST;
+    }
+
+    private List<Map<String, String>> getResourceMetrics() {
+        String resourcesUrl = baseUrl + "/v1/search/resource/generic";
+        try {
+            URL url = new URL(resourcesUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty(AUTHORIZATION, basicAuth);
+            conn.setRequestProperty(CONTENT_TYPE, APPLICATION_JSON);
+            conn.setRequestProperty(ACCEPT, APPLICATION_JSON);
+            conn.setRequestMethod(POST);
+            conn.setDoInput(true);
+            conn.setDoOutput(true);
+            OutputStream os = conn.getOutputStream();
+            os.write(metricResourceQuery.getBytes());
+            os.flush();
+            os.close();
+            List rawResources = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+            log.debugf("Gnocchi Resources found %s", rawResources);
+            List<Map<String, String>> rawMetrics = new ArrayList<>();
+            for (int i = 0; i < rawResources.size(); i++) {
+                Map<String, Object> resource = (Map<String, Object>) rawResources.get(i);
+                if (resource.containsKey("metrics")) {
+                    Map<String, String> metrics = (Map<String, String>) resource.get("metrics");
+                    for (Map.Entry<String, String> metric : metrics.entrySet()) {
+                        Map<String, String> resultMetric = new HashMap<>();
+                        resultMetric.put("name", metric.getKey());
+                        resultMetric.put("id", metric.getValue());
+                        rawMetrics.add(resultMetric);
+                    }
+                }
+            }
+            log.debugf("Gnocchi Metrics found %s", rawMetrics);
+            conn.disconnect();
+            return rawMetrics;
+        } catch (IOException e) {
+            log.errorf(e,"Error querying Gnocchi resources %s", resourcesUrl);
+        }
+        return Collections.EMPTY_LIST;
+    }
+
+    private long intervalStart() {
+        int value = getIntervalValue(interval);
+        switch (getIntervalUnit(interval)) {
+            case HOURS:
+                value = value * 3600 * 1000;
+                break;
+            case MINUTES:
+                value = value * 60 * 1000;
+                break;
+            case SECONDS:
+                value = value * 1000;
+                break;
+        }
+        return (long)((System.currentTimeMillis() - value) / 1000);
+    }
+
+    public long parseTimestamp(String timestamp) {
+        try {
+            return ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant().toEpochMilli();
+        } catch (Exception e) {
+            log.debugf("Not able to parse [%s] with format [%s]", timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        return -1;
+    }
+
+    public void run() {
+        List<Future> futures = new ArrayList<>();
+        for (Map.Entry<String, String> query : queries.entrySet()) {
+            futures.add(executorService.submit(() -> {
+                String metricName = query.getKey();
+                String measuresUrl = query.getValue() + "start=" + intervalStart();
+                try {
+                    URL url = new URL(measuresUrl);
+                    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                    conn.setRequestProperty(AUTHORIZATION, basicAuth);
+                    conn.setRequestMethod(GET);
+                    conn.setDoInput(true);
+                    List measures = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+                    List<Data> data = new ArrayList<>();
+                    for (int i = 0; i < measures.size(); i++) {
+                        List measure = (List)measures.get(i);
+                        if (measure != null && measure.size() == 3) {
+                            String timestamp = (String)measure.get(0);
+                            Double value = (Double)measure.get(2);
+                            data.add(Data.forNumeric(trigger.getTenantId(), metricName, parseTimestamp(timestamp), value));
+                        }
+                    }
+                    log.debugf("Sending [%s]", data);
+                    if (alerts != null) {
+                        alerts.sendData(data, true);
+                    }
+                } catch (IOException e) {
+                    log.errorf(e,"Error querying Gnochi URL %s", measuresUrl);
+                } catch (Exception e) {
+                    log.errorf(e, "Error sending data to the Alerting Engine");
+                }
+            }));
+        }
+        for (Future future : futures) {
+            try {
+                future.get();
+            } catch (Exception e) {
+                log.error(e);
+            }
+        }
+    }
+}

--- a/alerters/alerters-plugins/alerters-gnocchi/src/test/java/org/hawkular/alerter/gnocchi/GnochiQueryTest.java
+++ b/alerters/alerters-plugins/alerters-gnocchi/src/test/java/org/hawkular/alerter/gnocchi/GnochiQueryTest.java
@@ -1,0 +1,220 @@
+package org.hawkular.alerter.gnocchi;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+
+import org.hawkular.alerts.api.json.JsonUtil;
+import org.hawkular.alerts.api.model.trigger.Trigger;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+public class GnochiQueryTest {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(GnochiQueryTest.class);
+
+    @Ignore
+    @Test
+    public void fetchResources() throws Exception {
+        String gnocchiUrl = "http://localhost:8041/v1/resource/generic";
+        String userPassword = "admin:admin";
+        String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userPassword.getBytes()));
+
+        URL url = new URL(gnocchiUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", basicAuth);
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        List resources = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+        log.infof("resources %s", resources);
+
+        conn.disconnect();
+    }
+
+    @Ignore
+    @Test
+    public void fetchMetrics() throws Exception {
+        String gnocchiUrl = "http://localhost:8041/v1/metric";
+        String userPassword = "admin:admin";
+        String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userPassword.getBytes()));
+
+        URL url = new URL(gnocchiUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", basicAuth);
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        List metrics = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+        log.infof("metrics %s", metrics);
+
+        conn.disconnect();
+    }
+
+    @Ignore
+    @Test
+    public void fetchMeasures() throws Exception {
+        String gnocchiUrl = "http://localhost:8041/v1/metric/0062038b-af87-4f5c-b250-72c986037fa2/measures";
+        String userPassword = "admin:admin";
+        String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userPassword.getBytes()));
+
+        URL url = new URL(gnocchiUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", basicAuth);
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        List measures = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+        log.infof("measures %s", measures);
+
+        conn.disconnect();
+    }
+
+    @Ignore
+    @Test
+    public void searchRersources() throws Exception {
+        String searchUrl = "http://localhost:8041/v1/search/resource/generic";
+        String userPassword = "admin:admin";
+        String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userPassword.getBytes()));
+        String resourceQuery = "{" +
+                                    "\"like\":{" +
+                                        "\"type\":\"c%\"" +
+                                    "}" +
+                                "}";
+
+        URL url = new URL(searchUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestProperty("Authorization", basicAuth);
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Accept", "application/json");
+        conn.setRequestMethod("POST");
+        conn.setDoInput(true);
+        conn.setDoOutput(true);
+
+        OutputStream os = conn.getOutputStream();
+        os.write(resourceQuery.getBytes());
+        os.flush();
+        os.close();
+
+        List resources = JsonUtil.getMapper().readValue(conn.getInputStream(), List.class);
+        log.infof("resources %s", resources);
+
+        conn.disconnect();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByMetricIds() throws Exception {
+        // Case 1
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        trigger.getContext().put("metric.ids", "0062038b-af87-4f5c-b250-72c986037fa2,01320e1e-0aeb-4e17-9402-d2450b2e0024");
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByMetricNames() {
+        // Case 2
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        trigger.getContext().put("metric.names", "cpu-0@cpu-user-0,cpu-1@cpu-user-0,cpu-2@cpu-user-0");
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByMetricRegexp() {
+        // Case 3
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        trigger.getContext().put("metric.names.regexp", "cpu-.@cpu.*");
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByResourcesAndMetricNames() {
+        // Case 4.1
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        trigger.getContext().put("metric.names", "cpu-0@cpu-user-0,cpu-1@cpu-user-0,cpu-2@cpu-user-0");
+        String resourceQuery = "{" +
+                "\"like\":{" +
+                "\"type\":\"c%\"" +
+                "}" +
+                "}";
+        trigger.getContext().put("metric.resource.query", resourceQuery);
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByResourcesAndMetricRegexp() {
+        // Case 4.2
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        trigger.getContext().put("metric.names.regexp", "cpu-.@cpu.*");
+        String resourceQuery = "{" +
+                "\"like\":{" +
+                "\"type\":\"c%\"" +
+                "}" +
+                "}";
+        trigger.getContext().put("metric.resource.query", resourceQuery);
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsByResources() {
+        // Case 4.2
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        String resourceQuery = "{" +
+                "\"like\":{" +
+                "\"type\":\"c%\"" +
+                "}" +
+                "}";
+        trigger.getContext().put("metric.resource.query", resourceQuery);
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetrics() {
+        // Case 5
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsAndAggregateMetricNames() {
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        String aggregatedMetrics = "cpu-user=mean(cpu-0@cpu-user-0,cpu-1@cpu-user-0);" +
+                "cpu-nice=mean(cpu-0@cpu-nice-0,cpu-1@cpu-nice-0);" +
+                "cpu-system=mean(cpu-0@cpu-system-0,cpu-1@cpu-system-0)";
+        trigger.addContext("metric.aggregation", aggregatedMetrics);
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void searchMetricsAndAggregateRegExp() {
+        Trigger trigger = new Trigger("tenant", "gnochi-test-id", "Gnocchi Trigger");
+        String aggregatedMetrics = "cpu-user=mean(cpu-.@cpu-user-.*);" +
+                "cpu-nice=mean(cpu-.@cpu-nice-.*);" +
+                "cpu-system=mean(cpu-.@cpu-system-.*)";
+        trigger.addContext("metric.aggregation", aggregatedMetrics);
+        new GnocchiQuery(trigger, null, null).run();
+    }
+
+    @Ignore
+    @Test
+    public void parseGnocchiDates() throws Exception {
+        ZonedDateTime.parse("2017-09-14T21:15:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant().toEpochMilli();
+    }
+}

--- a/alerters/alerters-plugins/alerters-gnocchi/src/test/resources/log4j2.xml
+++ b/alerters/alerters-plugins/alerters-gnocchi/src/test/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/alerters/alerters-plugins/pom.xml
+++ b/alerters/alerters-plugins/pom.xml
@@ -77,6 +77,7 @@
         <module>alerters-elasticsearch</module>
         <module>alerters-prometheus</module>
         <module>alerters-kafka</module>
+        <module>alerters-gnocchi</module>
       </modules>
     </profile>
   </profiles>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -108,6 +108,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-gnocchi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${version.org.apache.logging.log4j}</version>

--- a/examples/gnocchi/README.adoc
+++ b/examples/gnocchi/README.adoc
@@ -1,0 +1,167 @@
+= Gnocchi Integration
+
+This example shows how to integrate Gnocchi with Hawkular Alerting.
+
+====
+The scripts used for this example are written in *bash* and tested on Linux platforms. +
+Those are pretty simple and can be translated a different environment easily.
+====
+
+== Install a Gnocchi demo environment
+
+For this example we use the link:https://github.com/gnocchixyz/gnocchi-docker/[gnocchi-docker] repository.
+
+Check it out and perform a
+
+[source,shell]
+----
+  docker-compose up
+----
+
+== Install Hawkular Alerting
+
+For this example we use use the link:https://hub.docker.com/r/hawkular/hawkular-alerts[docker hawkular-alerts] image.
+
+Run a command
+
+[source,shell]
+----
+  docker run -i -t -p 8080:8080 hawkular/hawkular-alerts
+----
+
+== Create Triggers definitions
+
+Run the script
+
+[source,shell]
+----
+  ./create-definitions.sh
+----
+
+This script will create the following triggers on Gnocchi systems
+
+[source,shell]
+----
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "high-load",
+        "name": "High Load",
+        "description": "Alert when mean of load is > 2. Resolved automatically.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoResolve": true,
+        "autoResolveAlerts": true,
+        "tags": {
+          "Gnocchi": "Localhost instance" // <1>
+        },
+        "context": {
+          "metric.names": "load@load-0,load@load-1,load@load-2", // <2>
+          "metric.aggregation":"load=mean(load@load-0,load@load-1,load@load-2)" // <3>
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "THRESHOLD",
+          "dataId": "load",
+          "operator": "GT",
+          "threshold": 2
+        },
+        {
+          "triggerMode": "AUTORESOLVE",
+          "type": "THRESHOLD",
+          "dataId": "load",
+          "operator": "LTE",
+          "threshold": 2
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "high-user-cpu",
+        "name": "High User CPU",
+        "description": "Alert when mean of user cpu is > 3.7M. Investigate manually.",
+        "severity": "MEDIUM",
+        "enabled": true,
+        "tags": {
+          "Gnocchi": "Localhost instance" // <1>
+        },
+        "context": {
+          "metric.names.regexp": "cpu-.@cpu-user-.*", // <2>
+          "metric.aggregation":"cpu-user=mean(cpu-.@cpu-user-.*)" // <3>
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "THRESHOLD",
+          "dataId": "cpu-user",
+          "operator": "GT",
+          "threshold": 3700000
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "low-free-memory",
+        "name": "Low Free Memory",
+        "description": "Alert when Free Memory < 20% Memory Used.",
+        "severity": "CRITICAL",
+        "enabled": true,
+        "tags": {
+          "Gnocchi": "Localhost instance" // <1>
+        },
+        "context": {
+          "metric.names": "memory@memory-used-0,memory@memory-free-0" // <2>
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "COMPARE",
+          "dataId": "memory@memory-free-0",
+          "operator": "LT",
+          "dataId2": "memory@memory-used-0",
+          "data2Multiplier": 0.2
+        }
+      ]
+    }
+  ],
+  "actions":[
+    {
+      "actionPlugin": "email",
+      "actionId": "email-to-admins",
+      "properties": {
+        "to": "admins@hawkular.org"
+      }
+    }
+  ]
+}
+----
+
+<1> Triggers tagged with _Gnocchi_ will be managed by the alerter to collect metrics from a Gnocchi system
+<2> Gnocchi metrics are identified by metric names
+<3> These triggers use aggregated metrics which will be used in the conditions as dataIds
+
+== Visualize Alerts on Hawkular
+
+Access to the link:http://localhost:8080/hawkular/alerts/ui[Hawkular Alerting Console] to get details of the Alerts and Triggers.
+

--- a/examples/gnocchi/create-definitions.sh
+++ b/examples/gnocchi/create-definitions.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+main() {
+    local url=$1
+    local tenant=$2
+    if [ "x$url" == "x" ]; then
+        url="http://localhost:8080"
+    fi
+    if [ "x$tenant" == "x" ]; then
+        tenant="my-organization"
+    fi
+    local response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -H "Hawkular-Tenant: $tenant" -XPOST "$url/hawkular/alerts/import/all" --data "@gnocchi-triggers.json")
+    if [ "$response" -gt "300" ]; then
+        echo "Error importing definitions into hawkular"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/examples/gnocchi/gnocchi-triggers.json
+++ b/examples/gnocchi/gnocchi-triggers.json
@@ -1,0 +1,113 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "high-load",
+        "name": "High Load",
+        "description": "Alert when mean of load is > 2. Resolved automatically.",
+        "severity": "HIGH",
+        "enabled": true,
+        "autoResolve": true,
+        "autoResolveAlerts": true,
+        "tags": {
+          "Gnocchi": "Localhost instance"
+        },
+        "context": {
+          "metric.names": "load@load-0,load@load-1,load@load-2",
+          "metric.aggregation":"load=mean(load@load-0,load@load-1,load@load-2)"
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "THRESHOLD",
+          "dataId": "load",
+          "operator": "GT",
+          "threshold": 2
+        },
+        {
+          "triggerMode": "AUTORESOLVE",
+          "type": "THRESHOLD",
+          "dataId": "load",
+          "operator": "LTE",
+          "threshold": 2
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "high-user-cpu",
+        "name": "High User CPU",
+        "description": "Alert when mean of user cpu is > 3.7M. Investigate manually.",
+        "severity": "MEDIUM",
+        "enabled": true,
+        "tags": {
+          "Gnocchi": "Localhost instance"
+        },
+        "context": {
+          "metric.names.regexp": "cpu-.@cpu-user-.*",
+          "metric.aggregation":"cpu-user=mean(cpu-.@cpu-user-.*)"
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "THRESHOLD",
+          "dataId": "cpu-user",
+          "operator": "GT",
+          "threshold": 3700000
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "id": "low-free-memory",
+        "name": "Low Free Memory",
+        "description": "Alert when Free Memory < 20% Memory Used.",
+        "severity": "CRITICAL",
+        "enabled": true,
+        "tags": {
+          "Gnocchi": "Localhost instance"
+        },
+        "context": {
+          "metric.names": "memory@memory-used-0,memory@memory-free-0"
+        },
+        "actions":[
+          {
+            "actionPlugin": "email",
+            "actionId": "email-to-admins"
+          }
+        ]
+      },
+      "conditions":[
+        {
+          "type": "COMPARE",
+          "dataId": "memory@memory-free-0",
+          "operator": "LT",
+          "dataId2": "memory@memory-used-0",
+          "data2Multiplier": 0.2
+        }
+      ]
+    }
+  ],
+  "actions":[
+    {
+      "actionPlugin": "email",
+      "actionId": "email-to-admins",
+      "properties": {
+        "to": "admins@hawkular.org"
+      }
+    }
+  ]
+}

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -108,6 +108,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.alerts</groupId>
+      <artifactId>hawkular-alerts-alerters-gnocchi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${version.org.apache.logging.log4j}</version>


### PR DESCRIPTION
Background

Hawkular Alerting is a federated alerting engine. Today it offers a REST API to integrate with any system and a set of pre-built integrations with Elasticsearch, Prometheus and Apache Kafka.

This PR adds Gnocchi into the alerter plugins.

In the context of the discussion
https://github.com/gnocchixyz/gnocchi/issues/71

We commented that we could add a poll alerter as a first step to cover Gnocchi and collect requeriments.
If the features Hawkular Alerting offers are interesting we can propose a fully streaming approach being Gnocchi owner to send data into Hawkular Alerting.

Anyway, this is just a first step to add alerting capabilities into Gnocchi.

cc @seuf @chungg @sileht @jd