### PR TITLE
Triggers API: Orphan/Unorphan to use PUT instead of POST

### DIFF
--- a/itests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
+++ b/itests/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
@@ -128,7 +128,7 @@ class TriggersITest extends AbstractITestBase {
         assertEquals(200, resp.status)
 
         // orphan member2, it should no longer get updates
-        resp = client.post(path: "triggers/groups/members/member2/orphan");
+        resp = client.put(path: "triggers/groups/members/member2/orphan");
         assertEquals(200, resp.status)
 
         // add dampening to the group
@@ -273,7 +273,7 @@ class TriggersITest extends AbstractITestBase {
         dataIdMap.put("DataId1-Token", "DataId1-Child2");
         dataIdMap.put("DataId2-Token", "DataId2-Child2");
         UnorphanMemberInfo unorphanMemberInfo = new UnorphanMemberInfo(null, null, dataIdMap);
-        resp = client.post(path: "triggers/groups/members/member2/unorphan", body: unorphanMemberInfo);
+        resp = client.put(path: "triggers/groups/members/member2/unorphan", body: unorphanMemberInfo);
         assertEquals(200, resp.status)
 
         // get the member2 trigger

--- a/rest-handlers/src/main/java/org/hawkular/alerts/handlers/TriggersHandler.java
+++ b/rest-handlers/src/main/java/org/hawkular/alerts/handlers/TriggersHandler.java
@@ -135,8 +135,8 @@ public class TriggersHandler implements RestHandler {
         router.put(path + "/groups/:groupId/conditions").handler(this::setGroupConditions);
         router.delete(path + "/:triggerId/dampenings/:dampeningId").handler(this::deleteDampening);
         router.get(path + "/:triggerId/dampenings/mode/:triggerMode").handler(this::getTriggerModeDampenings);
-        router.post(path + "/groups/members/:memberId/orphan").handler(this::orphanMemberTrigger);
-        router.post(path + "/groups/members/:memberId/unorphan").handler(this::unorphanMemberTrigger);
+        router.put(path + "/groups/members/:memberId/orphan").handler(this::orphanMemberTrigger);
+        router.put(path + "/groups/members/:memberId/unorphan").handler(this::unorphanMemberTrigger);
         router.put(path + "/groups/:groupId/dampenings/:dampeningId").handler(this::updateGroupDampening);
         router.put(path + "/groups/:groupId/conditions/:triggerMode").handler(this::setGroupConditionsTriggerMode);
         router.delete(path + "/groups/:groupId/dampenings/:dampeningId").handler(this::deleteGroupDampening);
@@ -950,7 +950,7 @@ public class TriggersHandler implements RestHandler {
                 }, res -> result(routing, res));
     }
 
-    @DocPath(method = POST,
+    @DocPath(method = PUT,
             path = "/groups/members/{memberId}/orphan",
             name = "Make a non-orphan member trigger into an orphan.")
     @DocParameters(value = {
@@ -1072,7 +1072,7 @@ public class TriggersHandler implements RestHandler {
                 }, res -> result(routing, res));
     }
 
-    @DocPath(method = POST,
+    @DocPath(method = PUT,
             path = "/groups/members/{memberId}/unorphan",
             name = "Make an orphan member trigger into an group trigger.")
     @DocParameters(value = {


### PR DESCRIPTION
Proposal to make REST-API more consistent.

Change orphan/unorphan triggers to follow PUT as they should behave like idempotent methods. Update is already PUT method and these should be for that reason too.