### PR TITLE
HWKALERTS-291 Split backend caches

### DIFF
--- a/hawkular-alerts-commons/src/main/java/org/hawkular/alerts/cache/IspnCacheManager.java
+++ b/hawkular-alerts-commons/src/main/java/org/hawkular/alerts/cache/IspnCacheManager.java
@@ -37,6 +37,9 @@ import org.infinispan.query.SearchManager;
  */
 public class IspnCacheManager {
     private static final MsgLogger log = MsgLogging.getMsgLogger(IspnCacheManager.class);
+    public static final String BACKEND_TRIGGERS_CACHE = "backend_triggers";
+    public static final String BACKEND_EVENTS_CACHE = "backend_events";
+    private static final String[] CACHES = { BACKEND_TRIGGERS_CACHE, BACKEND_EVENTS_CACHE };
     private static final String ISPN_BACKEND_REINDEX = "hawkular-alerts.backend-reindex";
     private static final String ISPN_BACKEND_REINDEX_DEFAULT = "false";
     private static final String ISPN_CONFIG = "hawkular-alerting-ispn.xml";
@@ -77,13 +80,15 @@ public class IspnCacheManager {
 
                 if (Boolean.valueOf(
                         HawkularProperties.getProperty(ISPN_BACKEND_REINDEX, ISPN_BACKEND_REINDEX_DEFAULT))) {
-                    log.info("Reindexing Ispn [backend] started.");
-                    long startReindex = System.currentTimeMillis();
-                    SearchManager searchManager = Search
-                            .getSearchManager(IspnCacheManager.getCacheManager().getCache("backend"));
-                    searchManager.getMassIndexer().start();
-                    long stopReindex = System.currentTimeMillis();
-                    log.info("Reindexing Ispn [backend] completed in [" + (stopReindex - startReindex) + " ms]");
+                    for (String cache : CACHES) {
+                        log.infof("Reindexing Ispn [%s] started.", cache);
+                        long startReindex = System.currentTimeMillis();
+                        SearchManager searchManager = Search
+                                .getSearchManager(IspnCacheManager.getCacheManager().getCache(cache));
+                        searchManager.getMassIndexer().start();
+                        long stopReindex = System.currentTimeMillis();
+                        log.infof("Reindexing Ispn [%s] completed in [%s] ms", cache, (stopReindex - startReindex));
+                    }
                 }
             } catch (IOException e) {
                 log.error(e);

--- a/hawkular-alerts-commons/src/main/resources/hawkular-alerting-ispn-85.xml
+++ b/hawkular-alerts-commons/src/main/resources/hawkular-alerting-ispn-85.xml
@@ -22,7 +22,7 @@
     xsi:schemaLocation="urn:infinispan:config:8.5 infinispan-config-8.5.xsd"
     xmlns="urn:infinispan:config:8.5">
 
-  <cache-container name="hawkular-alerts" default-cache="backend">
+  <cache-container name="hawkular-alerts" default-cache="backend_triggers">
     <local-cache name="partition"/>
     <local-cache name="triggers"/>
     <local-cache name="data"/>
@@ -37,7 +37,7 @@
     </local-cache>
 
     <!-- Backend for definitions, actions history, events and alerts -->
-    <local-cache name="backend">
+    <local-cache name="backend_triggers">
       <transaction mode="BATCH"/>
       <persistence>
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
@@ -46,19 +46,17 @@
       </persistence>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnAction</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnActionDefinition</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnCondition</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnDampening</indexed-entity>
-          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnEvent</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnTrigger</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>
         <property name="default.chunk_size">128000</property>
-        <property name="default.locking_cachename">LuceneIndexesLocking_custom</property>
-        <property name="default.data_cachename">LuceneIndexesData_custom</property>
-        <property name="default.metadata_cachename">LuceneIndexesMetadata_custom</property>
+        <property name="default.locking_cachename">backend_triggers_locking</property>
+        <property name="default.data_cachename">backend_triggers_indexes_data</property>
+        <property name="default.metadata_cachename">backend_triggers_indexes_metadata</property>
         <!-- The default is 10, but we don't want to waste many cycles in merging
          (tune for writes at cost of reader fragmentation) -->
 
@@ -72,7 +70,7 @@
         <property name="lucene_version">LUCENE_CURRENT</property>
       </indexing>
     </local-cache>
-    <local-cache name="LuceneIndexesMetadata_custom">
+    <local-cache name="backend_triggers_indexes_metadata">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />
@@ -80,7 +78,7 @@
       </persistence>
       <indexing index="NONE"/>
     </local-cache>
-    <local-cache name="LuceneIndexesData_custom">
+    <local-cache name="backend_triggers_indexes_data">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />
@@ -88,7 +86,7 @@
       </persistence>
       <indexing index="NONE" />
     </local-cache>
-    <local-cache name="LuceneIndexesLocking_custom">
+    <local-cache name="backend_triggers_locking">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />
@@ -96,5 +94,62 @@
       </persistence>
       <indexing index="NONE" />
     </local-cache>
+
+    <local-cache name="backend_events">
+      <transaction mode="BATCH"/>
+      <persistence>
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" modification-queue-size="10000" />
+        </file-store>
+      </persistence>
+      <indexing index="LOCAL">
+        <indexed-entities>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnAction</indexed-entity>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnEvent</indexed-entity>
+        </indexed-entities>
+        <property name="default.indexmanager">near-real-time</property>
+        <property name="default.directory_provider">infinispan</property>
+        <property name="default.chunk_size">128000</property>
+        <property name="default.locking_cachename">backend_events_locking</property>
+        <property name="default.data_cachename">backend_events_indexes_data</property>
+        <property name="default.metadata_cachename">backend_events_indexes_metadata</property>
+        <!-- The default is 10, but we don't want to waste many cycles in merging
+         (tune for writes at cost of reader fragmentation) -->
+
+        <property name="default.indexwriter.merge_factor">30</property>
+        <!-- Never create segments larger than 1GB -->
+        <property name="default.indexwriter.merge_max_size">1024</property>
+        <!-- IndexWriter flush buffer size in MB -->
+        <property name="default.indexwriter.ram_buffer_size">64</property>
+        <!-- Enable sharding on writers -->
+        <property name="default.sharding_strategy.nbr_of_shards">6</property>
+        <property name="lucene_version">LUCENE_CURRENT</property>
+      </indexing>
+    </local-cache>
+    <local-cache name="backend_events_indexes_metadata">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE"/>
+    </local-cache>
+    <local-cache name="backend_events_indexes_data">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE" />
+    </local-cache>
+    <local-cache name="backend_events_locking">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE" />
+    </local-cache>
+
   </cache-container>
 </infinispan>

--- a/hawkular-alerts-commons/src/main/resources/hawkular-alerting-ispn-91.xml
+++ b/hawkular-alerts-commons/src/main/resources/hawkular-alerting-ispn-91.xml
@@ -22,7 +22,7 @@
     xsi:schemaLocation="urn:infinispan:config:9.1 http://www.infinispan.org/schemas/infinispan-config-9.1.xsd"
     xmlns="urn:infinispan:config:9.1">
 
-  <cache-container name="hawkular-alerts" default-cache="backend">
+  <cache-container name="hawkular-alerts" default-cache="backend_triggers">
     <local-cache name="partition"/>
     <local-cache name="triggers"/>
     <local-cache name="data"/>
@@ -37,7 +37,7 @@
     </local-cache>
 
     <!-- Backend for definitions, actions history, events and alerts -->
-    <local-cache name="backend">
+    <local-cache name="backend_triggers">
       <transaction mode="BATCH"/>
       <persistence>
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
@@ -46,19 +46,17 @@
       </persistence>
       <indexing index="LOCAL">
         <indexed-entities>
-          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnAction</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnActionDefinition</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnCondition</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnDampening</indexed-entity>
-          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnEvent</indexed-entity>
           <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnTrigger</indexed-entity>
         </indexed-entities>
         <property name="default.indexmanager">near-real-time</property>
         <property name="default.directory_provider">infinispan</property>
         <property name="default.chunk_size">128000</property>
-        <property name="default.locking_cachename">LuceneIndexesLocking_custom</property>
-        <property name="default.data_cachename">LuceneIndexesData_custom</property>
-        <property name="default.metadata_cachename">LuceneIndexesMetadata_custom</property>
+        <property name="default.locking_cachename">backend_triggers_locking</property>
+        <property name="default.data_cachename">backend_triggers_indexes_data</property>
+        <property name="default.metadata_cachename">backend_triggers_indexes_metadata</property>
         <!-- The default is 10, but we don't want to waste many cycles in merging
          (tune for writes at cost of reader fragmentation) -->
 
@@ -72,7 +70,7 @@
         <property name="lucene_version">LUCENE_CURRENT</property>
       </indexing>
     </local-cache>
-    <local-cache name="LuceneIndexesMetadata_custom">
+    <local-cache name="backend_triggers_indexes_metadata">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />
@@ -80,7 +78,7 @@
       </persistence>
       <indexing index="NONE"/>
     </local-cache>
-    <local-cache name="LuceneIndexesData_custom">
+    <local-cache name="backend_triggers_indexes_data">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />
@@ -88,7 +86,63 @@
       </persistence>
       <indexing index="NONE" />
     </local-cache>
-    <local-cache name="LuceneIndexesLocking_custom">
+    <local-cache name="backend_triggers_locking">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE" />
+    </local-cache>
+
+    <local-cache name="backend_events">
+      <transaction mode="BATCH"/>
+      <persistence>
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" modification-queue-size="10000" />
+        </file-store>
+      </persistence>
+      <indexing index="LOCAL">
+        <indexed-entities>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnAction</indexed-entity>
+          <indexed-entity>org.hawkular.alerts.engine.impl.ispn.model.IspnEvent</indexed-entity>
+        </indexed-entities>
+        <property name="default.indexmanager">near-real-time</property>
+        <property name="default.directory_provider">infinispan</property>
+        <property name="default.chunk_size">128000</property>
+        <property name="default.locking_cachename">backend_events_locking</property>
+        <property name="default.data_cachename">backend_events_indexes_data</property>
+        <property name="default.metadata_cachename">backend_events_indexes_metadata</property>
+        <!-- The default is 10, but we don't want to waste many cycles in merging
+         (tune for writes at cost of reader fragmentation) -->
+
+        <property name="default.indexwriter.merge_factor">30</property>
+        <!-- Never create segments larger than 1GB -->
+        <property name="default.indexwriter.merge_max_size">1024</property>
+        <!-- IndexWriter flush buffer size in MB -->
+        <property name="default.indexwriter.ram_buffer_size">64</property>
+        <!-- Enable sharding on writers -->
+        <property name="default.sharding_strategy.nbr_of_shards">6</property>
+        <property name="lucene_version">LUCENE_CURRENT</property>
+      </indexing>
+    </local-cache>
+    <local-cache name="backend_events_indexes_metadata">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE"/>
+    </local-cache>
+    <local-cache name="backend_events_indexes_data">
+      <persistence passivation="false">
+        <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
+          <write-behind thread-pool-size="5" />
+        </file-store>
+      </persistence>
+      <indexing index="NONE" />
+    </local-cache>
+    <local-cache name="backend_events_locking">
       <persistence passivation="false">
         <file-store preload="true" fetch-state="true" read-only="false" purge="false" path="${jboss.server.data.dir}/hawkular-alerting">
           <write-behind thread-pool-size="5" />


### PR DESCRIPTION
I wanted to perform this change some time ago, since we introduced it in inventory.
Now, we have a better split in alerting too, and as definitions population will be expected to be minor than events/alerts/actions population, then this will improve the search use cases (specially from MiQ use cases).
