### PR TITLE
Openshift template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 notifications:
   irc:
     channels:

--- a/dist/hawkular-alerts-openshift.yml
+++ b/dist/hawkular-alerts-openshift.yml
@@ -1,0 +1,75 @@
+#
+# Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+id: hawkular-alerts
+kind: Template
+apiVersion: v1
+name: Hawkular Alerts
+metadata:
+  name: hawkular-alerts
+
+
+objects:
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: hawkular-alerts
+    labels:
+      app: hawkular-alerts
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: hawkular-alerts
+      spec:
+        containers:
+        - env:
+          image: hawkular/hawkular-alerts
+          name: hawkular-alerts
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: hawkular-alerts
+    labels:
+      app: hawkular-alerts
+  spec:
+    ports:
+      - name: hawkular-alerts
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+    selector:
+      app: hawkular-alerts
+    type: LoadBalancer
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: alerts
+  spec:
+    path: /hawkular/alerts/ui
+    port:
+      targetPort: hawkular-alerts
+    to:
+      kind: Service
+      name: hawkular-alerts

--- a/itests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
+++ b/itests/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
@@ -204,4 +204,45 @@ class EventsITest extends AbstractITestBase {
         assertEquals(200, resp.status)
         assertEquals(1, resp.data.size())
     }
+
+    // HWKALERTS-275
+    @Test
+    void testCreateAndQueryEvents() {
+        def numEvents = 1000
+        def resp
+        for (int i = 0; i < numEvents; i++) {
+            Event eventX = new Event()
+            eventX.setId("event" + i)
+            eventX.setCategory("test")
+            eventX.setText("Event message " + i)
+            eventX.getTags().put("tag" + (i % 3), "value" + (i % 3))
+            resp = client.post(path: "events", body: eventX)
+            assertEquals(200, resp.status)
+        }
+
+        def tagQuery = "tag0"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(334, resp.data.size())
+
+        tagQuery = "tag1"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(333, resp.data.size())
+
+        tagQuery = "tag2"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(333, resp.data.size())
+
+        def eventIds = ""
+        for (int i = 0; i < 199; i++) {
+            eventIds += "event" + i + ",";
+        }
+        eventIds += "event199";
+
+        resp = client.get(path: "events", query: [eventIds: eventIds])
+        assertEquals(200, resp.status)
+        assertEquals(200, resp.data.size())
+    }
 }


### PR DESCRIPTION
Hi @jshaughn and @lucasponce.

Based on @jmazzitelli k8s template, I created a openshift templated

I think we can use that template to some testing under openshift. On the future, we can create a setup running some of the hawkular-alerts integration running on openshift such as Kafka, Prometheus, Gnocci, etc.

