### PR TITLE
Fixing references to old alerts page

### DIFF
--- a/examples/events-aggregation/README.adoc
+++ b/examples/events-aggregation/README.adoc
@@ -6,7 +6,7 @@ The Events Aggregation Extension allows to scope Sliding Windows on Events and d
 
 A introductory article can be found under the link link:http://www.hawkular.org/blog/2017/01/13/events-aggregation-extension.html[Extending Complex Event Processing in Hawkular Alerting].
 
-Full documentation about this Extension can que found in link:http://www.hawkular.org/community/docs/developer-guide/alerts.html#_events_aggregation_extension[Events Aggregation Extension].
+Full documentation about this Extension can que found in link:http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#_events_aggregation_extension[Events Aggregation Extension].
 
 [NOTE]
 ====

--- a/examples/tutorial/lessons/lesson-02-first-alert.adoc
+++ b/examples/tutorial/lessons/lesson-02-first-alert.adoc
@@ -84,7 +84,7 @@ We'll ignore some fields for now, but a couple of settings are important:
 
 === Conditions
 
-The big thing we're missing are the conditions that define when the trigger should fire an alert.  HAlerting offers http://www.hawkular.org/community/docs/developer-guide/alerts.html#\_conditions[many different condition types] out of the box.  Each condition performs evaluations against incoming data to see if it is satisfied.  A condition type found in virtually any alerting system is __Threshold__, so let's start with a threshold condition for our tutorial. Note that the body supports a list of conditions but for now we'll only use one.
+The big thing we're missing are the conditions that define when the trigger should fire an alert.  HAlerting offers http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#\_conditions[many different condition types] out of the box.  Each condition performs evaluations against incoming data to see if it is satisfied.  A condition type found in virtually any alerting system is __Threshold__, so let's start with a threshold condition for our tutorial. Note that the body supports a list of conditions but for now we'll only use one.
 
 [cols="1,5l"]
 |===
@@ -242,11 +242,11 @@ Content-Type: application/json
 }
 ----
 
-You can see that an Alert carries a lot of information to help understand its origin. The alert fields themselves are probably clear.  The trigger is attached for reference.  We'll cover dampening and lifecycle in the next few lessons.  For now, look more closely at the _evalSets_ field.  This field explains why the trigger fired the alert.  Because the `lesson-02` trigger has only one condition, each evalSet has only one condition evaluation.  And because we are firing as soon as we have a single true evaluation (no dampening), we only have one evalSet.  In this case we can see that a `gauge-1' datapoint was received with a value of 93. because `93 GTE 50` is true, the trigger fired.
+You can see that an Alert carries a lot of information to help understand its origin. The alert fields themselves are probably clear.  The trigger is attached for reference.  We'll cover dampening and lifecycle in the next few lessons.  For now, look more closely at the _evalSets_ field.  This field explains why the trigger fired the alert.  Because the `lesson-02` trigger has only one condition, each evalSet has only one condition evaluation.  And because we are firing as soon as we have a single true evaluation (no dampening), we only have one evalSet.  In this case we can see that a `gauge-1` datapoint was received with a value of 93. because `93 GTE 50` is true, the trigger fired.
 
 === Exercise
 
-At this point you may feel comfortable creating a trigger and trying some of the http://www.hawkular.org/community/docs/developer-guide/alerts.html#\_conditions[other condition types] offered out of the box by hAlerting.
+At this point you may feel comfortable creating a trigger and trying some of the http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#\_conditions[other condition types] offered out of the box by hAlerting.
 
 When you are ready, move on to the next lesson.
 

--- a/examples/tutorial/lessons/lesson-03-dampening.adoc
+++ b/examples/tutorial/lessons/lesson-03-dampening.adoc
@@ -14,7 +14,7 @@ Dampening is concerned with *condition set* evaluations, not individual conditio
 
 Sometimes strict dampening is, well, too strict.  In that case we have relaxed dampening, again in the count and time varieties.  Relaxed-count means N out of M consecutive true evaluations.  Relaxed-time means N true evaluations in some minimum period of time.  One note on relaxed time, unless data is reported frequently enough the dampening may never be satisfied.  To varying degrees the time based dampening options are tied to the reporting intervals of the relevant dataIds.
 
-You can find http://www.hawkular.org/community/docs/developer-guide/alerts.html#_trigger_dampening[more details on dampening options here].
+You can find http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#_trigger_dampening[more details on dampening options here].
 
 === Example
 

--- a/examples/tutorial/lessons/lesson-05-lifecycle.adoc
+++ b/examples/tutorial/lessons/lesson-05-lifecycle.adoc
@@ -1,7 +1,7 @@
 
 == Lesson 05 - Alert Life-cycle and Auto-Resolve
 
-The past few lessons taught the basics of defining triggers and firing alerts.  Now that you can create alerts we recommend reading this brief snippet about our http://www.hawkular.org/community/docs/developer-guide/alerts.html#_alerting_philosophy[alerting philosophy].  When an alert is generated it typically requires human intervention and it begins a simple life-cycle:
+The past few lessons taught the basics of defining triggers and firing alerts.  Now that you can create alerts we recommend reading this brief snippet about our http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#_alerting_philosophy[alerting philosophy].  When an alert is generated it typically requires human intervention and it begins a simple life-cycle:
 
 image::image-alert-lifecycle.png[Alert Life-cycle]
 
@@ -150,7 +150,7 @@ Hawkular Alerting provides a powerful feature called _Auto-Resolve_.  We have al
 
 Note that when `autoResolve=true` the `autoDisable` and `autoEnable` options are *ignored*. An auto-resolve trigger toggles between FIRING mode and AUTORESOLVE mode so by its nature it autoDisables and autoEnables.
 
-The AUTORESOLVE condition set can logically be thought of as the opposite of the FIRING condition set. But in practice it is often not just the negation of the FIRING condition set.  Also, the AUTORESOLVE condition set can define its own dampening.  For example, an alert may be raised due to a shorter spike of high response times but we may not want to declare the issue resolved until we have a longer period of acceptable response times. http://www.hawkular.org/community/docs/developer-guide/alerts.html#_autoresolve[See here for more detail] on the auto resolve feature.  Now, let's try an example to see it in action.
+The AUTORESOLVE condition set can logically be thought of as the opposite of the FIRING condition set. But in practice it is often not just the negation of the FIRING condition set.  Also, the AUTORESOLVE condition set can define its own dampening.  For example, an alert may be raised due to a shorter spike of high response times but we may not want to declare the issue resolved until we have a longer period of acceptable response times. http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#_autoresolve[See here for more detail] on the auto resolve feature.  Now, let's try an example to see it in action.
 
 First, let's delete the lesson-03 trigger, so we don't get any more lesson-03 alerts.
 

--- a/examples/tutorial/lessons/lesson-06-actions.adoc
+++ b/examples/tutorial/lessons/lesson-06-actions.adoc
@@ -332,7 +332,7 @@ This introduction to actions should be enough to get you going.  But with the pr
 
 Here is a short https://github.com/hawkular/hawkular-alerts/tree/master/examples/webhook[example showing the webhook plugin].
 
-Here are some instructions for http://www.hawkular.org/community/docs/developer-guide/alerts.html#_actions_plugins[building a custom plugin].
+Here are some instructions for http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#_actions_plugins[building a custom plugin].
 
 Otherwise, it's time to move on...
 

--- a/examples/tutorial/lessons/lesson-07-events.adoc
+++ b/examples/tutorial/lessons/lesson-07-events.adoc
@@ -1,7 +1,7 @@
 
 == Lesson 07 - Events
 
-In previous lessons we've learned about defining triggers and how those triggers fire alerts.  We've learned about the alert lifecycle and how actions can be executed on lifecycle changes.  As we discuss in our http://www.hawkular.org/community/docs/developer-guide/alerts.html#\_alerting\_philosophy[alerting philosophy], alerts should be generated infrequently and with great care, in order to maintain their relevance. In Hawkular Alerting a trigger can also generate an __Event__. Events are used to record interesting system happenings that don't justify an alert, or may help build evidence towards a future alert.
+In previous lessons we've learned about defining triggers and how those triggers fire alerts.  We've learned about the alert lifecycle and how actions can be executed on lifecycle changes.  As we discuss in our http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html#\_alerting\_philosophy[alerting philosophy], alerts should be generated infrequently and with great care, in order to maintain their relevance. In Hawkular Alerting a trigger can also generate an __Event__. Events are used to record interesting system happenings that don't justify an alert, or may help build evidence towards a future alert.
 
 Events don't require immediate human intervention, don't need to be resolved, and don't have life-cycle.  They just record a happening at some point in time.  There are multiple ways to get events into the system, and several things that can be done with them.  Let's work through an example...
 

--- a/ui/src/main/ui/bower.json
+++ b/ui/src/main/ui/bower.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Hawkular Alerts UI App",
   "license": "Apache-2.0",
-  "homepage": "http://www.hawkular.org/community/docs/developer-guide/alerts.html",
+  "homepage": "http://www.hawkular.org/community/docs/developer-guide/alerts-v2.html",
   "repository": {
     "type": "git",
     "url": "https://github.com/hawkular/hawkular-alerts"


### PR DESCRIPTION
This PR fix all URL references to old alert page (alerts.html) to the new one (alerts-v2.html).
Also includes one adoc syntax problem on lesson-2: using `gauge-1' instead of `gauge-1`