### PR TITLE
[HWKALERTS-287 REST-API is missing multiple methods for same path 

### DIFF
--- a/rest-handlers/src/main/rest-doc/generate-api.groovy
+++ b/rest-handlers/src/main/rest-doc/generate-api.groovy
@@ -160,7 +160,7 @@ try {
                     DocPath docPath = method.getAnnotation(DocPath.class)
 
                     def path = (endPointPath == '/' && docPath.path() != '/' ? '' : endPointPath) + (docPath.path() == '/' ? '' : docPath.path())
-                    if (!json["paths"].hasProperty(path)) {
+                    if (!json["paths"].containsKey(path)) {
                         json["paths"][path] = [:]
                     }
                     json["paths"][path][docPath.method()] = [:]


### PR DESCRIPTION
Change hasProperty to containsKey to get all the methods printed in the documentation for same path.