### PR TITLE
[HWKALERTS-290] upgrade hawkular-commons 0.9.2->0.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.org.drools>6.4.0.Final</version.org.drools>
     <version.org.elasticsearch.client>5.2.2</version.org.elasticsearch.client>
     <version.org.freemarker>2.3.23</version.org.freemarker>
-    <version.org.hawkular.commons>0.9.2.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.9.7.Final</version.org.hawkular.commons>
     <version.org.infinispan.wildfly>8.0.1.Final</version.org.infinispan.wildfly>
     <version.org.infinispan.eap64>5.2.9.Final</version.org.infinispan.eap64>
     <version.org.jboss.jboss-vfs>3.2.10.Final</version.org.jboss.jboss-vfs>


### PR DESCRIPTION
This brings hawkular alerts in sync with hawkular services version 0.40.x